### PR TITLE
feat(llm): add provider-neutral Ollama integration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -21,3 +21,9 @@ TEST_POSTGRES_PORT=55432
 # Host is "db" (the compose service name) when running via docker compose,
 # or "localhost" when running the API directly on your machine.
 DATABASE_URL=postgresql+psycopg://synapseos:change-me-in-your-local-env@db:5432/synapseos
+
+# --- Local Ollama provider (Phase 4) ---
+OLLAMA_BASE_URL=http://localhost:11434
+OLLAMA_MODEL=qwen3:8b
+OLLAMA_TIMEOUT_SECONDS=60
+OLLAMA_MAX_RESPONSE_BYTES=10485760

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,12 +5,14 @@ This file provides guidance to Codex (Codex.ai/code) when working with code in t
 ## Repository status
 
 The repository has completed **Phase 1 — repository initialization** and **Phase 2 — fundamental
-data model**, and is implementing **Phase 3 — task state machine**. It contains a minimal FastAPI
+data model** and **Phase 3 — task state machine**, and is implementing **Phase 4 — LLM provider
+boundary**. It contains a minimal FastAPI
 application, typed SQLAlchemy models, Alembic migrations, append-only history protection, an
-audited task workflow, a PostgreSQL Docker Compose service, and real-PostgreSQL integration tests.
+audited task workflow, bounded provider-neutral LLM contracts, an Ollama adapter, a PostgreSQL
+Docker Compose service, and real-PostgreSQL integration tests.
 
-Phase 4 and later phases are not implemented. In particular, there are no LLM integrations,
-autonomous runtime agents, executable tools, skills, MCP integrations, QA/security engines, or
+Phase 5 and later phases are not implemented. In particular, there are no autonomous runtime
+agents, executable tools, skills, MCP integrations, QA/security engines, provider router, or
 frontend. Do not implement work from a later phase unless the user explicitly starts that phase.
 
 Important files:

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 > The operating system for autonomous AI organizations.
 
-[![Status](https://img.shields.io/badge/status-Phase_3-orange)](SYNAPSEOS_DEVELOPMENT_CHECKLIST.md)
+[![Status](https://img.shields.io/badge/status-Phase_4-orange)](SYNAPSEOS_DEVELOPMENT_CHECKLIST.md)
 [![Python](https://img.shields.io/badge/python-3.12%2B-blue)](https://www.python.org/)
 [![Code style: Ruff](https://img.shields.io/badge/code_style-ruff-blueviolet)](https://docs.astral.sh/ruff/)
 [![Types: mypy](https://img.shields.io/badge/types-mypy-blue)](https://mypy-lang.org/)
@@ -48,8 +48,9 @@ See [`docs/cahier de charges.md`](docs/cahier%20de%20charges.md) for the full pr
 
 ## Status
 
-**Phase 3 — task state machine.** The repository now provides the persistence foundation and a
-deterministic, audited task workflow. Runtime agents, LLM calls, executable tools, skills, MCP, QA
+**Phase 4 — LLM provider boundary.** The repository now provides the persistence foundation, an
+audited task workflow, and a bounded provider-neutral LLM interface with an Ollama adapter. Runtime
+agents, executable tools, skills, MCP, QA
 and security engines, and the frontend remain intentionally unimplemented.
 
 What exists today:
@@ -63,6 +64,8 @@ What exists today:
   `AuditEvent`.
 - A framework-independent `TaskStateMachine` with exhaustive transition rules, atomic audit
   events, and protection against direct persisted status changes.
+- Provider-neutral immutable LLM contracts, normalized errors, a bounded Ollama HTTP adapter, and a
+  deterministic fake provider that requires no Ollama service in tests.
 - A full tooling baseline: `pytest`, `Ruff`, `mypy` (strict), plus `Dockerfile` and
   `docker-compose.yml` for the API + PostgreSQL.
 
@@ -113,7 +116,8 @@ core/                     # Domain layer (placeholders filled in later phases)
   config.py               # Application settings (env-driven)
 infrastructure/           # Adapters to the outside world
   database/               # SQLAlchemy models, sessions, repositories, and append-only guard
-  llm/ git/               # Placeholders for later phases
+  llm/                    # Ollama and deterministic fake LLM adapters
+  git/                    # Placeholder for a later phase
 alembic/                  # Versioned PostgreSQL migrations
 tests/                    # Unit and real-PostgreSQL integration tests
 docs/adr/                 # Architecture Decision Records
@@ -145,8 +149,8 @@ validated pull request. The near-term sequence is:
 
 1. **Repository initialization** — completed
 2. **Fundamental data model** — completed
-3. **Task state machine** — *current*
-4. LLM provider abstraction (Ollama first)
+3. **Task state machine** — completed
+4. **LLM provider abstraction (Ollama first)** — *current*
 5. Agent core
 6. Tool registry
 
@@ -157,6 +161,7 @@ The complete phased plan (up to a full engineering organisation) lives in
 
 - **Product / organization specification:** [`docs/cahier de charges.md`](docs/cahier%20de%20charges.md)
 - **Task workflow:** [`docs/task-state-machine.md`](docs/task-state-machine.md)
+- **LLM providers:** [`docs/llm-providers.md`](docs/llm-providers.md)
 - **Architecture decisions (ADRs):** [`docs/adr/`](docs/adr/)
 - **Repository working agreement:** [`AGENTS.md`](AGENTS.md)
 

--- a/SYNAPSEOS_DEVELOPMENT_CHECKLIST.md
+++ b/SYNAPSEOS_DEVELOPMENT_CHECKLIST.md
@@ -449,18 +449,18 @@ Découpler SynapseOS du fournisseur de modèle.
 
 ## Checklist
 
-- [ ] Créer interface `LLMProvider`.
-- [ ] Créer types `LLMRequest`.
-- [ ] Créer `LLMResponse`.
-- [ ] Créer provider Ollama.
-- [ ] Support system prompt.
-- [ ] Support messages.
-- [ ] Timeout.
-- [ ] Gestion erreurs.
-- [ ] Nombre de tokens si disponible.
-- [ ] Métadonnées modèle.
-- [ ] Mock provider pour tests.
-- [ ] Tests sans dépendre d'Ollama réel.
+- [x] Créer interface `LLMProvider`.
+- [x] Créer types `LLMRequest`.
+- [x] Créer `LLMResponse`.
+- [x] Créer provider Ollama.
+- [x] Support system prompt.
+- [x] Support messages.
+- [x] Timeout.
+- [x] Gestion erreurs.
+- [x] Nombre de tokens si disponible.
+- [x] Métadonnées modèle.
+- [x] Mock provider pour tests.
+- [x] Tests sans dépendre d'Ollama réel.
 
 ## Prompt Claude Code — Phase 4
 

--- a/core/config.py
+++ b/core/config.py
@@ -6,6 +6,7 @@ file). No secrets are hard-coded; see ``.env.example`` for the expected keys.
 
 from __future__ import annotations
 
+from pydantic import Field
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
@@ -27,6 +28,10 @@ class Settings(BaseSettings):
     test_postgres_host: str = "localhost"
     test_postgres_port: int = 55432
     database_url: str = "postgresql+psycopg://synapseos:synapseos@localhost:55432/synapseos"
+    ollama_base_url: str = "http://localhost:11434"
+    ollama_model: str = "qwen3:8b"
+    ollama_timeout_seconds: float = Field(default=60.0, gt=0)
+    ollama_max_response_bytes: int = Field(default=10_485_760, gt=0)
 
 
 def get_settings() -> Settings:

--- a/core/llm/__init__.py
+++ b/core/llm/__init__.py
@@ -1,0 +1,33 @@
+"""Provider-neutral language model contracts."""
+
+from core.llm.errors import (
+    LLMConfigurationError,
+    LLMConnectionError,
+    LLMProviderError,
+    LLMResponseError,
+    LLMTimeoutError,
+)
+from core.llm.provider import LLMProvider
+from core.llm.types import (
+    LLMMessage,
+    LLMModelMetadata,
+    LLMRequest,
+    LLMResponse,
+    LLMRole,
+    LLMUsage,
+)
+
+__all__ = [
+    "LLMConfigurationError",
+    "LLMConnectionError",
+    "LLMMessage",
+    "LLMModelMetadata",
+    "LLMProvider",
+    "LLMProviderError",
+    "LLMRequest",
+    "LLMResponse",
+    "LLMResponseError",
+    "LLMRole",
+    "LLMUsage",
+    "LLMTimeoutError",
+]

--- a/core/llm/errors.py
+++ b/core/llm/errors.py
@@ -1,0 +1,34 @@
+"""Safe normalized failures exposed by language model providers."""
+
+from __future__ import annotations
+
+
+class LLMProviderError(Exception):
+    """Base error containing only safe provider context."""
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        provider: str,
+        status_code: int | None = None,
+    ) -> None:
+        super().__init__(message)
+        self.provider = provider
+        self.status_code = status_code
+
+
+class LLMConfigurationError(LLMProviderError):
+    """Provider configuration is missing or invalid."""
+
+
+class LLMTimeoutError(LLMProviderError):
+    """Provider request exceeded its configured deadline."""
+
+
+class LLMConnectionError(LLMProviderError):
+    """Provider could not be reached."""
+
+
+class LLMResponseError(LLMProviderError):
+    """Provider returned an unsuccessful or malformed response."""

--- a/core/llm/provider.py
+++ b/core/llm/provider.py
@@ -1,0 +1,16 @@
+"""Provider-neutral language model interface."""
+
+from __future__ import annotations
+
+from typing import Protocol, runtime_checkable
+
+from core.llm.types import LLMRequest, LLMResponse
+
+
+@runtime_checkable
+class LLMProvider(Protocol):
+    """Asynchronous contract implemented by every language model adapter."""
+
+    async def generate(self, request: LLMRequest) -> LLMResponse:
+        """Generate one response for a provider-neutral request."""
+        ...

--- a/core/llm/types.py
+++ b/core/llm/types.py
@@ -1,0 +1,108 @@
+"""Provider-neutral values exchanged with language model providers."""
+
+from __future__ import annotations
+
+import math
+from collections.abc import Mapping
+from enum import StrEnum
+from types import MappingProxyType
+from typing import Annotated, Any, cast
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+
+class LLMRole(StrEnum):
+    """Roles supported by the provider-neutral chat contract."""
+
+    SYSTEM = "system"
+    USER = "user"
+    ASSISTANT = "assistant"
+
+
+class _ImmutableModel(BaseModel):
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+
+NonEmptyText = Annotated[str, Field(min_length=1)]
+TokenCount = Annotated[int, Field(ge=0)]
+
+
+def _freeze(value: Any) -> Any:
+    """Recursively detach and freeze JSON-like metadata."""
+    if isinstance(value, Mapping):
+        if not all(isinstance(key, str) for key in value):
+            raise ValueError("metadata keys must be strings")
+        return MappingProxyType({key: _freeze(item) for key, item in value.items()})
+    if isinstance(value, (list, tuple)):
+        return tuple(_freeze(item) for item in value)
+    if value is None or isinstance(value, (str, bool, int)):
+        return value
+    if isinstance(value, float) and math.isfinite(value):
+        return value
+    raise ValueError("metadata values must be finite JSON-compatible values")
+
+
+class LLMMessage(_ImmutableModel):
+    """One ordered chat message."""
+
+    role: LLMRole
+    content: NonEmptyText
+
+    @field_validator("content")
+    @classmethod
+    def reject_blank_content(cls, value: str) -> str:
+        if not value.strip():
+            raise ValueError("message content must not be blank")
+        return value
+
+
+class LLMRequest(_ImmutableModel):
+    """Provider-independent generation request."""
+
+    messages: Annotated[tuple[LLMMessage, ...], Field(min_length=1)]
+    system_prompt: NonEmptyText | None = None
+    temperature: Annotated[float, Field(ge=0.0, le=2.0, allow_inf_nan=False)] | None = None
+    max_tokens: Annotated[int, Field(gt=0, le=131_072)] = 2048
+    metadata: Mapping[str, Any] = Field(default_factory=lambda: MappingProxyType({}))
+
+    @field_validator("system_prompt")
+    @classmethod
+    def reject_blank_system_prompt(cls, value: str | None) -> str | None:
+        if value is not None and not value.strip():
+            raise ValueError("system prompt must not be blank")
+        return value
+
+    @field_validator("metadata", mode="after")
+    @classmethod
+    def freeze_metadata(cls, value: Mapping[str, Any]) -> Mapping[str, Any]:
+        return cast(Mapping[str, Any], _freeze(value))
+
+
+class LLMUsage(_ImmutableModel):
+    """Token counters reported by a provider when available."""
+
+    prompt_tokens: TokenCount | None = None
+    completion_tokens: TokenCount | None = None
+    total_tokens: TokenCount | None = None
+
+
+class LLMModelMetadata(_ImmutableModel):
+    """Safe model identity and sanitized provider details."""
+
+    provider: NonEmptyText
+    model: NonEmptyText
+    details: Mapping[str, Any] = Field(default_factory=lambda: MappingProxyType({}))
+
+    @field_validator("details", mode="after")
+    @classmethod
+    def freeze_details(cls, value: Mapping[str, Any]) -> Mapping[str, Any]:
+        return cast(Mapping[str, Any], _freeze(value))
+
+
+class LLMResponse(_ImmutableModel):
+    """Provider-independent generation response."""
+
+    content: str
+    finish_reason: str | None = None
+    usage: LLMUsage | None = None
+    model: LLMModelMetadata

--- a/docs/adr/0004-provider-neutral-llm-boundary.md
+++ b/docs/adr/0004-provider-neutral-llm-boundary.md
@@ -1,0 +1,40 @@
+# ADR-0004 — Provider-neutral LLM boundary
+
+- **Status:** Accepted
+- **Date:** 2026-08-25
+- **Deciders:** SynapseOS maintainers
+
+## Context
+
+SynapseOS must begin with local Ollama models while remaining ready for MLX, API gateways, and cloud
+providers. Provider behavior must be bounded, resource-conscious, testable without network access,
+and unable to leak prompts or credentials through errors.
+
+## Options considered
+
+- Depend directly on the Ollama SDK — convenient, but couples consumers to one provider.
+- Introduce a multi-provider framework — broad coverage, but premature routing complexity.
+- Define core contracts and an independent HTTP adapter — a small stable boundary with explicit
+  translation and lifecycle control.
+
+## Decision
+
+Core owns immutable provider-neutral values, normalized errors, and an asynchronous protocol.
+Infrastructure owns a bounded Ollama adapter built on `httpx` and a deterministic fake. Ollama is
+called through its public HTTP contract rather than a provider SDK.
+
+Each provider call has a wall-clock timeout, response-size limit, and bounded token control;
+performs no hidden retry
+or persistence; preserves cancellation; filters metadata; and exposes only safe errors. Provider-
+owned HTTP pools require explicit closure, while injected clients remain caller-owned.
+
+Core metadata accepts only recursively immutable, finite JSON-compatible values. Ollama metadata is
+further restricted to documented keys with bounded primitive value shapes.
+
+## Consequences
+
+- Consumers can change providers without changing their request or response code.
+- Future gateway credentials remain isolated in provider-specific configuration.
+- Routing, retries, fallback, budgets, tool calling, cloud providers, and MLX remain deferred.
+- The adapter maintains provider translation code, but its behavior is fully unit-testable without
+  a real Ollama service.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -36,3 +36,4 @@ Trade-offs, risks, follow-ups.
 - [ADR-0001 — Phase 1 project initialization](0001-phase-1-project-initialization.md)
 - [ADR-0002 — Phase 2 fundamental data model](0002-phase-2-fundamental-data-model.md)
 - [ADR-0003 — Audited task state machine](0003-phase-3-task-state-machine.md)
+- [ADR-0004 — Provider-neutral LLM boundary](0004-provider-neutral-llm-boundary.md)

--- a/docs/llm-providers.md
+++ b/docs/llm-providers.md
@@ -1,0 +1,73 @@
+# LLM Providers
+
+Phase 4 defines a provider-neutral asynchronous boundary. Application code imports request,
+response, and error contracts from `core.llm`; only composition code imports infrastructure
+adapters.
+
+## Core contract
+
+```python
+from core.llm import LLMMessage, LLMProvider, LLMRequest, LLMRole
+
+
+async def generate_summary(provider: LLMProvider, text: str) -> str:
+    response = await provider.generate(
+        LLMRequest(
+            system_prompt="Summarize accurately and surface uncertainty.",
+            messages=(LLMMessage(role=LLMRole.USER, content=text),),
+            max_tokens=512,
+        )
+    )
+    return response.content
+```
+
+Consumers do not know whether the implementation uses Ollama, a future API gateway, or a cloud
+provider. Provider URLs and credentials never belong in `LLMRequest`. Every request has a default
+generation ceiling of 2,048 tokens and accepts an explicit maximum no greater than 131,072.
+
+## Ollama
+
+Configure the local adapter through the environment:
+
+```text
+OLLAMA_BASE_URL=http://localhost:11434
+OLLAMA_MODEL=qwen3:8b
+OLLAMA_TIMEOUT_SECONDS=60
+OLLAMA_MAX_RESPONSE_BYTES=10485760
+```
+
+Create and close a provider-owned HTTP pool explicitly:
+
+```python
+from core.config import get_settings
+from infrastructure.llm import OllamaLLMProvider
+
+settings = get_settings()
+async with OllamaLLMProvider(
+    base_url=settings.ollama_base_url,
+    model=settings.ollama_model,
+    timeout_seconds=settings.ollama_timeout_seconds,
+    max_response_bytes=settings.ollama_max_response_bytes,
+) as provider:
+    response = await provider.generate(request)
+```
+
+An injected `httpx.AsyncClient` remains owned by its caller and is never closed by the adapter.
+The adapter makes one request without hidden retries, propagates cancellation, streams into a
+bounded buffer, skips unsuccessful response bodies, filters model metadata by both key and bounded
+value shape, and normalizes failures without exposing prompts, response bodies, headers, or
+credentials. Response cleanup is best-effort and cannot extend the configured wall-clock deadline.
+Cleanup operations are tracked by the provider until completion and are cancelled and joined when
+the provider closes; compliant HTTP transports must cooperate with asynchronous cancellation.
+
+## Deterministic fake
+
+`FakeLLMProvider` returns queued responses without network I/O. Its recorded request history has a
+finite capacity and fails explicitly when exhausted. It is intended for application tests and
+controlled development, not automatic production selection.
+
+## Deferred work
+
+Provider routing, retries, fallbacks, budgets, tool calling, cloud gateways, and MLX adapters are
+not part of Phase 4. Future adapters can carry their own base URL and secret configuration while
+preserving the core contract.

--- a/docs/superpowers/plans/2026-08-25-phase-4-llm-provider.md
+++ b/docs/superpowers/plans/2026-08-25-phase-4-llm-provider.md
@@ -1,0 +1,306 @@
+# Phase 4 LLM Provider Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add provider-neutral asynchronous LLM contracts, a tested Ollama HTTP adapter, and a deterministic fake provider without implementing agent behavior or later provider routing.
+
+**Architecture:** Core owns immutable request/response types, normalized errors, and the provider protocol. Infrastructure owns Ollama and fake implementations; callers never depend on Ollama-specific types. HTTP behavior is tested with `httpx.MockTransport`, so no test requires a running Ollama service.
+
+**Tech Stack:** Python 3.12, Pydantic v2, `typing.Protocol`, httpx async client, pytest, Ruff, mypy.
+
+**Spec:** `docs/superpowers/specs/2026-08-25-phase-4-llm-provider-design.md`
+
+## Global Constraints
+
+- Implement Phase 4 only; do not add agents, provider routing, cloud gateways, tools, or Phase 5 behavior.
+- Use English for code, comments, tests, commits, and new documentation.
+- Observe every new behavioral test fail for the expected reason before production implementation.
+- Tests must not connect to a real Ollama instance.
+- PostgreSQL-backed repository tests continue to use real PostgreSQL through Alembic.
+- Credentials must never enter core request/response objects, metadata, exceptions, or logs.
+- Network duration, response bytes, generated tokens, and in-memory test history must be bounded.
+- Providers perform no implicit retries or persistence.
+- Do not commit or push until the user explicitly requests it.
+
+---
+
+### Task 1: Core LLM value objects
+
+**Files:**
+- Create: `core/llm/__init__.py`
+- Create: `core/llm/types.py`
+- Test: `tests/llm/__init__.py`
+- Test: `tests/llm/test_types.py`
+
+**Interfaces:**
+- Produces: `LLMRole`, `LLMMessage`, `LLMRequest`, `LLMUsage`, `LLMModelMetadata`, and `LLMResponse`.
+- All models use `ConfigDict(frozen=True, extra="forbid")`.
+
+- [ ] **Step 1: Write failing tests for strict validation and immutability**
+
+  Cover non-empty message content, non-empty messages, optional trimmed system prompt, temperature
+  bounds `0.0..2.0`, positive `max_tokens`, non-negative usage values, forbidden extras, tuple
+  normalization, and frozen instances. Expected values must be literal and independent of the
+  production validators.
+
+- [ ] **Step 2: Run the focused tests and verify RED**
+
+  Run: `.venv/bin/pytest tests/llm/test_types.py -q`
+
+  Expected: collection/import failure because `core.llm` contracts do not exist.
+
+- [ ] **Step 3: Implement the minimal Pydantic models**
+
+  Use a local `LLMRole(StrEnum)` with `SYSTEM`, `USER`, and `ASSISTANT`. Use `Annotated` constraints
+  and immutable defaults. Do not add provider configuration to `LLMRequest`.
+
+- [ ] **Step 4: Run focused tests and verify GREEN**
+
+  Run: `.venv/bin/pytest tests/llm/test_types.py -q`
+
+  Expected: all tests pass without warnings.
+
+### Task 2: Provider protocol and normalized errors
+
+**Files:**
+- Create: `core/llm/provider.py`
+- Create: `core/llm/errors.py`
+- Modify: `core/llm/__init__.py`
+- Test: `tests/llm/test_provider_contract.py`
+
+**Interfaces:**
+- Produces: runtime-checkable `LLMProvider` with `generate(LLMRequest) -> Awaitable[LLMResponse]`.
+- Produces: `LLMProviderError`, `LLMConfigurationError`, `LLMTimeoutError`,
+  `LLMConnectionError`, and `LLMResponseError`.
+
+- [ ] **Step 1: Write failing protocol and safe-error tests**
+
+  Prove a structural async implementation satisfies the protocol. Prove normalized errors retain a
+  provider identifier and optional status code while their public string contains only the supplied
+  safe message.
+
+- [ ] **Step 2: Run focused tests and verify RED**
+
+  Run: `.venv/bin/pytest tests/llm/test_provider_contract.py -q`
+
+  Expected: import failure for the missing protocol/errors.
+
+- [ ] **Step 3: Implement the minimal protocol and error hierarchy**
+
+  Keep the protocol free of constructors and infrastructure imports. Store only safe structured
+  fields on errors.
+
+- [ ] **Step 4: Run focused tests and verify GREEN**
+
+  Run: `.venv/bin/pytest tests/llm/test_provider_contract.py -q`
+
+### Task 3: Deterministic fake provider
+
+**Files:**
+- Create: `infrastructure/llm/fake.py`
+- Modify: `infrastructure/llm/__init__.py`
+- Test: `tests/llm/test_fake_provider.py`
+
+**Interfaces:**
+- Consumes: core LLM contracts.
+- Produces: `FakeLLMProvider(responses=(), error=None, max_history=100)` and async `generate()`.
+- Exposes recorded requests as an immutable tuple.
+
+- [ ] **Step 1: Write failing behavior tests**
+
+  Prove queued responses are returned in order, requests are recorded, configured errors propagate,
+  response-queue or history exhaustion raises a normalized response error, and the class structurally satisfies
+  `LLMProvider`.
+
+- [ ] **Step 2: Run focused tests and verify RED**
+
+  Run: `.venv/bin/pytest tests/llm/test_fake_provider.py -q`
+
+- [ ] **Step 3: Implement the minimal in-memory provider**
+
+  Use a deque internally, append the immutable request before resolving the configured outcome, and
+  never perform I/O.
+
+- [ ] **Step 4: Run focused tests and verify GREEN**
+
+  Run: `.venv/bin/pytest tests/llm/test_fake_provider.py -q`
+
+### Task 4: Ollama request and response translation
+
+**Files:**
+- Modify: `pyproject.toml`
+- Create: `infrastructure/llm/ollama.py`
+- Test: `tests/llm/test_ollama_provider.py`
+
+**Interfaces:**
+- Consumes: core LLM contracts and `httpx.AsyncClient`.
+- Produces: `OllamaLLMProvider(base_url, model, timeout_seconds, max_response_bytes, client=None)`.
+- Calls: `POST {base_url}/api/chat` with `stream: false`.
+
+- [ ] **Step 1: Move httpx into runtime dependencies**
+
+  Keep one `httpx>=0.27` declaration under project dependencies and remove its duplicate from dev
+  dependencies. Refresh the environment using `make install` after the manifest change.
+
+- [ ] **Step 2: Write a failing successful-generation test**
+
+  Use `httpx.MockTransport` with a complete Ollama response fixture. Assert the real provider output
+  and inspect the received HTTP request to prove system-message precedence, caller-message order,
+  model selection, non-streaming mode, temperature, and `num_predict` translation.
+
+- [ ] **Step 3: Run the focused test and verify RED**
+
+  Run: `.venv/bin/pytest tests/llm/test_ollama_provider.py -q`
+
+- [ ] **Step 4: Implement minimal request/response translation**
+
+  Parse `message.content`, `model`, `done_reason`, `prompt_eval_count`, `eval_count`, and sanitized
+  `details`. Derive total tokens only when both component counts are available.
+
+- [ ] **Step 5: Run focused tests and verify GREEN**
+
+  Run: `.venv/bin/pytest tests/llm/test_ollama_provider.py -q`
+
+- [ ] **Step 6: Add RED tests for omitted optional values**
+
+  Prove omitted request options are not sent and absent token counters produce `usage=None` rather
+  than fabricated zeros.
+
+- [ ] **Step 7: Implement optional-value behavior and verify GREEN**
+
+  Run: `.venv/bin/pytest tests/llm/test_ollama_provider.py -q`
+
+### Task 5: Ollama failure normalization and lifecycle
+
+**Files:**
+- Modify: `infrastructure/llm/ollama.py`
+- Modify: `tests/llm/test_ollama_provider.py`
+
+**Interfaces:**
+- Produces safe normalized failures while preserving `asyncio.CancelledError`.
+
+- [ ] **Step 1: Add parameterized RED tests for provider failures**
+
+  Cover `httpx.TimeoutException`, `httpx.ConnectError`, HTTP 4xx/5xx with a secret-bearing body,
+  oversized streamed responses, invalid JSON, missing message, non-string content, and cancellation.
+  Assert secret text is absent from normalized errors and prove no request is retried.
+
+- [ ] **Step 2: Run focused tests and verify RED**
+
+  Run: `.venv/bin/pytest tests/llm/test_ollama_provider.py -q`
+
+- [ ] **Step 3: Implement narrow exception translation**
+
+  Catch timeout and connection exceptions separately, map HTTP/malformed payloads to
+  `LLMResponseError`, and avoid catching `BaseException` so cancellation propagates.
+
+- [ ] **Step 4: Add and satisfy client-ownership tests**
+
+  Prove injected clients remain open and internally created clients close after a request. Run the
+  focused test file until pristine GREEN.
+
+### Task 6: Environment configuration
+
+**Files:**
+- Modify: `core/config.py`
+- Modify: `.env.example`
+- Test: `tests/test_config.py`
+
+**Interfaces:**
+- Produces: `ollama_base_url: str`, `ollama_model: str`, `ollama_timeout_seconds: float`, and
+  `ollama_max_response_bytes: int` on `Settings`.
+
+- [ ] **Step 1: Write RED tests for defaults, overrides, and invalid timeout**
+
+  Instantiate settings with `_env_file=None` and literal environment-shaped keyword values to avoid
+  coupling tests to the developer's `.env` file.
+
+- [ ] **Step 2: Run focused tests and verify RED**
+
+  Run: `.venv/bin/pytest tests/test_config.py -q`
+
+- [ ] **Step 3: Implement constrained settings and placeholders**
+
+  Default to `http://localhost:11434`, a documented local model name, and a positive timeout. Add no
+  credential field for Ollama.
+
+- [ ] **Step 4: Run focused tests and verify GREEN**
+
+  Run: `.venv/bin/pytest tests/test_config.py -q`
+
+### Task 7: Documentation and Phase 4 acceptance
+
+**Files:**
+- Create: `docs/llm-providers.md`
+- Create: `docs/adr/0004-provider-neutral-llm-boundary.md`
+- Modify: `docs/adr/README.md`
+- Modify: `README.md`
+- Modify: `AGENTS.md`
+- Modify: `SYNAPSEOS_DEVELOPMENT_CHECKLIST.md`
+
+**Interfaces:**
+- Documents core usage, Ollama configuration, fake usage, safe error handling, and future adapters.
+
+- [ ] **Step 1: Document the verified implementation**
+
+  Include a minimal async consumer example that imports only `core.llm` contracts, an Ollama setup
+  example at the infrastructure boundary, all environment variables, error behavior, and an explicit
+  statement that gateway/cloud providers and routing remain future work.
+
+- [ ] **Step 2: Record the architectural decision**
+
+  Explain why the core uses a protocol and normalized types, why Ollama uses HTTP instead of its SDK,
+  and how future base-URL/API-key providers remain isolated.
+
+- [ ] **Step 3: Update only verified Phase 4 checkboxes**
+
+  Do not modify Phase 5 or later sections. Update the repository status and commands where the actual
+  implementation changed them.
+
+### Task 8: Complete verification and review
+
+**Files:**
+- Review all Phase 4 changes.
+
+**Interfaces:**
+- Produces a verified Phase 4 branch ready for user-authorized commit and push.
+
+- [ ] **Step 1: Run focused and complete test suites**
+
+  Run:
+
+  ```text
+  .venv/bin/pytest tests/llm tests/test_config.py -q
+  TEST_POSTGRES_PORT=55432 .venv/bin/pytest -q
+  ```
+
+- [ ] **Step 2: Run static quality gates**
+
+  Run:
+
+  ```text
+  .venv/bin/ruff check .
+  .venv/bin/ruff format --check .
+  .venv/bin/mypy .
+  git diff --check
+  ```
+
+- [ ] **Step 3: Validate the containerized application**
+
+  Rebuild the API image, upgrade Alembic to head, run `alembic check`, and verify `/health`. Ollama is
+  not added to Docker Compose and is not required for API liveness.
+
+- [ ] **Step 4: Run an independent code review**
+
+  Resolve every Critical or Important finding through a new RED-GREEN cycle, then rerun all gates.
+
+- [ ] **Step 5: Run a dedicated security and resource-efficiency review**
+
+  Review secret handling, SSRF/trust boundaries, cancellation, response limits, client ownership,
+  unbounded collections, duplicate requests, and accidental persistence. Resolve confirmed findings
+  through RED-GREEN cycles.
+
+- [ ] **Step 6: Report without committing automatically**
+
+  List files, commands, tests, decisions, problems, and remaining work. Commit and push only after an
+  explicit user instruction.

--- a/docs/superpowers/specs/2026-08-25-phase-4-llm-provider-design.md
+++ b/docs/superpowers/specs/2026-08-25-phase-4-llm-provider-design.md
@@ -1,0 +1,212 @@
+# Phase 4 LLM Provider Design
+
+## Status
+
+Approved on 2026-08-25.
+
+## Goal
+
+Introduce a provider-neutral asynchronous LLM contract and an Ollama adapter without adding agent
+runtime behavior. Consumers must depend only on core contracts so API gateways and cloud providers
+can be added later without changing consumer code.
+
+## Scope
+
+Phase 4 includes:
+
+- immutable request, message, response, usage, and model metadata types;
+- an asynchronous `LLMProvider` protocol;
+- normalized provider errors;
+- an Ollama HTTP adapter;
+- a deterministic fake provider;
+- environment-driven Ollama configuration;
+- unit tests that never require a running Ollama instance;
+- usage documentation and an ADR.
+
+Phase 4 excludes:
+
+- cloud or API-gateway provider implementations;
+- provider selection or routing;
+- retries, fallback chains, budgets, rate limiting, or model scoring;
+- prompt templates, agent behavior, tools, skills, memory, and orchestration;
+- persistence of prompts or responses.
+
+## Operational Invariants
+
+Phase 4 is designed for a resource-conscious multinational deployment even though it introduces
+only one local provider:
+
+- memory, response size, request duration, and generated tokens are explicitly bounded;
+- providers perform no implicit retry, fallback, or duplicate request that could multiply cost;
+- prompts, response bodies, credentials, and headers never appear in normalized errors or logs;
+- provider-specific metadata uses an allowlist rather than forwarding arbitrary payloads;
+- caller-owned HTTP clients are never closed or mutated by an adapter;
+- provider-owned network resources have an explicit asynchronous close operation;
+- cancellation propagates immediately and is never reported as an ordinary provider failure;
+- no request or response is persisted by the provider layer.
+
+## Architectural Boundary
+
+The core owns the vocabulary used by all callers:
+
+```text
+Consumer -> core.llm.LLMProvider -> infrastructure adapter -> external model service
+```
+
+`core/llm` must not import `httpx`, Ollama, or any infrastructure package. Infrastructure adapters
+may import core contracts. Consumers must never import an Ollama-specific request or response type.
+
+Future adapters may represent OpenAI-compatible gateways, direct cloud APIs, or local runtimes.
+They will implement the same protocol and translate provider-specific payloads at the infrastructure
+boundary. A future provider may accept a base URL and API key in its own configuration, but API keys
+must never appear in core request objects, response metadata, exceptions, or logs.
+
+## Core Types
+
+All public value objects are frozen Pydantic models with forbidden extra fields.
+
+### `LLMMessage`
+
+- `role`: `SYSTEM`, `USER`, or `ASSISTANT`;
+- `content`: non-empty text.
+
+The role enum belongs in `core/llm/types.py` because it is specific to the LLM contract, not a
+repository-wide domain enum.
+
+### `LLMRequest`
+
+- `messages`: a non-empty tuple of messages;
+- `system_prompt`: optional non-empty text;
+- `temperature`: optional finite value from `0.0` through `2.0`;
+- `max_tokens`: positive integer, default `2048`, maximum `131072`;
+- `metadata`: immutable caller context intended for local correlation only.
+
+The request does not contain provider credentials, provider URLs, or an Ollama model name. Its
+bounded default ensures every provider call carries an explicit generation ceiling. Provider
+configuration belongs to each adapter. `system_prompt` is a first-class field and is translated to
+the provider's native system message representation.
+
+### `LLMUsage`
+
+- `prompt_tokens`: optional non-negative integer;
+- `completion_tokens`: optional non-negative integer;
+- `total_tokens`: optional non-negative integer.
+
+Usage is optional because not every provider reports token counts. Adapters must not fabricate
+counts.
+
+### `LLMModelMetadata`
+
+- `provider`: stable provider identifier;
+- `model`: provider model identifier;
+- `details`: sanitized provider-specific metadata.
+
+Metadata must never contain credentials or request headers.
+
+### `LLMResponse`
+
+- `content`: generated text;
+- `finish_reason`: optional normalized/provider reason;
+- `usage`: optional `LLMUsage`;
+- `model`: `LLMModelMetadata`.
+
+## Provider Protocol
+
+`LLMProvider` exposes one operation:
+
+```python
+async def generate(self, request: LLMRequest) -> LLMResponse: ...
+```
+
+The protocol is runtime-checkable and contains no lifecycle, routing, retry, or agent logic. Each
+provider instance owns its immutable configuration. This keeps consumers independent of constructor
+details such as a future gateway's `base_url` and API key.
+
+## Normalized Errors
+
+All adapter failures exposed to consumers derive from `LLMProviderError`:
+
+- `LLMConfigurationError`: invalid or missing provider configuration;
+- `LLMTimeoutError`: the configured deadline expired;
+- `LLMConnectionError`: the provider could not be reached;
+- `LLMResponseError`: HTTP failure or malformed/unsupported response.
+
+Errors expose a safe message, provider identifier, and optional status code. They must not embed
+credentials, request headers, full prompt bodies, or raw response bodies.
+
+Cancellation remains cancellation: adapters must not convert `asyncio.CancelledError` into a
+provider error.
+
+## Ollama Adapter
+
+`OllamaLLMProvider` uses `httpx.AsyncClient` and Ollama's public chat HTTP endpoint. It receives:
+
+- `base_url`, defaulting to `http://localhost:11434`;
+- `model`;
+- a positive timeout in seconds;
+- an optional injected `httpx.AsyncClient` for controlled tests and caller-owned connection pools.
+- a positive maximum response size in bytes.
+
+The adapter sends non-streaming chat requests. It prepends `system_prompt` as a system message and
+then preserves the caller message order. Request options are included only when supplied.
+
+The adapter reads the response incrementally and rejects it when the configured byte limit is
+exceeded. It extracts generated content, model identity, completion reason, Ollama token counters
+when present, and an allowlisted subset of model details. Unknown response fields are ignored.
+Missing required response structure raises `LLMResponseError`.
+
+Client ownership is explicit: an injected client is never closed by the provider. A provider-created
+client is reused to avoid repeated connection and TLS setup, and is released through `aclose()` or
+the adapter's asynchronous context manager. Calling `generate()` after closure fails explicitly.
+
+## Configuration
+
+Application settings add:
+
+- `ollama_base_url`, environment key `OLLAMA_BASE_URL`;
+- `ollama_model`, environment key `OLLAMA_MODEL`;
+- `ollama_timeout_seconds`, environment key `OLLAMA_TIMEOUT_SECONDS`.
+- `ollama_max_response_bytes`, environment key `OLLAMA_MAX_RESPONSE_BYTES`.
+
+Defaults support local development but do not start or require Ollama. No API key is introduced for
+Ollama. Future gateway credentials will use provider-specific secret settings and will not alter the
+core contracts.
+
+## Fake Provider
+
+`FakeLLMProvider` is a deterministic implementation of the same protocol. It accepts queued
+responses or an error, records immutable requests for assertions up to a configurable finite
+history limit, and never performs I/O. Exhausted response queues and exhausted history capacity fail
+explicitly instead of inventing output or growing memory without bound.
+
+The fake is shipped in `infrastructure/llm/fake.py` so application-level tests can reuse it without
+reimplementing mocks. It is not selected automatically in production.
+
+## Test Strategy
+
+Every behavior follows RED-GREEN-REFACTOR. Tests first prove:
+
+- strict validation and immutability of core types;
+- protocol substitutability;
+- fake response order, request recording, exhaustion, and configured errors;
+- exact Ollama message ordering and optional request options;
+- response, token, finish-reason, and model-metadata translation;
+- absent token counters remain absent;
+- timeout, connection, HTTP, and malformed-response normalization;
+- cancellation propagation;
+- oversized response rejection without exposing its body;
+- absence of implicit retries;
+- injected clients are not closed;
+- provider-owned clients are reused and explicitly closed;
+- environment configuration is parsed and validated.
+
+Ollama HTTP tests use `httpx.MockTransport`; no test connects to a real Ollama service. The complete
+repository test suite continues to use real PostgreSQL where persistence is involved. Final gates
+are pytest, Ruff lint, Ruff format check, strict mypy, Docker/Alembic validation, health check, and
+an independent code review.
+
+## Documentation and Acceptance
+
+Phase 4 adds an ADR and an LLM-provider usage document, and updates `.env.example`, README,
+`AGENTS.md`, and the ADR index. Only Phase 4 checklist items that pass their validation are checked.
+No Phase 5 checkbox or functionality is changed.

--- a/infrastructure/llm/__init__.py
+++ b/infrastructure/llm/__init__.py
@@ -1,1 +1,6 @@
-"""LLM provider abstraction (placeholder — implemented in Phase 4)."""
+"""Language model provider adapters."""
+
+from infrastructure.llm.fake import FakeLLMProvider
+from infrastructure.llm.ollama import OllamaLLMProvider
+
+__all__ = ["FakeLLMProvider", "OllamaLLMProvider"]

--- a/infrastructure/llm/fake.py
+++ b/infrastructure/llm/fake.py
@@ -1,0 +1,42 @@
+"""Deterministic LLM provider for tests and controlled development."""
+
+from __future__ import annotations
+
+from collections import deque
+from collections.abc import Iterable
+
+from core.llm import LLMProviderError, LLMRequest, LLMResponse, LLMResponseError
+
+
+class FakeLLMProvider:
+    """Return queued outcomes without performing network I/O."""
+
+    def __init__(
+        self,
+        *,
+        responses: Iterable[LLMResponse] = (),
+        error: LLMProviderError | None = None,
+        max_history: int = 100,
+    ) -> None:
+        if max_history < 1:
+            raise ValueError("max_history must be positive")
+        self._responses = deque(responses)
+        self._error = error
+        self._max_history = max_history
+        self._requests: list[LLMRequest] = []
+
+    @property
+    def requests(self) -> tuple[LLMRequest, ...]:
+        """Return the requests observed so far as an immutable snapshot."""
+        return tuple(self._requests)
+
+    async def generate(self, request: LLMRequest) -> LLMResponse:
+        """Record a request and resolve the configured deterministic outcome."""
+        if len(self._requests) >= self._max_history:
+            raise LLMResponseError("Fake provider history capacity reached", provider="fake")
+        self._requests.append(request)
+        if self._error is not None:
+            raise self._error
+        if not self._responses:
+            raise LLMResponseError("Fake provider has no queued response", provider="fake")
+        return self._responses.popleft()

--- a/infrastructure/llm/ollama.py
+++ b/infrastructure/llm/ollama.py
@@ -1,0 +1,233 @@
+"""Bounded HTTP adapter for Ollama's chat API."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import math
+from contextlib import suppress
+from types import TracebackType
+from typing import Any, Self, TypeGuard
+from urllib.parse import urlsplit
+
+import httpx
+from pydantic import ValidationError
+
+from core.llm import (
+    LLMConfigurationError,
+    LLMConnectionError,
+    LLMModelMetadata,
+    LLMRequest,
+    LLMResponse,
+    LLMResponseError,
+    LLMTimeoutError,
+    LLMUsage,
+)
+
+_STRING_DETAIL_FIELDS = ("family", "parameter_size", "quantization_level")
+_MAX_DETAIL_LENGTH = 256
+_MAX_FAMILIES = 16
+
+
+def _sanitize_details(value: object) -> dict[str, object]:
+    if not isinstance(value, dict):
+        return {}
+    sanitized: dict[str, object] = {}
+    for field in _STRING_DETAIL_FIELDS:
+        item = value.get(field)
+        if isinstance(item, str) and len(item) <= _MAX_DETAIL_LENGTH:
+            sanitized[field] = item
+    families = value.get("families")
+    if (
+        isinstance(families, list)
+        and len(families) <= _MAX_FAMILIES
+        and all(isinstance(item, str) and len(item) <= _MAX_DETAIL_LENGTH for item in families)
+    ):
+        sanitized["families"] = families
+    return sanitized
+
+
+def _is_valid_counter(value: object) -> TypeGuard[int | None]:
+    return value is None or (type(value) is int and value >= 0)
+
+
+def _discard_task_result(task: asyncio.Task[None]) -> None:
+    with suppress(BaseException):
+        task.result()
+
+
+class OllamaLLMProvider:
+    """Translate provider-neutral requests to Ollama without hidden retries."""
+
+    def __init__(
+        self,
+        *,
+        base_url: str,
+        model: str,
+        timeout_seconds: float,
+        max_response_bytes: int,
+        client: httpx.AsyncClient | None = None,
+    ) -> None:
+        parsed_url = urlsplit(base_url)
+        if (
+            parsed_url.scheme not in {"http", "https"}
+            or not parsed_url.hostname
+            or parsed_url.username is not None
+            or parsed_url.password is not None
+            or parsed_url.query
+            or parsed_url.fragment
+        ):
+            raise LLMConfigurationError("Invalid Ollama base URL", provider="ollama")
+        if not model.strip():
+            raise LLMConfigurationError("Ollama model must not be blank", provider="ollama")
+        if not math.isfinite(timeout_seconds) or timeout_seconds <= 0:
+            raise LLMConfigurationError("Ollama timeout must be positive", provider="ollama")
+        if max_response_bytes <= 0:
+            raise LLMConfigurationError(
+                "Ollama response size limit must be positive", provider="ollama"
+            )
+
+        self._base_url = base_url.rstrip("/")
+        self._model = model.strip()
+        self._timeout = timeout_seconds
+        self._max_response_bytes = max_response_bytes
+        self._client = client or httpx.AsyncClient()
+        self._owns_client = client is None
+        self._closed = False
+        self._cleanup_tasks: set[asyncio.Task[None]] = set()
+
+    async def generate(self, request: LLMRequest) -> LLMResponse:
+        """Generate one bounded, non-streaming Ollama response."""
+        if self._closed:
+            raise LLMConfigurationError("Ollama provider is closed", provider="ollama")
+        deadline = asyncio.get_running_loop().time() + self._timeout
+        try:
+            async with asyncio.timeout_at(deadline):
+                return await self._generate(request, deadline)
+        except (TimeoutError, httpx.TimeoutException) as error:
+            raise LLMTimeoutError("Ollama request timed out", provider="ollama") from error
+        except httpx.ConnectError as error:
+            raise LLMConnectionError("Ollama is unavailable", provider="ollama") from error
+        except httpx.TransportError as error:
+            raise LLMConnectionError(
+                "Ollama response stream was interrupted", provider="ollama"
+            ) from error
+
+    async def _generate(self, request: LLMRequest, deadline: float) -> LLMResponse:
+        """Perform one request inside the caller's wall-clock deadline."""
+        messages: list[dict[str, str]] = []
+        if request.system_prompt is not None:
+            messages.append({"role": "system", "content": request.system_prompt})
+        messages.extend(
+            {"role": message.role.value, "content": message.content} for message in request.messages
+        )
+        payload: dict[str, Any] = {
+            "model": self._model,
+            "messages": messages,
+            "stream": False,
+        }
+        options: dict[str, int | float] = {}
+        if request.temperature is not None:
+            options["temperature"] = request.temperature
+        options["num_predict"] = request.max_tokens
+        if options:
+            payload["options"] = options
+
+        http_request = self._client.build_request(
+            "POST",
+            f"{self._base_url}/api/chat",
+            json=payload,
+            timeout=self._timeout,
+        )
+        response = await self._client.send(http_request, stream=True)
+        try:
+            if not response.is_success:
+                raise LLMResponseError(
+                    "Ollama returned an unsuccessful response",
+                    provider="ollama",
+                    status_code=response.status_code,
+                )
+            body = bytearray()
+            async for chunk in response.aiter_bytes():
+                body.extend(chunk)
+                if len(body) > self._max_response_bytes:
+                    raise LLMResponseError(
+                        "Ollama response exceeded the configured size limit",
+                        provider="ollama",
+                    )
+        finally:
+            self._schedule_response_close(response)
+
+        try:
+            data = json.loads(body)
+            if not isinstance(data, dict):
+                raise TypeError
+            message = data["message"]
+            if not isinstance(message, dict) or not isinstance(message.get("content"), str):
+                raise TypeError
+            model = data.get("model", self._model)
+            if not isinstance(model, str):
+                raise TypeError
+        except (json.JSONDecodeError, KeyError, TypeError) as error:
+            raise LLMResponseError(
+                "Ollama returned an invalid response", provider="ollama"
+            ) from error
+        prompt_tokens = data.get("prompt_eval_count")
+        completion_tokens = data.get("eval_count")
+        usage = None
+        if prompt_tokens is not None or completion_tokens is not None:
+            if not _is_valid_counter(prompt_tokens) or not _is_valid_counter(completion_tokens):
+                raise LLMResponseError("Ollama returned an invalid response", provider="ollama")
+            total_tokens = (
+                prompt_tokens + completion_tokens
+                if prompt_tokens is not None and completion_tokens is not None
+                else None
+            )
+            usage = LLMUsage(
+                prompt_tokens=prompt_tokens,
+                completion_tokens=completion_tokens,
+                total_tokens=total_tokens,
+            )
+        details = _sanitize_details(data.get("details"))
+        try:
+            return LLMResponse(
+                content=message["content"],
+                finish_reason=data.get("done_reason"),
+                usage=usage,
+                model=LLMModelMetadata(provider="ollama", model=model, details=details),
+            )
+        except ValidationError as error:
+            raise LLMResponseError(
+                "Ollama returned an invalid response", provider="ollama"
+            ) from error
+
+    def _schedule_response_close(self, response: httpx.Response) -> None:
+        close_task = asyncio.create_task(response.aclose())
+        self._cleanup_tasks.add(close_task)
+        close_task.add_done_callback(_discard_task_result)
+        close_task.add_done_callback(self._cleanup_tasks.discard)
+
+    async def aclose(self) -> None:
+        """Close only a client owned by this provider."""
+        self._closed = True
+        if self._cleanup_tasks:
+            for task in self._cleanup_tasks:
+                task.cancel()
+            await asyncio.gather(*tuple(self._cleanup_tasks), return_exceptions=True)
+        if self._owns_client:
+            await self._client.aclose()
+
+    async def __aenter__(self) -> Self:
+        """Enter the provider-owned network resource scope."""
+        if self._closed:
+            raise LLMConfigurationError("Ollama provider is closed", provider="ollama")
+        return self
+
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_value: BaseException | None,
+        traceback: TracebackType | None,
+    ) -> None:
+        """Release provider-owned network resources."""
+        await self.aclose()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,12 +20,12 @@ dependencies = [
     "sqlalchemy>=2.0",
     "alembic>=1.13",
     "psycopg[binary]>=3.1",
+    "httpx>=0.27",
 ]
 
 [project.optional-dependencies]
 dev = [
     "pytest>=8.2",
-    "httpx>=0.27",
     "ruff>=0.6",
     "mypy>=1.11",
 ]

--- a/tests/llm/__init__.py
+++ b/tests/llm/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for provider-neutral LLM contracts and adapters."""

--- a/tests/llm/test_fake_provider.py
+++ b/tests/llm/test_fake_provider.py
@@ -1,0 +1,82 @@
+"""Tests for the deterministic fake LLM provider."""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from core.llm import (
+    LLMMessage,
+    LLMModelMetadata,
+    LLMProvider,
+    LLMRequest,
+    LLMResponse,
+    LLMResponseError,
+    LLMRole,
+    LLMTimeoutError,
+)
+from infrastructure.llm.fake import FakeLLMProvider
+
+
+def _request(content: str) -> LLMRequest:
+    return LLMRequest(messages=[LLMMessage(role=LLMRole.USER, content=content)])
+
+
+def _response(content: str) -> LLMResponse:
+    return LLMResponse(
+        content=content,
+        model=LLMModelMetadata(provider="fake", model="deterministic"),
+    )
+
+
+def test_fake_returns_queued_responses_in_order_and_records_requests() -> None:
+    provider = FakeLLMProvider(responses=[_response("first"), _response("second")])
+    first_request = _request("one")
+    second_request = _request("two")
+
+    results = asyncio.run(_generate_twice(provider, first_request, second_request))
+
+    assert [response.content for response in results] == ["first", "second"]
+    assert provider.requests == (first_request, second_request)
+    assert isinstance(provider, LLMProvider)
+
+
+async def _generate_twice(
+    provider: FakeLLMProvider,
+    first: LLMRequest,
+    second: LLMRequest,
+) -> tuple[LLMResponse, LLMResponse]:
+    return await provider.generate(first), await provider.generate(second)
+
+
+def test_fake_records_request_before_propagating_configured_error() -> None:
+    error = LLMTimeoutError("Timed out", provider="fake")
+    provider = FakeLLMProvider(error=error)
+    request = _request("fail")
+
+    with pytest.raises(LLMTimeoutError) as raised:
+        asyncio.run(provider.generate(request))
+
+    assert raised.value is error
+    assert provider.requests == (request,)
+
+
+def test_fake_fails_explicitly_when_response_queue_is_exhausted() -> None:
+    provider = FakeLLMProvider()
+
+    with pytest.raises(LLMResponseError, match="no queued response"):
+        asyncio.run(provider.generate(_request("empty")))
+
+
+def test_fake_bounds_recorded_request_history() -> None:
+    provider = FakeLLMProvider(
+        responses=[_response("first"), _response("second")],
+        max_history=1,
+    )
+    asyncio.run(provider.generate(_request("one")))
+
+    with pytest.raises(LLMResponseError, match="history capacity"):
+        asyncio.run(provider.generate(_request("two")))
+
+    assert provider.requests == (_request("one"),)

--- a/tests/llm/test_ollama_provider.py
+++ b/tests/llm/test_ollama_provider.py
@@ -1,0 +1,532 @@
+"""Tests for the bounded Ollama HTTP adapter."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from collections.abc import AsyncIterator, Callable
+
+import httpx
+import pytest
+
+from core.llm import (
+    LLMConfigurationError,
+    LLMConnectionError,
+    LLMMessage,
+    LLMRequest,
+    LLMResponseError,
+    LLMRole,
+    LLMTimeoutError,
+)
+from infrastructure.llm.ollama import OllamaLLMProvider
+
+
+def test_generate_translates_chat_request_and_successful_response() -> None:
+    received: list[dict[str, object]] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        received.append(json.loads(request.content))
+        return httpx.Response(
+            200,
+            json={
+                "model": "qwen3:8b",
+                "message": {"role": "assistant", "content": "Completed"},
+                "done": True,
+                "done_reason": "stop",
+                "prompt_eval_count": 12,
+                "eval_count": 8,
+                "total_duration": 900,
+                "details": {
+                    "family": "qwen3",
+                    "families": ["qwen3"],
+                    "parameter_size": "8.2B",
+                    "quantization_level": "Q4_K_M",
+                    "secret": "must-not-cross-boundary",
+                },
+            },
+        )
+
+    client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+    provider = OllamaLLMProvider(
+        base_url="http://ollama.internal/",
+        model="qwen3:8b",
+        timeout_seconds=15,
+        max_response_bytes=10_000,
+        client=client,
+    )
+    request = LLMRequest(
+        system_prompt="You are a reviewer.",
+        messages=(
+            LLMMessage(role=LLMRole.USER, content="Review this"),
+            LLMMessage(role=LLMRole.ASSISTANT, content="Ready"),
+        ),
+        temperature=0.2,
+        max_tokens=256,
+    )
+
+    response = asyncio.run(provider.generate(request))
+
+    assert received == [
+        {
+            "model": "qwen3:8b",
+            "messages": [
+                {"role": "system", "content": "You are a reviewer."},
+                {"role": "user", "content": "Review this"},
+                {"role": "assistant", "content": "Ready"},
+            ],
+            "stream": False,
+            "options": {"temperature": 0.2, "num_predict": 256},
+        }
+    ]
+    assert response.content == "Completed"
+    assert response.finish_reason == "stop"
+    assert response.usage is not None
+    assert response.usage.model_dump() == {
+        "prompt_tokens": 12,
+        "completion_tokens": 8,
+        "total_tokens": 20,
+    }
+    assert response.model.provider == "ollama"
+    assert response.model.model == "qwen3:8b"
+    assert dict(response.model.details) == {
+        "family": "qwen3",
+        "families": ("qwen3",),
+        "parameter_size": "8.2B",
+        "quantization_level": "Q4_K_M",
+    }
+    assert not client.is_closed
+    asyncio.run(client.aclose())
+
+
+@pytest.mark.parametrize(
+    ("failure", "expected_type", "expected_message"),
+    [
+        (httpx.ReadTimeout("late"), LLMTimeoutError, "Ollama request timed out"),
+        (httpx.ConnectError("offline"), LLMConnectionError, "Ollama is unavailable"),
+    ],
+)
+def test_generate_normalizes_transport_failures_without_retry(
+    failure: Exception,
+    expected_type: type[Exception],
+    expected_message: str,
+) -> None:
+    calls = 0
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal calls
+        calls += 1
+        failure.request = request  # type: ignore[attr-defined]
+        raise failure
+
+    provider, client = _provider(handler)
+
+    with pytest.raises(expected_type, match=expected_message):
+        asyncio.run(provider.generate(_simple_request()))
+
+    assert calls == 1
+    asyncio.run(client.aclose())
+
+
+@pytest.mark.parametrize(
+    "response",
+    [
+        httpx.Response(401, text="api_key=super-secret"),
+        httpx.Response(200, content=b"not-json"),
+        httpx.Response(200, json={"model": "qwen3:8b"}),
+    ],
+)
+def test_generate_normalizes_http_and_malformed_responses_without_leaking_body(
+    response: httpx.Response,
+) -> None:
+    provider, client = _provider(lambda request: response)
+
+    with pytest.raises(LLMResponseError) as raised:
+        asyncio.run(provider.generate(_simple_request()))
+
+    assert "super-secret" not in str(raised.value)
+    asyncio.run(client.aclose())
+
+
+def test_generate_rejects_oversized_response() -> None:
+    provider, client = _provider(
+        lambda request: httpx.Response(200, content=b"x" * 65),
+        max_response_bytes=64,
+    )
+
+    with pytest.raises(LLMResponseError, match="size limit"):
+        asyncio.run(provider.generate(_simple_request()))
+
+    asyncio.run(client.aclose())
+
+
+def test_generate_sends_default_token_limit_and_does_not_fabricate_usage() -> None:
+    received: list[dict[str, object]] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        received.append(json.loads(request.content))
+        return httpx.Response(
+            200,
+            json={
+                "model": "qwen3:8b",
+                "message": {"role": "assistant", "content": "Hello"},
+                "done": True,
+            },
+        )
+
+    provider, client = _provider(handler)
+
+    response = asyncio.run(provider.generate(_simple_request()))
+
+    assert received[0]["options"] == {"num_predict": 2048}
+    assert response.usage is None
+    asyncio.run(client.aclose())
+
+
+def test_generate_propagates_cancellation_and_does_not_retry() -> None:
+    calls = 0
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal calls
+        calls += 1
+        raise asyncio.CancelledError
+
+    provider, client = _provider(handler)
+
+    with pytest.raises(asyncio.CancelledError):
+        asyncio.run(provider.generate(_simple_request()))
+
+    assert calls == 1
+    asyncio.run(client.aclose())
+
+
+def test_close_does_not_close_injected_client() -> None:
+    provider, client = _provider(
+        lambda request: httpx.Response(
+            200,
+            json={"model": "qwen3:8b", "message": {"content": "Hello"}},
+        )
+    )
+
+    asyncio.run(provider.aclose())
+
+    assert not client.is_closed
+    asyncio.run(client.aclose())
+
+
+def test_generate_fails_explicitly_after_provider_is_closed() -> None:
+    calls = 0
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal calls
+        calls += 1
+        return httpx.Response(500)
+
+    provider, client = _provider(handler)
+    asyncio.run(provider.aclose())
+
+    with pytest.raises(LLMConfigurationError, match="closed"):
+        asyncio.run(provider.generate(_simple_request()))
+
+    assert calls == 0
+    asyncio.run(client.aclose())
+
+
+@pytest.mark.parametrize(
+    "overrides",
+    [
+        {"base_url": "file:///tmp/model"},
+        {"base_url": "http://user:secret@ollama.internal"},
+        {"model": "   "},
+        {"timeout_seconds": 0},
+        {"max_response_bytes": 0},
+    ],
+)
+def test_provider_rejects_unsafe_or_unbounded_configuration(
+    overrides: dict[str, object],
+) -> None:
+    values: dict[str, object] = {
+        "base_url": "http://ollama.internal",
+        "model": "qwen3:8b",
+        "timeout_seconds": 5,
+        "max_response_bytes": 10_000,
+    }
+    values.update(overrides)
+
+    with pytest.raises(LLMConfigurationError):
+        OllamaLLMProvider(**values)  # type: ignore[arg-type]
+
+
+def test_async_context_closes_provider_owned_client(monkeypatch: pytest.MonkeyPatch) -> None:
+    owned_client = httpx.AsyncClient(
+        transport=httpx.MockTransport(lambda request: httpx.Response(500))
+    )
+    monkeypatch.setattr(httpx, "AsyncClient", lambda: owned_client)
+    provider = OllamaLLMProvider(
+        base_url="http://ollama.internal",
+        model="qwen3:8b",
+        timeout_seconds=5,
+        max_response_bytes=10_000,
+    )
+
+    async def use_provider() -> None:
+        async with provider as entered:
+            assert entered is provider
+
+    asyncio.run(use_provider())
+
+    assert owned_client.is_closed
+
+
+class _NeverEndingStream(httpx.AsyncByteStream):
+    async def __aiter__(self) -> AsyncIterator[bytes]:
+        yield b'{"message":'
+        await asyncio.Event().wait()
+
+
+class _FailingStream(httpx.AsyncByteStream):
+    async def __aiter__(self) -> AsyncIterator[bytes]:
+        yield b"{"
+        raise httpx.ReadError("stream failed")
+
+
+class _TrackingStream(httpx.AsyncByteStream):
+    def __init__(self, content: bytes) -> None:
+        self.content = content
+        self.iterated = False
+
+    async def __aiter__(self) -> AsyncIterator[bytes]:
+        self.iterated = True
+        yield self.content
+
+
+class _RaisingCloseStream(_TrackingStream):
+    async def aclose(self) -> None:
+        raise httpx.ReadError("close failed")
+
+
+class _SlowCancellationCloseStream(_NeverEndingStream):
+    def __init__(self) -> None:
+        self.cancellations = 0
+
+    async def aclose(self) -> None:
+        try:
+            await asyncio.Event().wait()
+        except asyncio.CancelledError:
+            self.cancellations += 1
+            raise
+
+
+def test_timeout_is_a_wall_clock_deadline_for_response_stream() -> None:
+    client = httpx.AsyncClient(
+        transport=httpx.MockTransport(
+            lambda request: httpx.Response(200, stream=_NeverEndingStream())
+        )
+    )
+    provider = OllamaLLMProvider(
+        base_url="http://ollama.internal",
+        model="qwen3:8b",
+        timeout_seconds=0.01,
+        max_response_bytes=10_000,
+        client=client,
+    )
+
+    with pytest.raises(LLMTimeoutError, match="timed out"):
+        asyncio.run(provider.generate(_simple_request()))
+
+    asyncio.run(client.aclose())
+
+
+def test_streaming_transport_failure_is_normalized() -> None:
+    provider, client = _provider(lambda request: httpx.Response(200, stream=_FailingStream()))
+
+    with pytest.raises(LLMConnectionError, match="interrupted"):
+        asyncio.run(provider.generate(_simple_request()))
+
+    asyncio.run(client.aclose())
+
+
+def test_negative_or_boolean_usage_counters_are_normalized() -> None:
+    provider, client = _provider(
+        lambda request: httpx.Response(
+            200,
+            json={
+                "model": "qwen3:8b",
+                "message": {"content": "Hello"},
+                "prompt_eval_count": -1,
+                "eval_count": True,
+            },
+        )
+    )
+
+    with pytest.raises(LLMResponseError, match="invalid response"):
+        asyncio.run(provider.generate(_simple_request()))
+
+    asyncio.run(client.aclose())
+
+
+def test_http_error_body_is_not_consumed() -> None:
+    stream = _TrackingStream(b"secret" * 100)
+    provider, client = _provider(lambda request: httpx.Response(500, stream=stream))
+
+    with pytest.raises(LLMResponseError):
+        asyncio.run(provider.generate(_simple_request()))
+
+    assert not stream.iterated
+    asyncio.run(client.aclose())
+
+
+def test_close_failure_does_not_replace_primary_http_error() -> None:
+    stream = _RaisingCloseStream(b"unused")
+    provider, client = _provider(lambda request: httpx.Response(500, stream=stream))
+
+    with pytest.raises(LLMResponseError, match="unsuccessful response"):
+        asyncio.run(provider.generate(_simple_request()))
+
+    asyncio.run(client.aclose())
+
+
+def test_slow_close_cannot_extend_wall_clock_deadline() -> None:
+    stream = _SlowCancellationCloseStream()
+    client = httpx.AsyncClient(
+        transport=httpx.MockTransport(lambda request: httpx.Response(200, stream=stream))
+    )
+    provider = OllamaLLMProvider(
+        base_url="http://ollama.internal",
+        model="qwen3:8b",
+        timeout_seconds=0.01,
+        max_response_bytes=10_000,
+        client=client,
+    )
+
+    async def assert_bounded() -> None:
+        task = asyncio.create_task(provider.generate(_simple_request()))
+        await asyncio.sleep(0.05)
+        try:
+            assert task.done()
+            with pytest.raises(LLMTimeoutError):
+                await task
+        finally:
+            if not task.done():
+                task.cancel()
+                with pytest.raises(asyncio.CancelledError):
+                    await task
+
+    asyncio.run(assert_bounded())
+    asyncio.run(client.aclose())
+
+
+def test_cleanup_deadline_does_not_replace_primary_http_error() -> None:
+    stream = _SlowCancellationCloseStream()
+    client = httpx.AsyncClient(
+        transport=httpx.MockTransport(lambda request: httpx.Response(500, stream=stream))
+    )
+    provider = OllamaLLMProvider(
+        base_url="http://ollama.internal",
+        model="qwen3:8b",
+        timeout_seconds=0.01,
+        max_response_bytes=10_000,
+        client=client,
+    )
+
+    async def assert_primary_error() -> None:
+        task = asyncio.create_task(provider.generate(_simple_request()))
+        await asyncio.sleep(0.05)
+        try:
+            assert task.done()
+            with pytest.raises(LLMResponseError, match="unsuccessful response"):
+                await task
+        finally:
+            if not task.done():
+                task.cancel()
+                with pytest.raises(asyncio.CancelledError):
+                    await task
+
+    asyncio.run(assert_primary_error())
+    asyncio.run(client.aclose())
+
+
+@pytest.mark.parametrize(
+    ("counters", "expected"),
+    [
+        ({"prompt_eval_count": 0}, (0, None, None)),
+        ({"eval_count": 7}, (None, 7, None)),
+        ({"prompt_eval_count": 3, "eval_count": 4}, (3, 4, 7)),
+        ({}, None),
+    ],
+)
+def test_usage_accepts_independently_reported_counters(
+    counters: dict[str, int],
+    expected: tuple[int | None, int | None, int | None] | None,
+) -> None:
+    provider, client = _provider(
+        lambda request: httpx.Response(
+            200,
+            json={
+                "model": "qwen3:8b",
+                "message": {"content": "Hello"},
+                **counters,
+            },
+        )
+    )
+
+    response = asyncio.run(provider.generate(_simple_request()))
+
+    actual = (
+        None
+        if response.usage is None
+        else (
+            response.usage.prompt_tokens,
+            response.usage.completion_tokens,
+            response.usage.total_tokens,
+        )
+    )
+    assert actual == expected
+    asyncio.run(client.aclose())
+
+
+def test_model_metadata_omits_malformed_or_oversized_allowlisted_values() -> None:
+    provider, client = _provider(
+        lambda request: httpx.Response(
+            200,
+            json={
+                "model": "qwen3:8b",
+                "message": {"content": "Hello"},
+                "details": {
+                    "family": {"authorization": "Bearer secret"},
+                    "families": ["valid", {"api_key": "secret"}],
+                    "parameter_size": "x" * 257,
+                    "quantization_level": "Q4_K_M",
+                },
+            },
+        )
+    )
+
+    response = asyncio.run(provider.generate(_simple_request()))
+
+    assert dict(response.model.details) == {"quantization_level": "Q4_K_M"}
+    asyncio.run(client.aclose())
+
+
+def _simple_request() -> LLMRequest:
+    return LLMRequest(messages=[LLMMessage(role=LLMRole.USER, content="Hello")])
+
+
+def _provider(
+    handler: httpx.MockTransport | Callable[[httpx.Request], httpx.Response],
+    *,
+    max_response_bytes: int = 10_000,
+) -> tuple[OllamaLLMProvider, httpx.AsyncClient]:
+    transport = (
+        handler if isinstance(handler, httpx.MockTransport) else httpx.MockTransport(handler)
+    )
+    client = httpx.AsyncClient(transport=transport)
+    return (
+        OllamaLLMProvider(
+            base_url="http://ollama.internal",
+            model="qwen3:8b",
+            timeout_seconds=5,
+            max_response_bytes=max_response_bytes,
+            client=client,
+        ),
+        client,
+    )

--- a/tests/llm/test_provider_contract.py
+++ b/tests/llm/test_provider_contract.py
@@ -1,0 +1,61 @@
+"""Tests for the provider protocol and normalized errors."""
+
+from __future__ import annotations
+
+import asyncio
+
+from core.llm import (
+    LLMConnectionError,
+    LLMMessage,
+    LLMModelMetadata,
+    LLMProvider,
+    LLMRequest,
+    LLMResponse,
+    LLMResponseError,
+    LLMRole,
+    LLMTimeoutError,
+)
+
+
+class StructuralProvider:
+    """Minimal structural implementation used to verify the public protocol."""
+
+    async def generate(self, request: LLMRequest) -> LLMResponse:
+        return LLMResponse(
+            content=request.messages[-1].content,
+            model=LLMModelMetadata(provider="structural", model="test"),
+        )
+
+
+def test_async_structural_provider_satisfies_runtime_protocol() -> None:
+    assert isinstance(StructuralProvider(), LLMProvider)
+
+
+def test_provider_error_exposes_only_safe_structured_context() -> None:
+    error = LLMResponseError(
+        "Provider returned an unsuccessful response",
+        provider="gateway",
+        status_code=401,
+    )
+
+    assert str(error) == "Provider returned an unsuccessful response"
+    assert error.provider == "gateway"
+    assert error.status_code == 401
+
+
+def test_normalized_error_types_share_the_provider_error_contract() -> None:
+    errors = (
+        LLMTimeoutError("Request timed out", provider="ollama"),
+        LLMConnectionError("Provider unavailable", provider="ollama"),
+    )
+
+    assert [str(error) for error in errors] == ["Request timed out", "Provider unavailable"]
+    assert all(error.provider == "ollama" for error in errors)
+
+
+def test_structural_provider_uses_core_values_only() -> None:
+    request = LLMRequest(messages=[LLMMessage(role=LLMRole.USER, content="Hello")])
+
+    response = asyncio.run(StructuralProvider().generate(request))
+
+    assert response.content == "Hello"

--- a/tests/llm/test_types.py
+++ b/tests/llm/test_types.py
@@ -1,0 +1,130 @@
+"""Behavioral tests for immutable provider-neutral LLM values."""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+from pydantic import ValidationError
+
+from core.llm import LLMMessage, LLMModelMetadata, LLMRequest, LLMResponse, LLMRole, LLMUsage
+
+
+def test_request_normalizes_messages_to_an_immutable_tuple() -> None:
+    request = LLMRequest(messages=[LLMMessage(role=LLMRole.USER, content="Build it")])
+
+    assert request.messages == (LLMMessage(role=LLMRole.USER, content="Build it"),)
+    with pytest.raises(ValidationError):
+        request.max_tokens = 10  # type: ignore[misc]
+
+
+@pytest.mark.parametrize("content", ["", "   "])
+def test_message_rejects_blank_content(content: str) -> None:
+    with pytest.raises(ValidationError):
+        LLMMessage(role=LLMRole.USER, content=content)
+
+
+def test_request_rejects_empty_messages() -> None:
+    with pytest.raises(ValidationError):
+        LLMRequest(messages=[])
+
+
+@pytest.mark.parametrize("system_prompt", ["", "   "])
+def test_request_rejects_blank_system_prompt(system_prompt: str) -> None:
+    with pytest.raises(ValidationError):
+        LLMRequest(
+            messages=[LLMMessage(role=LLMRole.USER, content="Hello")],
+            system_prompt=system_prompt,
+        )
+
+
+@pytest.mark.parametrize("temperature", [-0.1, 2.1, math.inf, math.nan])
+def test_request_rejects_invalid_temperature(temperature: float) -> None:
+    with pytest.raises(ValidationError):
+        LLMRequest(
+            messages=[LLMMessage(role=LLMRole.USER, content="Hello")],
+            temperature=temperature,
+        )
+
+
+def test_request_rejects_non_positive_max_tokens_and_extra_fields() -> None:
+    message = LLMMessage(role=LLMRole.USER, content="Hello")
+    with pytest.raises(ValidationError):
+        LLMRequest(messages=[message], max_tokens=0)
+    with pytest.raises(ValidationError):
+        LLMRequest(messages=[message], max_tokens=131_073)
+    with pytest.raises(ValidationError):
+        LLMRequest(messages=[message], unknown=True)  # type: ignore[call-arg]
+
+
+def test_request_has_a_bounded_default_generation_limit() -> None:
+    request = LLMRequest(messages=[LLMMessage(role=LLMRole.USER, content="Hello")])
+
+    assert request.max_tokens == 2048
+
+
+def test_usage_rejects_negative_token_counts() -> None:
+    with pytest.raises(ValidationError):
+        LLMUsage(prompt_tokens=-1)
+
+
+def test_response_carries_optional_usage_and_sanitized_model_metadata() -> None:
+    response = LLMResponse(
+        content="Done",
+        finish_reason="stop",
+        usage=LLMUsage(prompt_tokens=3, completion_tokens=2, total_tokens=5),
+        model=LLMModelMetadata(provider="ollama", model="qwen3", details={"family": "qwen"}),
+    )
+
+    assert response.content == "Done"
+    assert response.usage is not None
+    assert response.usage.total_tokens == 5
+    assert response.model.provider == "ollama"
+
+
+def test_request_and_model_metadata_are_deeply_immutable() -> None:
+    request = LLMRequest(
+        messages=[LLMMessage(role=LLMRole.USER, content="Hello")],
+        metadata={"trace": {"tags": ["phase-4"]}},
+    )
+    model = LLMModelMetadata(
+        provider="ollama",
+        model="qwen3",
+        details={"families": ["qwen"]},
+    )
+
+    with pytest.raises(TypeError):
+        request.metadata["new"] = True  # type: ignore[index]
+    with pytest.raises(TypeError):
+        request.metadata["trace"]["tags"] += ("changed",)
+    with pytest.raises(TypeError):
+        model.details["families"] += ("changed",)  # type: ignore[index]
+
+
+@pytest.mark.parametrize(
+    "metadata",
+    [
+        {"unsupported": {"set"}},
+        {"unsupported": bytearray(b"mutable")},
+        {1: "non-string-key"},
+        {"not_finite": math.inf},
+    ],
+)
+def test_metadata_rejects_non_json_or_unsafe_values(metadata: object) -> None:
+    with pytest.raises(ValidationError):
+        LLMRequest(
+            messages=[LLMMessage(role=LLMRole.USER, content="Hello")],
+            metadata=metadata,
+        )
+
+
+def test_metadata_is_detached_from_original_nested_input() -> None:
+    original = {"trace": {"tags": ["initial"]}}
+    request = LLMRequest(
+        messages=[LLMMessage(role=LLMRole.USER, content="Hello")],
+        metadata=original,
+    )
+
+    original["trace"]["tags"].append("mutated")
+
+    assert request.metadata["trace"]["tags"] == ("initial",)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,45 @@
+"""Tests for environment-driven application configuration."""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from core.config import Settings
+
+
+def test_ollama_settings_have_bounded_local_defaults() -> None:
+    settings = Settings(_env_file=None)
+
+    assert settings.ollama_base_url == "http://localhost:11434"
+    assert settings.ollama_model == "qwen3:8b"
+    assert settings.ollama_timeout_seconds == 60.0
+    assert settings.ollama_max_response_bytes == 10_485_760
+
+
+def test_ollama_settings_are_overridden_by_environment(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("OLLAMA_BASE_URL", "http://models.internal:11434")
+    monkeypatch.setenv("OLLAMA_MODEL", "gemma3:12b")
+    monkeypatch.setenv("OLLAMA_TIMEOUT_SECONDS", "30.5")
+    monkeypatch.setenv("OLLAMA_MAX_RESPONSE_BYTES", "2048")
+
+    settings = Settings(_env_file=None)
+
+    assert settings.ollama_base_url == "http://models.internal:11434"
+    assert settings.ollama_model == "gemma3:12b"
+    assert settings.ollama_timeout_seconds == 30.5
+    assert settings.ollama_max_response_bytes == 2048
+
+
+@pytest.mark.parametrize(
+    "environment_key",
+    ["OLLAMA_TIMEOUT_SECONDS", "OLLAMA_MAX_RESPONSE_BYTES"],
+)
+def test_ollama_settings_reject_non_positive_limits(
+    environment_key: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv(environment_key, "0")
+
+    with pytest.raises(ValidationError):
+        Settings(_env_file=None)


### PR DESCRIPTION
## Summary

- add immutable provider-neutral LLM request, response, usage, metadata, error, and provider contracts
- add a bounded Ollama HTTP adapter with wall-clock timeout, response-size and token limits, safe error normalization, cancellation propagation, metadata sanitization, and explicit client lifecycle
- add a deterministic bounded fake provider for tests and controlled development
- add environment configuration, ADR, usage documentation, and verified Phase 4 checklist updates

## Validation

- 286 tests passed, including real PostgreSQL integration tests
- Ruff checks passed
- Ruff formatting check passed
- mypy strict passed
- Docker image rebuilt successfully
- Alembic upgrade/current/check passed
- API health check returned `{"status":"ok"}`
- secret scan passed
- independent security and code reviews found no remaining Critical or Important issues

## Dependency

This PR is intentionally based on `phase-3/task-state-machine` and should be merged after PR #2.

No Phase 5 functionality is included.