### PR TITLE
feat(tools): implement bounded read-only tool registry

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,17 +5,19 @@ This file provides guidance to Codex (Codex.ai/code) when working with code in t
 ## Repository status
 
 The repository has completed **Phase 1 — repository initialization**, **Phase 2 — fundamental data
-model**, **Phase 3 — task state machine**, and **Phase 4 — LLM provider boundary**, and is
-implementing **Phase 5 — agent core**. It contains a minimal FastAPI application, typed SQLAlchemy
-models, Alembic migrations, append-only history protection, an audited task workflow, bounded
-provider-neutral LLM contracts, an Ollama adapter, a bounded runtime agent with four strict
-structured operations, a PostgreSQL Docker Compose service, and real-PostgreSQL integration tests.
+model**, **Phase 3 — task state machine**, **Phase 4 — LLM provider boundary**, **Phase 5 — agent
+core**, and **Phase 6 — tool registry**. It contains a minimal FastAPI application, typed
+SQLAlchemy models, Alembic migrations, append-only history protection, an audited task workflow,
+bounded provider-neutral LLM contracts, an Ollama adapter, a bounded runtime agent with four
+strict structured operations, five bounded read-only repository tools, a PostgreSQL Docker
+Compose service, and real-PostgreSQL integration tests.
 
-Phase 5 does not include autonomous loops, executable tools, skill loading, shell/filesystem/MCP
-access, provider routing, or multi-agent behavior. `skill_ids` are inert declarations; do not read
-or execute `SKILL.md` before the Phase 8 Skills Registry. Phase 6 and later phases are not
-implemented. In particular, there are no tool registry, permission engine, MCP integrations,
-QA/security engines, provider router, or frontend. Do not implement work from a later phase unless
+Phase 6 includes only `read_file`, `list_files`, `search_text`, `git_status`, and `git_diff` behind
+the central executor. It does not include autonomous loops, write tools, free-form shell, skill
+loading, MCP access, provider routing, or multi-agent behavior. `skill_ids` are inert declarations;
+do not read or execute `SKILL.md` before the Phase 8 Skills Registry. Phase 7 and later phases are
+not implemented. In particular, there is no policy-based permission engine, MCP integration,
+QA/security engine, provider router, or frontend. Do not implement work from a later phase unless
 the user explicitly starts that phase.
 
 Important files:
@@ -56,10 +58,10 @@ For repository acceptance against the Docker PostgreSQL port, run:
 TEST_POSTGRES_PORT=55432 make test
 ```
 
-For the focused Phase 5 runtime tests, run:
+For the focused Phase 6 tool tests, run:
 
 ```bash
-.venv/bin/pytest tests/agents -q
+.venv/bin/pytest tests/tools tests/database/test_tool_execution.py -q
 ```
 
 Run a single test with:

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,11 @@ ENV PYTHONUNBUFFERED=1 \
 
 WORKDIR /app
 
+# Phase 6 Git tools invoke this fixed executable directly without a shell.
+RUN apt-get update \
+    && apt-get install --yes --no-install-recommends git \
+    && rm -rf /var/lib/apt/lists/*
+
 # Copy metadata + sources needed to build/install the package.
 COPY pyproject.toml README.md alembic.ini ./
 COPY apps ./apps

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 > The operating system for autonomous AI organizations.
 
-[![Status](https://img.shields.io/badge/status-Phase_5-orange)](SYNAPSEOS_DEVELOPMENT_CHECKLIST.md)
+[![Status](https://img.shields.io/badge/status-Phase_6-orange)](SYNAPSEOS_DEVELOPMENT_CHECKLIST.md)
 [![Python](https://img.shields.io/badge/python-3.12%2B-blue)](https://www.python.org/)
 [![Code style: Ruff](https://img.shields.io/badge/code_style-ruff-blueviolet)](https://docs.astral.sh/ruff/)
 [![Types: mypy](https://img.shields.io/badge/types-mypy-blue)](https://mypy-lang.org/)
@@ -48,11 +48,11 @@ See [`docs/cahier de charges.md`](docs/cahier%20de%20charges.md) for the full pr
 
 ## Status
 
-**Phase 5 — Agent core.** The repository now provides the persistence foundation, an audited task
-workflow, provider-neutral LLM contracts with an Ollama adapter, and a bounded runtime agent with
-four strict structured operations. Executable tools, skill loading, MCP, autonomous loops,
-multi-agent coordination, QA and security engines, and the frontend remain intentionally
-unimplemented.
+**Phase 6 — Tool registry completed.** The repository now provides the persistence foundation, an
+audited task workflow, provider-neutral LLM contracts with an Ollama adapter, a bounded runtime
+agent, and five deny-by-default read-only repository tools. Write tools, shell access, rich
+permission policy, skill loading, MCP, autonomous loops, multi-agent coordination, QA and security
+engines, and the frontend remain intentionally unimplemented.
 
 What exists today:
 
@@ -70,6 +70,9 @@ What exists today:
 - A provider-neutral, in-memory agent runtime with immutable profiles, `observe()`, `plan()`,
   `decide()`, and `report()` operations, strict structured validation, and bounded metadata-only
   history.
+- An immutable registry and central executor for bounded file reads, file listing, literal search,
+  Git status, and Git diff, with workspace isolation, permission membership, timeout, cancellation,
+  safe output limits, and sanitized PostgreSQL audit records.
 - A full tooling baseline: `pytest`, `Ruff`, `mypy` (strict), plus `Dockerfile` and
   `docker-compose.yml` for the API + PostgreSQL.
 
@@ -121,7 +124,7 @@ core/                     # Domain layer (placeholders filled in later phases)
 infrastructure/           # Adapters to the outside world
   database/               # SQLAlchemy models, sessions, repositories, and append-only guard
   llm/                    # Ollama and deterministic fake LLM adapters
-  git/                    # Placeholder for a later phase
+  tools/                  # Bounded filesystem, Git, path, and audit adapters
 alembic/                  # Versioned PostgreSQL migrations
 tests/                    # Unit and real-PostgreSQL integration tests
 docs/adr/                 # Architecture Decision Records
@@ -147,10 +150,10 @@ The complete suite uses the Docker PostgreSQL service when it is exposed on the 
 TEST_POSTGRES_PORT=55432 make test
 ```
 
-The focused Phase 5 runtime suite is deterministic and needs no live LLM provider:
+The focused Phase 6 tool suite uses deterministic adapters plus real PostgreSQL audit tests:
 
 ```bash
-.venv/bin/pytest tests/agents -q
+.venv/bin/pytest tests/tools tests/database/test_tool_execution.py -q
 ```
 
 Run `make help` to list every available target.
@@ -167,8 +170,9 @@ validated pull request. The near-term sequence is:
 2. **Fundamental data model** — completed
 3. **Task state machine** — completed
 4. **LLM provider abstraction (Ollama first)** — completed
-5. **Agent core** — *current*
-6. Tool registry
+5. **Agent core** — completed
+6. **Tool registry** — completed
+7. Permission engine — not started
 
 The complete phased plan (up to a full engineering organisation) lives in
 [`SYNAPSEOS_DEVELOPMENT_CHECKLIST.md`](SYNAPSEOS_DEVELOPMENT_CHECKLIST.md).
@@ -179,6 +183,7 @@ The complete phased plan (up to a full engineering organisation) lives in
 - **Task workflow:** [`docs/task-state-machine.md`](docs/task-state-machine.md)
 - **LLM providers:** [`docs/llm-providers.md`](docs/llm-providers.md)
 - **Agent core:** [`docs/agent-core.md`](docs/agent-core.md)
+- **Tool registry:** [`docs/tools.md`](docs/tools.md)
 - **Architecture decisions (ADRs):** [`docs/adr/`](docs/adr/)
 - **Repository working agreement:** [`AGENTS.md`](AGENTS.md)
 

--- a/SYNAPSEOS_DEVELOPMENT_CHECKLIST.md
+++ b/SYNAPSEOS_DEVELOPMENT_CHECKLIST.md
@@ -574,29 +574,29 @@ Permettre aux agents d'utiliser uniquement des capacités explicitement enregist
 
 ## Interface d'un Tool
 
-- [ ] nom
-- [ ] description
-- [ ] schéma d'entrée
-- [ ] permissions requises
-- [ ] niveau de risque
-- [ ] timeout
-- [ ] méthode `execute`
+- [x] nom
+- [x] description
+- [x] schéma d'entrée
+- [x] permissions requises
+- [x] niveau de risque
+- [x] timeout
+- [x] méthode `execute`
 
 ## Tools V1
 
-- [ ] `read_file`
-- [ ] `list_files`
-- [ ] `search_text`
-- [ ] `git_status`
-- [ ] `git_diff`
+- [x] `read_file`
+- [x] `list_files`
+- [x] `search_text`
+- [x] `git_status`
+- [x] `git_diff`
 
 ## Sécurité
 
-- [ ] path traversal bloqué
-- [ ] sandbox root obligatoire
-- [ ] audit automatique
-- [ ] permissions vérifiées
-- [ ] timeout
+- [x] path traversal bloqué
+- [x] sandbox root obligatoire
+- [x] audit automatique
+- [x] permissions vérifiées
+- [x] timeout
 
 ## Prompt Claude Code — Phase 6
 

--- a/core/tools/__init__.py
+++ b/core/tools/__init__.py
@@ -7,6 +7,8 @@ from core.tools.errors import (
     ToolInputError,
     ToolWorkspaceError,
 )
+from core.tools.registry import ToolDefinition, ToolRegistry
+from core.tools.tool import Tool
 from core.tools.types import (
     JsonValue,
     ToolErrorCode,
@@ -18,14 +20,17 @@ from core.tools.types import (
 
 __all__ = [
     "JsonValue",
+    "Tool",
     "ToolAuditError",
     "ToolDefinitionError",
+    "ToolDefinition",
     "ToolError",
     "ToolErrorCode",
     "ToolExecutionContext",
     "ToolInputError",
     "ToolResult",
     "ToolResultStatus",
+    "ToolRegistry",
     "ToolRiskLevel",
     "ToolWorkspaceError",
 ]

--- a/core/tools/__init__.py
+++ b/core/tools/__init__.py
@@ -1,1 +1,31 @@
-"""Tools registry (placeholder — implemented in Phase 6)."""
+"""Public contracts for the Phase 6 tool registry."""
+
+from core.tools.errors import (
+    ToolAuditError,
+    ToolDefinitionError,
+    ToolError,
+    ToolInputError,
+    ToolWorkspaceError,
+)
+from core.tools.types import (
+    JsonValue,
+    ToolErrorCode,
+    ToolExecutionContext,
+    ToolResult,
+    ToolResultStatus,
+    ToolRiskLevel,
+)
+
+__all__ = [
+    "JsonValue",
+    "ToolAuditError",
+    "ToolDefinitionError",
+    "ToolError",
+    "ToolErrorCode",
+    "ToolExecutionContext",
+    "ToolInputError",
+    "ToolResult",
+    "ToolResultStatus",
+    "ToolRiskLevel",
+    "ToolWorkspaceError",
+]

--- a/core/tools/__init__.py
+++ b/core/tools/__init__.py
@@ -1,5 +1,12 @@
 """Public contracts for the Phase 6 tool registry."""
 
+from core.tools.audit import (
+    ToolAuditFinish,
+    ToolAuditHandle,
+    ToolAuditOutcome,
+    ToolAuditRecorder,
+    ToolAuditStart,
+)
 from core.tools.errors import (
     ToolAuditError,
     ToolDefinitionError,
@@ -7,6 +14,7 @@ from core.tools.errors import (
     ToolInputError,
     ToolWorkspaceError,
 )
+from core.tools.executor import ToolExecutor
 from core.tools.registry import ToolDefinition, ToolRegistry
 from core.tools.tool import Tool
 from core.tools.types import (
@@ -21,11 +29,17 @@ from core.tools.types import (
 __all__ = [
     "JsonValue",
     "Tool",
+    "ToolAuditFinish",
+    "ToolAuditHandle",
+    "ToolAuditOutcome",
+    "ToolAuditRecorder",
+    "ToolAuditStart",
     "ToolAuditError",
     "ToolDefinitionError",
     "ToolDefinition",
     "ToolError",
     "ToolErrorCode",
+    "ToolExecutor",
     "ToolExecutionContext",
     "ToolInputError",
     "ToolResult",

--- a/core/tools/audit.py
+++ b/core/tools/audit.py
@@ -1,0 +1,66 @@
+"""Persistence-neutral audit lifecycle for tool invocations."""
+
+from __future__ import annotations
+
+from enum import StrEnum
+from typing import Annotated, Protocol
+from uuid import UUID
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from core.tools.types import Identifier, ToolErrorCode
+
+
+class ToolAuditOutcome(StrEnum):
+    """Terminal audit outcome, including propagated cancellation."""
+
+    SUCCEEDED = "SUCCEEDED"
+    FAILED = "FAILED"
+    DENIED = "DENIED"
+    TIMED_OUT = "TIMED_OUT"
+    CANCELLED = "CANCELLED"
+
+
+class _ImmutableAuditModel(BaseModel):
+    model_config = ConfigDict(frozen=True, extra="forbid", hide_input_in_errors=True)
+
+
+class ToolAuditHandle(_ImmutableAuditModel):
+    """Opaque identity returned after mandatory audit creation."""
+
+    tool_call_id: UUID
+
+
+class ToolAuditStart(_ImmutableAuditModel):
+    """Content-free scope required to begin one tool audit."""
+
+    tool_name: Identifier
+    agent_id: Identifier
+    agent_run_id: UUID
+    project_id: UUID
+    task_id: UUID
+    correlation_id: UUID
+    argument_count: Annotated[int, Field(ge=0, le=128)]
+
+
+class ToolAuditFinish(_ImmutableAuditModel):
+    """Allowlisted terminal metadata for one tool audit."""
+
+    outcome: ToolAuditOutcome
+    duration_ms: Annotated[float, Field(ge=0.0, allow_inf_nan=False)]
+    truncated: bool
+    output_field_count: Annotated[int, Field(ge=0, le=128)]
+    output_bytes: Annotated[int, Field(ge=0, le=1_048_576)]
+    error_code: ToolErrorCode | None = None
+
+
+class ToolAuditRecorder(Protocol):
+    """Caller-owned synchronous persistence boundary used by the executor."""
+
+    def begin(self, start: ToolAuditStart) -> ToolAuditHandle:
+        """Create the mandatory running audit record."""
+        ...
+
+    def finish(self, handle: ToolAuditHandle, finish: ToolAuditFinish) -> None:
+        """Finalize the call and append its terminal event."""
+        ...

--- a/core/tools/errors.py
+++ b/core/tools/errors.py
@@ -1,0 +1,30 @@
+"""Sanitized errors for the Phase 6 tool boundary."""
+
+from __future__ import annotations
+
+from core.tools.types import ToolErrorCode
+
+
+class ToolError(Exception):
+    """Base tool failure carrying only a stable code and safe message."""
+
+    def __init__(self, code: ToolErrorCode, safe_message: str) -> None:
+        self.code = code
+        self.safe_message = safe_message
+        super().__init__(safe_message)
+
+
+class ToolDefinitionError(ToolError):
+    """Raised when a tool descriptor or registry is invalid."""
+
+
+class ToolInputError(ToolError):
+    """Raised when invocation arguments cannot be accepted safely."""
+
+
+class ToolWorkspaceError(ToolError):
+    """Raised when a requested resource escapes the approved workspace."""
+
+
+class ToolAuditError(ToolError):
+    """Raised when mandatory tool auditing cannot be completed."""

--- a/core/tools/executor.py
+++ b/core/tools/executor.py
@@ -1,0 +1,322 @@
+"""Central deny-by-default execution lifecycle for registered tools."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import re
+from collections.abc import Mapping
+from time import perf_counter
+from typing import cast
+
+from pydantic import ValidationError
+
+from core.tools.audit import (
+    ToolAuditFinish,
+    ToolAuditHandle,
+    ToolAuditOutcome,
+    ToolAuditRecorder,
+    ToolAuditStart,
+)
+from core.tools.errors import ToolAuditError, ToolError, ToolInputError
+from core.tools.registry import ToolRegistry
+from core.tools.types import (
+    JsonValue,
+    ToolErrorCode,
+    ToolExecutionContext,
+    ToolResult,
+    ToolResultStatus,
+)
+
+_IDENTIFIER_PATTERN = re.compile(r"^[a-z0-9][a-z0-9._:-]{0,127}$")
+_MAX_ARGUMENTS = 128
+_SAFE_MESSAGES: dict[ToolErrorCode, str] = {
+    ToolErrorCode.TOOL_NOT_FOUND: "Requested tool is not registered.",
+    ToolErrorCode.TOOL_NOT_DECLARED: "Requested tool is not declared for this agent.",
+    ToolErrorCode.PERMISSION_DENIED: "Required tool permission is missing.",
+    ToolErrorCode.INVALID_INPUT: "Tool input is invalid.",
+    ToolErrorCode.WORKSPACE_VIOLATION: "Requested workspace resource is not allowed.",
+    ToolErrorCode.UNSUPPORTED_FILE: "Requested file type is not supported.",
+    ToolErrorCode.OUTPUT_LIMIT: "Tool output is invalid or exceeds its limit.",
+    ToolErrorCode.TOOL_FAILED: "Tool execution failed.",
+    ToolErrorCode.AUDIT_FAILED: "Tool audit failed.",
+    ToolErrorCode.TOOL_TIMED_OUT: "Tool execution timed out.",
+    ToolErrorCode.CANCELLED: "Tool execution was cancelled.",
+}
+
+
+class ToolExecutor:
+    """Apply uniform safety and audit controls around exactly one tool call."""
+
+    def __init__(self, registry: ToolRegistry, audit_recorder: ToolAuditRecorder) -> None:
+        self._registry = registry
+        self._audit_recorder = audit_recorder
+
+    async def execute(
+        self,
+        tool_name: str,
+        arguments: Mapping[str, object],
+        context: ToolExecutionContext,
+    ) -> ToolResult:
+        """Execute one registered tool or return one audited safe failure."""
+        validated_context = self._validate_context(context)
+        validated_name, copied_arguments = self._validate_request(tool_name, arguments)
+        started_at = perf_counter()
+        handle = self._begin_audit(validated_name, len(copied_arguments), validated_context)
+
+        tool = self._registry.get(validated_name)
+        if tool is None:
+            return self._failure_result(
+                handle,
+                validated_name,
+                started_at,
+                ToolResultStatus.DENIED,
+                ToolAuditOutcome.DENIED,
+                ToolErrorCode.TOOL_NOT_FOUND,
+            )
+        if validated_name not in validated_context.declared_tool_ids:
+            return self._failure_result(
+                handle,
+                validated_name,
+                started_at,
+                ToolResultStatus.DENIED,
+                ToolAuditOutcome.DENIED,
+                ToolErrorCode.TOOL_NOT_DECLARED,
+            )
+        if not tool.required_permissions.issubset(validated_context.permission_ids):
+            return self._failure_result(
+                handle,
+                validated_name,
+                started_at,
+                ToolResultStatus.DENIED,
+                ToolAuditOutcome.DENIED,
+                ToolErrorCode.PERMISSION_DENIED,
+            )
+
+        try:
+            parsed_arguments = tool.input_type.model_validate(
+                copied_arguments,
+                strict=True,
+                extra="forbid",
+            )
+        except (TypeError, ValueError, ValidationError) as error:
+            del error, copied_arguments
+            return self._failure_result(
+                handle,
+                validated_name,
+                started_at,
+                ToolResultStatus.FAILED,
+                ToolAuditOutcome.FAILED,
+                ToolErrorCode.INVALID_INPUT,
+            )
+
+        try:
+            async with asyncio.timeout(float(tool.timeout_seconds)):
+                raw_output = await tool.execute(parsed_arguments, validated_context)
+        except TimeoutError:
+            return self._failure_result(
+                handle,
+                validated_name,
+                started_at,
+                ToolResultStatus.TIMED_OUT,
+                ToolAuditOutcome.TIMED_OUT,
+                ToolErrorCode.TOOL_TIMED_OUT,
+            )
+        except asyncio.CancelledError:
+            self._finish_audit(
+                handle,
+                ToolAuditFinish(
+                    outcome=ToolAuditOutcome.CANCELLED,
+                    duration_ms=self._duration_ms(started_at),
+                    truncated=False,
+                    output_field_count=0,
+                    output_bytes=0,
+                    error_code=ToolErrorCode.CANCELLED,
+                ),
+            )
+            raise
+        except ToolError as error:
+            code = error.code
+            error.__traceback__ = None
+            del error
+            return self._failure_result(
+                handle,
+                validated_name,
+                started_at,
+                ToolResultStatus.FAILED,
+                ToolAuditOutcome.FAILED,
+                code,
+            )
+        except Exception as error:
+            error.__traceback__ = None
+            del error
+            return self._failure_result(
+                handle,
+                validated_name,
+                started_at,
+                ToolResultStatus.FAILED,
+                ToolAuditOutcome.FAILED,
+                ToolErrorCode.TOOL_FAILED,
+            )
+
+        try:
+            output = self._validated_output(raw_output)
+            duration_ms = self._duration_ms(started_at)
+            truncated = output.get("truncated") is True
+            output_bytes = self._output_bytes(output)
+            result = ToolResult(
+                tool_name=validated_name,
+                status=ToolResultStatus.SUCCEEDED,
+                output=output,
+                duration_ms=duration_ms,
+                truncated=truncated,
+                tool_call_id=handle.tool_call_id,
+            )
+        except (TypeError, ValueError, ValidationError) as error:
+            error.__traceback__ = None
+            del error, raw_output
+            return self._failure_result(
+                handle,
+                validated_name,
+                started_at,
+                ToolResultStatus.FAILED,
+                ToolAuditOutcome.FAILED,
+                ToolErrorCode.OUTPUT_LIMIT,
+            )
+
+        self._finish_audit(
+            handle,
+            ToolAuditFinish(
+                outcome=ToolAuditOutcome.SUCCEEDED,
+                duration_ms=duration_ms,
+                truncated=truncated,
+                output_field_count=len(output),
+                output_bytes=output_bytes,
+            ),
+        )
+        return result
+
+    @staticmethod
+    def _validate_context(context: ToolExecutionContext) -> ToolExecutionContext:
+        try:
+            if type(context) is not ToolExecutionContext:
+                raise ValueError
+            return ToolExecutionContext.model_validate(context.__dict__, strict=True)
+        except (AttributeError, TypeError, ValueError, ValidationError) as error:
+            del error
+            raise ToolInputError(
+                ToolErrorCode.INVALID_INPUT,
+                "Tool execution context is invalid.",
+            ) from None
+
+    @staticmethod
+    def _validate_request(
+        tool_name: str,
+        arguments: Mapping[str, object],
+    ) -> tuple[str, dict[str, object]]:
+        try:
+            if not isinstance(tool_name, str) or _IDENTIFIER_PATTERN.fullmatch(tool_name) is None:
+                raise ValueError
+            if not isinstance(arguments, Mapping) or len(arguments) > _MAX_ARGUMENTS:
+                raise ValueError
+            copied = dict(arguments)
+            if any(not isinstance(key, str) for key in copied):
+                raise ValueError
+            return tool_name, copied
+        except (TypeError, ValueError) as error:
+            del error
+            raise ToolInputError(
+                ToolErrorCode.INVALID_INPUT,
+                "Tool invocation request is invalid.",
+            ) from None
+
+    def _begin_audit(
+        self,
+        tool_name: str,
+        argument_count: int,
+        context: ToolExecutionContext,
+    ) -> ToolAuditHandle:
+        try:
+            return self._audit_recorder.begin(
+                ToolAuditStart(
+                    tool_name=tool_name,
+                    agent_id=context.agent_id,
+                    agent_run_id=context.agent_run_id,
+                    project_id=context.project_id,
+                    task_id=context.task_id,
+                    correlation_id=context.correlation_id,
+                    argument_count=argument_count,
+                )
+            )
+        except Exception as error:
+            error.__traceback__ = None
+            del error
+            raise ToolAuditError(
+                ToolErrorCode.AUDIT_FAILED,
+                "Tool audit is unavailable.",
+            ) from None
+
+    def _finish_audit(self, handle: ToolAuditHandle, finish: ToolAuditFinish) -> None:
+        try:
+            self._audit_recorder.finish(handle, finish)
+        except Exception as error:
+            error.__traceback__ = None
+            del error
+            raise ToolAuditError(
+                ToolErrorCode.AUDIT_FAILED,
+                "Tool audit could not be finalized.",
+            ) from None
+
+    def _failure_result(
+        self,
+        handle: ToolAuditHandle,
+        tool_name: str,
+        started_at: float,
+        status: ToolResultStatus,
+        outcome: ToolAuditOutcome,
+        code: ToolErrorCode,
+    ) -> ToolResult:
+        duration_ms = self._duration_ms(started_at)
+        finish = ToolAuditFinish(
+            outcome=outcome,
+            duration_ms=duration_ms,
+            truncated=False,
+            output_field_count=0,
+            output_bytes=0,
+            error_code=code,
+        )
+        self._finish_audit(handle, finish)
+        return ToolResult(
+            tool_name=tool_name,
+            status=status,
+            output={},
+            error_code=code,
+            error_message=_SAFE_MESSAGES[code],
+            duration_ms=duration_ms,
+            truncated=False,
+            tool_call_id=handle.tool_call_id,
+        )
+
+    @staticmethod
+    def _validated_output(raw_output: object) -> dict[str, JsonValue]:
+        if not isinstance(raw_output, Mapping) or len(raw_output) > 128:
+            raise ValueError
+        output = dict(raw_output)
+        if any(not isinstance(key, str) for key in output):
+            raise ValueError
+        return cast(dict[str, JsonValue], output)
+
+    @staticmethod
+    def _output_bytes(output: dict[str, JsonValue]) -> int:
+        return len(
+            json.dumps(
+                output,
+                allow_nan=False,
+                ensure_ascii=False,
+                separators=(",", ":"),
+            ).encode("utf-8")
+        )
+
+    @staticmethod
+    def _duration_ms(started_at: float) -> float:
+        return max(0.0, (perf_counter() - started_at) * 1_000.0)

--- a/core/tools/registry.py
+++ b/core/tools/registry.py
@@ -1,0 +1,124 @@
+"""Explicit immutable registry of validated tool definitions."""
+
+from __future__ import annotations
+
+import math
+import re
+from collections.abc import Iterable
+from copy import deepcopy
+from typing import Any, cast
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from core.tools.errors import ToolDefinitionError
+from core.tools.tool import Tool
+from core.tools.types import JsonValue, ToolErrorCode, ToolRiskLevel
+
+_IDENTIFIER_PATTERN = re.compile(r"^[a-z0-9][a-z0-9._:-]{0,127}$")
+_MAX_DESCRIPTION_LENGTH = 1_024
+_MAX_PERMISSIONS = 128
+_MAX_TIMEOUT_SECONDS = 30.0
+_INVALID_DEFINITION_MESSAGE = "Tool definition is invalid."
+
+
+class ToolDefinition(BaseModel):
+    """Safe immutable descriptor exposed to capability consumers."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid", hide_input_in_errors=True)
+
+    name: str
+    description: str
+    input_schema: dict[str, JsonValue]
+    required_permissions: frozenset[str] = Field(min_length=1, max_length=128)
+    risk_level: ToolRiskLevel
+    timeout_seconds: float = Field(gt=0.0, le=30.0, allow_inf_nan=False)
+
+
+class ToolRegistry:
+    """Hold an explicit fixed set of validated tools."""
+
+    def __init__(self, tools: Iterable[Tool[Any]]) -> None:
+        registered: dict[str, Tool[Any]] = {}
+        for tool in tuple(tools):
+            self._validate_tool(tool)
+            if tool.name in registered:
+                raise ToolDefinitionError(
+                    ToolErrorCode.INVALID_INPUT,
+                    "Duplicate tool names are not allowed.",
+                )
+            registered[tool.name] = tool
+        self._tools = registered
+
+    @property
+    def names(self) -> tuple[str, ...]:
+        """Return registered names in deterministic order."""
+        return tuple(sorted(self._tools))
+
+    @property
+    def definitions(self) -> tuple[ToolDefinition, ...]:
+        """Return fresh immutable descriptors without exposing registry state."""
+        return tuple(self._definition(self._tools[name]) for name in self.names)
+
+    def get(self, name: str) -> Tool[Any] | None:
+        """Return the exact registered instance, if present."""
+        return self._tools.get(name)
+
+    @staticmethod
+    def _validate_tool(tool: Tool[Any]) -> None:
+        try:
+            if not isinstance(tool, Tool):
+                raise ValueError
+            if not isinstance(tool.name, str) or _IDENTIFIER_PATTERN.fullmatch(tool.name) is None:
+                raise ValueError
+            if (
+                not isinstance(tool.description, str)
+                or not tool.description.strip()
+                or len(tool.description) > _MAX_DESCRIPTION_LENGTH
+            ):
+                raise ValueError
+            if (
+                not isinstance(tool.input_type, type)
+                or tool.input_type is BaseModel
+                or not issubclass(tool.input_type, BaseModel)
+                or tool.input_type.model_config.get("extra") != "forbid"
+            ):
+                raise ValueError
+            permissions = tool.required_permissions
+            if (
+                not isinstance(permissions, frozenset)
+                or not 1 <= len(permissions) <= _MAX_PERMISSIONS
+                or any(
+                    not isinstance(permission, str)
+                    or _IDENTIFIER_PATTERN.fullmatch(permission) is None
+                    for permission in permissions
+                )
+            ):
+                raise ValueError
+            if type(tool.risk_level) is not ToolRiskLevel:
+                raise ValueError
+            if (
+                isinstance(tool.timeout_seconds, bool)
+                or not isinstance(tool.timeout_seconds, (int, float))
+                or not math.isfinite(tool.timeout_seconds)
+                or not 0.0 < tool.timeout_seconds <= _MAX_TIMEOUT_SECONDS
+            ):
+                raise ValueError
+            tool.input_type.model_json_schema()
+        except (AttributeError, TypeError, ValueError) as error:
+            del error
+            raise ToolDefinitionError(
+                ToolErrorCode.INVALID_INPUT,
+                _INVALID_DEFINITION_MESSAGE,
+            ) from None
+
+    @staticmethod
+    def _definition(tool: Tool[Any]) -> ToolDefinition:
+        schema = cast(dict[str, JsonValue], deepcopy(tool.input_type.model_json_schema()))
+        return ToolDefinition(
+            name=tool.name,
+            description=tool.description,
+            input_schema=schema,
+            required_permissions=tool.required_permissions,
+            risk_level=tool.risk_level,
+            timeout_seconds=float(tool.timeout_seconds),
+        )

--- a/core/tools/tool.py
+++ b/core/tools/tool.py
@@ -27,4 +27,3 @@ class Tool[InputT: BaseModel](ABC):
         context: ToolExecutionContext,
     ) -> Mapping[str, JsonValue]:
         """Execute one already-authorized invocation exactly once."""
-

--- a/core/tools/tool.py
+++ b/core/tools/tool.py
@@ -1,0 +1,30 @@
+"""Generic asynchronous contract implemented by every registered tool."""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from collections.abc import Mapping
+
+from pydantic import BaseModel
+
+from core.tools.types import JsonValue, ToolExecutionContext, ToolRiskLevel
+
+
+class Tool[InputT: BaseModel](ABC):
+    """Describe and execute one bounded capability."""
+
+    name: str
+    description: str
+    input_type: type[InputT]
+    required_permissions: frozenset[str]
+    risk_level: ToolRiskLevel
+    timeout_seconds: float
+
+    @abstractmethod
+    async def execute(
+        self,
+        arguments: InputT,
+        context: ToolExecutionContext,
+    ) -> Mapping[str, JsonValue]:
+        """Execute one already-authorized invocation exactly once."""
+

--- a/core/tools/types.py
+++ b/core/tools/types.py
@@ -1,0 +1,138 @@
+"""Strict immutable value objects for the Phase 6 tool boundary."""
+
+from __future__ import annotations
+
+import json
+from enum import StrEnum
+from pathlib import Path
+from typing import Annotated, Self
+from uuid import UUID
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+
+type JsonScalar = str | int | float | bool | None
+type JsonValue = JsonScalar | list[JsonValue] | dict[str, JsonValue]
+
+Identifier = Annotated[str, Field(pattern=r"^[a-z0-9][a-z0-9._:-]{0,127}$")]
+IdentifierSet = Annotated[frozenset[Identifier], Field(min_length=1, max_length=128)]
+SafeMessage = Annotated[str, Field(min_length=1, max_length=255)]
+_MAX_RESULT_BYTES = 1_048_576
+
+
+class ToolRiskLevel(StrEnum):
+    """Risk classification declared by a tool definition."""
+
+    LOW = "LOW"
+    MEDIUM = "MEDIUM"
+    HIGH = "HIGH"
+    CRITICAL = "CRITICAL"
+
+
+class ToolResultStatus(StrEnum):
+    """Public terminal outcome of one tool invocation."""
+
+    SUCCEEDED = "SUCCEEDED"
+    FAILED = "FAILED"
+    DENIED = "DENIED"
+    TIMED_OUT = "TIMED_OUT"
+
+
+class ToolErrorCode(StrEnum):
+    """Stable non-sensitive failure classifications."""
+
+    TOOL_NOT_FOUND = "TOOL_NOT_FOUND"
+    TOOL_NOT_DECLARED = "TOOL_NOT_DECLARED"
+    PERMISSION_DENIED = "PERMISSION_DENIED"
+    INVALID_INPUT = "INVALID_INPUT"
+    WORKSPACE_VIOLATION = "WORKSPACE_VIOLATION"
+    UNSUPPORTED_FILE = "UNSUPPORTED_FILE"
+    OUTPUT_LIMIT = "OUTPUT_LIMIT"
+    TOOL_FAILED = "TOOL_FAILED"
+    AUDIT_FAILED = "AUDIT_FAILED"
+    TOOL_TIMED_OUT = "TOOL_TIMED_OUT"
+    CANCELLED = "CANCELLED"
+
+
+class _ImmutableToolModel(BaseModel):
+    """Shared strict and frozen tool-model configuration."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid", hide_input_in_errors=True)
+
+
+class ToolExecutionContext(_ImmutableToolModel):
+    """Bounded caller-supplied authority and workspace scope for one invocation."""
+
+    workspace_root: Path
+    agent_id: Identifier
+    agent_run_id: UUID
+    project_id: UUID
+    task_id: UUID
+    declared_tool_ids: IdentifierSet
+    permission_ids: IdentifierSet
+    correlation_id: UUID
+
+    @field_validator("workspace_root")
+    @classmethod
+    def require_existing_directory(cls, value: Path) -> Path:
+        """Canonicalize a present directory without exposing rejected paths."""
+        try:
+            resolved = value.resolve(strict=True)
+            if not resolved.is_dir():
+                raise ValueError
+        except (OSError, RuntimeError, ValueError) as error:
+            del error
+            raise ValueError("workspace root must be an existing directory") from None
+        return resolved
+
+    @field_validator("declared_tool_ids", "permission_ids", mode="before")
+    @classmethod
+    def freeze_identifier_sets(cls, value: object) -> object:
+        """Copy common set inputs into immutable capability declarations."""
+        if isinstance(value, (set, frozenset, tuple, list)):
+            return frozenset(value)
+        return value
+
+
+class ToolResult(_ImmutableToolModel):
+    """Bounded structured outcome of one audited tool invocation."""
+
+    tool_name: Identifier
+    status: ToolResultStatus
+    output: dict[str, JsonValue]
+    error_code: ToolErrorCode | None = None
+    error_message: SafeMessage | None = None
+    duration_ms: Annotated[float, Field(ge=0.0, allow_inf_nan=False)]
+    truncated: bool
+    tool_call_id: UUID
+
+    @field_validator("output")
+    @classmethod
+    def require_bounded_json_output(
+        cls,
+        value: dict[str, JsonValue],
+    ) -> dict[str, JsonValue]:
+        """Reject non-JSON values and serialized output above the global cap."""
+        try:
+            encoded = json.dumps(
+                value,
+                allow_nan=False,
+                ensure_ascii=False,
+                separators=(",", ":"),
+            ).encode("utf-8")
+        except (TypeError, ValueError) as error:
+            del error
+            raise ValueError("tool output must be JSON-compatible") from None
+        if len(encoded) > _MAX_RESULT_BYTES:
+            raise ValueError("tool output must not exceed 1048576 bytes")
+        return value
+
+    @model_validator(mode="after")
+    def require_consistent_error_fields(self) -> Self:
+        """Keep success and failure shapes unambiguous."""
+        has_error = self.error_code is not None or self.error_message is not None
+        complete_error = self.error_code is not None and self.error_message is not None
+        if self.status is ToolResultStatus.SUCCEEDED and has_error:
+            raise ValueError("successful tool result must not contain error fields")
+        if self.status is not ToolResultStatus.SUCCEEDED and not complete_error:
+            raise ValueError("unsuccessful tool result must contain safe error fields")
+        return self

--- a/docs/adr/0006-tool-registry-execution-boundary.md
+++ b/docs/adr/0006-tool-registry-execution-boundary.md
@@ -1,0 +1,56 @@
+# ADR-0006 — Tool registry execution boundary
+
+- **Status:** Accepted
+- **Date:** 2026-08-26
+- **Deciders:** SynapseOS maintainers
+
+## Context
+
+Phase 6 must let future agents use a minimal set of repository-reading capabilities without
+granting shell access or letting each adapter interpret security, timeout, and audit policy
+differently. Tool output can contain source code, secrets, large logs, or hostile repository data,
+so both execution and persistence need strict boundaries.
+
+## Options considered
+
+- Let the registry execute tools — reduces the number of objects, but mixes immutable capability
+  discovery with mutable execution policy, persistence, cancellation, and resource lifecycle.
+- Put authorization and auditing in every tool — keeps adapters self-contained, but duplicates
+  security-critical logic and makes omission or inconsistent behavior likely.
+- Keep an immutable registry and route every invocation through one executor — separates
+  discovery from execution while enforcing one uniform deny-by-default lifecycle.
+
+## Decision
+
+Use a provider-neutral `Tool` contract and an immutable `ToolRegistry`. Compose exactly five
+read-only tools explicitly: `read_file`, `list_files`, `search_text`, `git_status`, and `git_diff`.
+The registry never imports or registers tools dynamically.
+
+Require application callers to use `ToolExecutor`. It begins mandatory audit before lookup,
+checks declaration and required permission membership, validates strict Pydantic input, performs
+one bounded execution under a mandatory timeout, validates bounded JSON output, and finalizes a
+sanitized audit record. It never retries. Cancellation is recorded and immediately propagated.
+
+Keep filesystem and Git access in infrastructure adapters. Reject every symlink and any path that
+is not canonically contained by the workspace. Git uses a fixed executable, fixed arguments, a
+clean allowlisted environment, no shell, and bounded concurrent pipe reads.
+
+Persist only allowlisted metrics and stable codes through a caller-owned SQLAlchemy session. Never
+persist raw arguments, tool output, source content, diffs, subprocess streams, exception messages,
+environment values, prompts, responses, or absolute host paths.
+
+Phase 6 permission enforcement is intentionally limited to exact set membership. Policy
+evaluation and approval decisions remain the responsibility of the Phase 7 Permission Engine.
+
+## Consequences
+
+- One central boundary consistently enforces declaration, permission membership, timeout,
+  cancellation, output limits, safe errors, and audit lifecycle.
+- Concrete tools remain small and testable, while the core package remains independent of
+  SQLAlchemy and subprocess implementations.
+- The caller retains transaction and resource ownership; a surrounding rollback removes the call
+  and its event atomically.
+- Symlinks are less convenient but remove a significant traversal and validation/open race class.
+- Dynamic tools, write actions, shell, MCP, skills, retries, approval gates, and rich permission
+  policy remain unavailable until their designated phases.
+

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -38,3 +38,4 @@ Trade-offs, risks, follow-ups.
 - [ADR-0003 — Audited task state machine](0003-phase-3-task-state-machine.md)
 - [ADR-0004 — Provider-neutral LLM boundary](0004-provider-neutral-llm-boundary.md)
 - [ADR-0005 — Agent runtime boundary](0005-agent-runtime-boundary.md)
+- [ADR-0006 — Tool registry execution boundary](0006-tool-registry-execution-boundary.md)

--- a/docs/superpowers/plans/2026-08-26-phase-6-tool-registry.md
+++ b/docs/superpowers/plans/2026-08-26-phase-6-tool-registry.md
@@ -1,0 +1,553 @@
+# Phase 6 Tool Registry Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build a deny-by-default, audited registry and executor for five bounded read-only repository tools.
+
+**Architecture:** Immutable core contracts describe tools, contexts, results, registry lookup, and audit lifecycle without importing infrastructure. A central executor performs declaration and permission checks, timeout/cancellation handling, and safe audit transitions; concrete filesystem, Git, and SQLAlchemy adapters live under `infrastructure/tools`.
+
+**Tech Stack:** Python 3.12, asyncio, Pydantic v2, SQLAlchemy 2, PostgreSQL 16, Alembic, pytest, Ruff, mypy.
+
+**Spec:** `docs/superpowers/specs/2026-08-26-phase-6-tool-registry-design.md`
+
+## Global Constraints
+
+- Implement Phase 6 only; do not add the Phase 7 Permission Engine, Agent integration, write tools, shell tools, MCP, skills, autonomous loops, or workspace lifecycle management.
+- Keep code, comments, docstrings, migrations, and new documentation in English.
+- Follow strict TDD: write one behavior test, observe the expected failure, implement the minimum, and rerun focused plus neighboring tests.
+- Use real PostgreSQL migrated through Alembic for persistence tests; never use SQLite or `metadata.create_all()`.
+- Allow exactly five read-only tools: `read_file`, `list_files`, `search_text`, `git_status`, and `git_diff`.
+- Require canonical workspace containment, including resolved symlink checks, before any file or Git access.
+- Never persist file contents, diff contents, search matches, raw subprocess streams, prompts, secrets, environment values, or absolute host paths.
+- Enforce one execution attempt, no retries, a maximum 30-second timeout, bounded output, and immediate cancellation propagation.
+- Never use `shell=True`, arbitrary command strings, user-controlled executables, or user-controlled environment values.
+- Injected sessions, recorders, registries, and clients remain caller-owned and are never committed, rolled back, or closed by Phase 6 code.
+- Preserve `CLAUDE.local.md` as untracked local state; never stage it.
+
+---
+
+### Task 1: Strict tool value objects and safe errors
+
+**Files:**
+- Create: `core/tools/types.py`
+- Create: `core/tools/errors.py`
+- Modify: `core/tools/__init__.py`
+- Create: `tests/tools/__init__.py`
+- Create: `tests/tools/test_types.py`
+
+**Interfaces:**
+- Produces `JsonValue`, `ToolRiskLevel`, `ToolResultStatus`, `ToolErrorCode`,
+  `ToolExecutionContext`, and `ToolResult`.
+- Produces sanitized `ToolError`, `ToolDefinitionError`, `ToolInputError`, `ToolWorkspaceError`, and `ToolAuditError` exceptions.
+
+- [ ] **Step 1: Write failing enum and context tests**
+
+```python
+def test_execution_context_is_strict_frozen_and_bounded(tmp_path: Path) -> None:
+    context = ToolExecutionContext(
+        workspace_root=tmp_path,
+        agent_id="backend-agent-03",
+        agent_run_id=uuid.uuid4(),
+        project_id=uuid.uuid4(),
+        task_id=uuid.uuid4(),
+        declared_tool_ids={"read_file"},
+        permission_ids={"workspace.read"},
+        correlation_id=uuid.uuid4(),
+    )
+    assert context.workspace_root == tmp_path.resolve()
+    with pytest.raises(ValidationError):
+        context.agent_id = "changed"  # type: ignore[misc]
+```
+
+- [ ] **Step 2: Run the focused test and verify RED**
+
+Run: `.venv/bin/pytest tests/tools/test_types.py -q`  
+Expected: collection fails because Phase 6 types do not exist.
+
+- [ ] **Step 3: Implement strict frozen types**
+
+Use `ConfigDict(frozen=True, extra="forbid")`, existing identifier syntax, immutable bounded sets, timezone-safe UUID fields, a canonical existing directory validator, finite non-negative duration, and a JSON-serializable output-size validator capped at 1 MiB.
+
+```python
+class ToolResultStatus(StrEnum):
+    SUCCEEDED = "SUCCEEDED"
+    FAILED = "FAILED"
+    DENIED = "DENIED"
+    TIMED_OUT = "TIMED_OUT"
+
+
+class ToolExecutionContext(_ImmutableToolModel):
+    workspace_root: Path
+    agent_id: Identifier
+    agent_run_id: UUID
+    project_id: UUID
+    task_id: UUID
+    declared_tool_ids: IdentifierSet
+    permission_ids: IdentifierSet
+    correlation_id: UUID
+```
+
+- [ ] **Step 4: Add failure-shape and leak-resistance tests**
+
+Assert blank/oversized identifiers, missing roots, files used as roots, extra fields, NaN durations, oversized output, output with unsupported values, and exception messages containing rejected values are refused safely.
+
+- [ ] **Step 5: Implement minimal sanitized errors and result invariants**
+
+Require successful results to have no error fields and unsuccessful results to have a stable `ToolErrorCode` plus bounded constant-safe message.
+
+- [ ] **Step 6: Run focused tests and quality checks**
+
+Run: `.venv/bin/pytest tests/tools/test_types.py -q`  
+Run: `.venv/bin/ruff check core/tools tests/tools`  
+Run: `.venv/bin/mypy core/tools tests/tools`
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add core/tools tests/tools
+git commit -m "feat(tools): add strict tool runtime types"
+```
+
+---
+
+### Task 2: Generic tool contract and immutable registry
+
+**Files:**
+- Create: `core/tools/tool.py`
+- Create: `core/tools/registry.py`
+- Modify: `core/tools/__init__.py`
+- Create: `tests/tools/conftest.py`
+- Create: `tests/tools/test_registry.py`
+
+**Interfaces:**
+- Produces `Tool[InputT]` with `name`, `description`, `input_type`, `required_permissions`, `risk_level`, `timeout_seconds`, and `execute(arguments, context)`.
+- Produces `ToolRegistry.get(name)`, `ToolRegistry.names`, and `ToolRegistry.definitions` as immutable reads.
+
+- [ ] **Step 1: Write a failing registry contract test**
+
+```python
+def test_registry_exposes_one_explicit_tool(fake_tool: FakeTool) -> None:
+    registry = ToolRegistry([fake_tool])
+    assert registry.get("fake_read") is fake_tool
+    assert registry.names == ("fake_read",)
+    assert registry.definitions[0].input_schema == FakeInput.model_json_schema()
+```
+
+- [ ] **Step 2: Verify RED**
+
+Run: `.venv/bin/pytest tests/tools/test_registry.py::test_registry_exposes_one_explicit_tool -q`  
+Expected: failure because `Tool` and `ToolRegistry` do not exist.
+
+- [ ] **Step 3: Implement the minimal generic contract and registry**
+
+```python
+class Tool[InputT: BaseModel](ABC):
+    name: str
+    description: str
+    input_type: type[InputT]
+    required_permissions: frozenset[str]
+    risk_level: ToolRiskLevel
+    timeout_seconds: float
+
+    @abstractmethod
+    async def execute(
+        self, arguments: InputT, context: ToolExecutionContext
+    ) -> Mapping[str, JsonValue]: ...
+```
+
+Construct a private mapping once, expose sorted immutable descriptors, and perform no dynamic import or later registration.
+
+- [ ] **Step 4: Add descriptor and duplicate security tests**
+
+Cover duplicate names, invalid names, blank/oversized descriptions, non-Pydantic input types, empty permissions, invalid permission IDs, timeout outside `(0, 30]`, mutable registry input after construction, and attempted mutation of descriptor views.
+
+- [ ] **Step 5: Implement descriptor validation and immutable snapshots**
+
+Reject invalid tools with `ToolDefinitionError` containing only a stable safe message.
+
+- [ ] **Step 6: Run focused and neighboring tests**
+
+Run: `.venv/bin/pytest tests/tools/test_registry.py tests/tools/test_types.py -q`  
+Run: `.venv/bin/ruff check core/tools tests/tools`  
+Run: `.venv/bin/mypy core/tools tests/tools`
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add core/tools tests/tools
+git commit -m "feat(tools): add immutable tool registry"
+```
+
+---
+
+### Task 3: Audit-neutral executor lifecycle
+
+**Files:**
+- Create: `core/tools/audit.py`
+- Create: `core/tools/executor.py`
+- Modify: `core/tools/__init__.py`
+- Create: `tests/tools/test_executor.py`
+- Modify: `tests/tools/conftest.py`
+
+**Interfaces:**
+- Produces `ToolAuditOutcome`, `ToolAuditHandle`, `ToolAuditStart`, `ToolAuditFinish`, and
+  synchronous `ToolAuditRecorder.begin()` / `finish()` protocol methods. `ToolAuditOutcome` adds
+  `CANCELLED` to the four public result outcomes because cancellation is propagated rather than
+  returned as a `ToolResult`.
+- Produces `ToolExecutor.execute(tool_name, arguments, context) -> ToolResult`.
+
+- [ ] **Step 1: Write failing success-lifecycle test**
+
+```python
+def test_executor_calls_registered_tool_once_and_audits_success(
+    executable_context: ToolExecutionContext,
+) -> None:
+    tool = CountingTool()
+    recorder = RecordingAuditRecorder()
+    result = asyncio.run(
+        ToolExecutor(ToolRegistry([tool]), recorder).execute(
+            "fake_read", {"path": "README.md"}, executable_context
+        )
+    )
+    assert result.status is ToolResultStatus.SUCCEEDED
+    assert tool.calls == 1
+    assert recorder.events == ["begin", "finish:SUCCEEDED"]
+```
+
+- [ ] **Step 2: Verify RED**
+
+Run: `.venv/bin/pytest tests/tools/test_executor.py::test_executor_calls_registered_tool_once_and_audits_success -q`  
+Expected: failure because the executor and audit port do not exist.
+
+- [ ] **Step 3: Implement one validated success path**
+
+Begin audit before lookup using only tool name and argument key/type metadata, revalidate the registered input model with strict/forbid settings, call the tool once under `asyncio.timeout(tool.timeout_seconds)`, validate output, finish audit, and return `ToolResult`.
+
+- [ ] **Step 4: Add deny-by-default tests**
+
+Prove unknown, undeclared, missing-permission, extra-input, coercible-input, and malformed-output requests never execute and each valid-scope attempt finishes one audit with the expected safe code. Verify audit metadata contains argument keys/types but no values.
+
+- [ ] **Step 5: Implement denial and failure mappings**
+
+Map unknown tool to `TOOL_NOT_FOUND`, undeclared to `TOOL_NOT_DECLARED`, missing permissions to `PERMISSION_DENIED`, strict Pydantic rejection to `INVALID_INPUT`, tool domain errors to their stable code, and unexpected exceptions to `TOOL_FAILED` without class message leakage.
+
+- [ ] **Step 6: Add timeout, cancellation, ownership, and no-retry tests**
+
+Use event-driven async test doubles rather than sleeps. Assert timeout calls once and returns `TIMED_OUT`; cancellation stages a `CANCELLED` audit finish then re-raises `CancelledError`; begin-audit failure prevents execution; finish-audit failure raises `ToolAuditError`; and executor never calls `close`, `commit`, `rollback`, or retry methods.
+
+- [ ] **Step 7: Implement timeout and cancellation cleanup**
+
+Use `asyncio.timeout`; do not catch-and-convert `CancelledError`; synchronously finish cancellation audit and immediately re-raise. Clear references to raw arguments/results in failure paths.
+
+- [ ] **Step 8: Run focused and full core tests**
+
+Run: `.venv/bin/pytest tests/tools/test_executor.py tests/tools/test_registry.py tests/tools/test_types.py -q`  
+Run: `.venv/bin/ruff check core/tools tests/tools`  
+Run: `.venv/bin/mypy core/tools tests/tools`
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add core/tools tests/tools
+git commit -m "feat(tools): enforce bounded tool execution"
+```
+
+---
+
+### Task 4: Canonical workspace path guard
+
+**Files:**
+- Create: `infrastructure/tools/__init__.py`
+- Create: `infrastructure/tools/paths.py`
+- Create: `tests/tools/test_paths.py`
+
+**Interfaces:**
+- Produces `resolve_workspace_path(root, relative_path, *, must_exist, expected_kind)`.
+- Produces `relative_workspace_path(root, resolved_path) -> str`.
+
+- [ ] **Step 1: Write failing containment tests**
+
+```python
+@pytest.mark.parametrize("path", ["../secret", "/etc/passwd", "a/../../secret", "\x00bad"])
+def test_path_guard_rejects_unsafe_paths(tmp_path: Path, path: str) -> None:
+    with pytest.raises(ToolWorkspaceError, match="requested path is not allowed"):
+        resolve_workspace_path(tmp_path, path, must_exist=True, expected_kind="file")
+```
+
+- [ ] **Step 2: Verify RED**
+
+Run: `.venv/bin/pytest tests/tools/test_paths.py -q`  
+Expected: collection failure because the path guard does not exist.
+
+- [ ] **Step 3: Implement lexical and canonical containment**
+
+Reject blank, absolute, NUL, and `..` components before joining. Resolve the root and target with `Path.resolve(strict=must_exist)`, verify containment with `Path.is_relative_to`, validate regular-file/directory kind, and return no absolute path in exceptions.
+
+- [ ] **Step 4: Add symlink, prefix-confusion, special-file, and race-oriented tests**
+
+Create internal symlinks, file symlinks escaping the root, directory symlinks escaping the root, a sibling named with the root prefix, broken symlinks, and a FIFO where supported. Assert allowed internal symlinks resolve safely and all escapes/special files fail without leaking either root or target path.
+
+- [ ] **Step 5: Implement safe relative rendering**
+
+Return POSIX paths only after canonical containment. Never call string-prefix containment checks.
+
+- [ ] **Step 6: Run focused quality checks**
+
+Run: `.venv/bin/pytest tests/tools/test_paths.py -q`  
+Run: `.venv/bin/ruff check infrastructure/tools tests/tools/test_paths.py`  
+Run: `.venv/bin/mypy infrastructure/tools tests/tools/test_paths.py`
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add infrastructure/tools tests/tools/test_paths.py
+git commit -m "feat(tools): secure workspace path resolution"
+```
+
+---
+
+### Task 5: Bounded filesystem tools
+
+**Files:**
+- Create: `infrastructure/tools/filesystem.py`
+- Modify: `infrastructure/tools/__init__.py`
+- Create: `tests/tools/test_filesystem_tools.py`
+
+**Interfaces:**
+- Produces strict `ReadFileInput`, `ListFilesInput`, and `SearchTextInput`.
+- Produces `ReadFileTool`, `ListFilesTool`, and `SearchTextTool`.
+
+- [ ] **Step 1: Write failing `read_file` happy-path and bounds tests**
+
+Create a UTF-8 fixture with numbered lines. Assert one-based slicing, relative path metadata, `workspace.read`, 256-KiB output cap, 8-MiB file cap, 2,000-line cap, truncation, binary/invalid UTF-8 rejection, special-file rejection, and symlink containment.
+
+- [ ] **Step 2: Verify RED**
+
+Run: `.venv/bin/pytest tests/tools/test_filesystem_tools.py -k read_file -q`  
+Expected: failure because `ReadFileTool` does not exist.
+
+- [ ] **Step 3: Implement streaming `ReadFileTool`**
+
+Open only a guarded regular file with a context manager, stream incrementally, count UTF-8 encoded bytes before appending, and return `content`, `path`, `start_line`, `end_line`, `total_lines_observed`, and `truncated`.
+
+- [ ] **Step 4: Write failing `list_files` tests**
+
+Assert deterministic sorting, hidden-file inclusion, recursive/non-recursive behavior, entry-kind output, 10,000-entry and requested limits, no directory-symlink following, no host paths, and safe handling of permission failures.
+
+- [ ] **Step 5: Implement bounded scandir traversal**
+
+Use closed `os.scandir` iterators, a deterministic pending-directory queue, `follow_symlinks=False`, and stop immediately at the requested entry budget.
+
+- [ ] **Step 6: Write failing `search_text` tests**
+
+Assert literal matching, case behavior, file/directory roots, deterministic path/line order, line truncation at 4,096 characters, query length, 1,000-result cap, 8-MiB candidate cap, binary/invalid UTF-8 skipping, symlink escape prevention, and no regex interpretation.
+
+- [ ] **Step 7: Implement streaming literal search**
+
+Walk with the same guarded traversal primitives, read one line at a time, preserve line numbers, stop at the result budget, and return only bounded match text and relative paths.
+
+- [ ] **Step 8: Run focused and tools tests**
+
+Run: `.venv/bin/pytest tests/tools/test_filesystem_tools.py tests/tools/test_paths.py -q`  
+Run: `.venv/bin/ruff check infrastructure/tools tests/tools`  
+Run: `.venv/bin/mypy infrastructure/tools tests/tools`
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add infrastructure/tools tests/tools
+git commit -m "feat(tools): add bounded filesystem readers"
+```
+
+---
+
+### Task 6: Fixed-command bounded Git tools
+
+**Files:**
+- Create: `infrastructure/tools/git.py`
+- Modify: `infrastructure/tools/__init__.py`
+- Create: `tests/tools/test_git_tools.py`
+
+**Interfaces:**
+- Produces `GitStatusInput`, `GitDiffInput`, `GitDiffTarget`, `GitStatusTool`, and `GitDiffTool`.
+- Internal `_run_git(args, workspace_root, output_limit)` accepts only adapter-owned argument tuples.
+
+- [ ] **Step 1: Write failing `git_status` integration test**
+
+Create a temporary local repository using test setup commands, then invoke the production tool and assert branch/status output, `git.read`, fixed action metadata, no shell, bounded output, and no absolute path.
+
+- [ ] **Step 2: Verify RED**
+
+Run: `.venv/bin/pytest tests/tools/test_git_tools.py -k status -q`  
+Expected: failure because `GitStatusTool` does not exist.
+
+- [ ] **Step 3: Implement one fixed status command**
+
+Use `asyncio.create_subprocess_exec` with exactly `git status --short --branch --untracked-files=all`, `cwd` set to canonical root, `start_new_session=True`, stdin disabled, and an environment built only from safe platform necessities plus fixed Git hardening variables.
+
+- [ ] **Step 4: Write failing `git_diff` tests**
+
+Cover worktree/staged selection, multiple validated path filters, filenames beginning with `-` after `--`, no external diff/textconv/color, 512-KiB truncation, non-repository failure, non-zero exit, stderr redaction, timeout termination, cancellation termination, and exactly one subprocess.
+
+- [ ] **Step 5: Implement fixed diff vectors and bounded subprocess collection**
+
+Construct only adapter-owned switches. Validate every filter through the path guard before passing its relative form after `--`. Read stdout/stderr concurrently with caps, terminate the process group on timeout/cancellation, await process exit, and never retry.
+
+- [ ] **Step 6: Add injected environment and command-leak tests**
+
+Set hostile `GIT_EXTERNAL_DIFF`, `GIT_CONFIG_*`, `LD_PRELOAD`, `PYTHONPATH`, and secret-marker variables in the test process; prove they do not influence or appear in production output/audit metadata.
+
+- [ ] **Step 7: Run focused checks**
+
+Run: `.venv/bin/pytest tests/tools/test_git_tools.py -q`  
+Run: `.venv/bin/ruff check infrastructure/tools/git.py tests/tools/test_git_tools.py`  
+Run: `.venv/bin/mypy infrastructure/tools/git.py tests/tools/test_git_tools.py`
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add infrastructure/tools tests/tools/test_git_tools.py
+git commit -m "feat(tools): add bounded git readers"
+```
+
+---
+
+### Task 7: SQLAlchemy audit recorder and real-PostgreSQL execution tests
+
+**Files:**
+- Create: `infrastructure/tools/audit.py`
+- Modify: `infrastructure/tools/__init__.py`
+- Create: `tests/database/test_tool_execution.py`
+- Create: `tests/database/tool_fixtures.py`
+
+**Interfaces:**
+- Produces `SQLAlchemyToolAuditRecorder(session: Session)` implementing the core audit port.
+- Reuses existing `ToolCall`, `AuditEvent`, `ToolCallStatus`, `AuditActorType`, and `AuditResult` without schema changes.
+
+- [ ] **Step 1: Write failing PostgreSQL success-audit test**
+
+Create `Project`, `Agent`, `Task`, and `AgentRun`, flush them, execute a deterministic read-only fake tool, and assert one `ToolCall` transitions `RUNNING -> SUCCEEDED` and one append-only `AuditEvent` is staged with matching project/task/run/correlation scope.
+
+- [ ] **Step 2: Verify RED against migrated PostgreSQL**
+
+Run: `.venv/bin/pytest tests/database/test_tool_execution.py::test_successful_tool_execution_is_audited -q`  
+Expected: failure because the SQLAlchemy recorder does not exist.
+
+- [ ] **Step 3: Implement caller-owned audit staging**
+
+`begin()` adds and flushes a `ToolCall` with UTC start time. `finish()` validates handle/session ownership, mutates terminal fields once, appends one `AuditEvent`, and does not commit, roll back, or close. Map statuses as follows:
+
+```text
+SUCCEEDED -> ToolCall SUCCEEDED / Audit SUCCEEDED
+DENIED    -> ToolCall DENIED    / Audit DENIED
+TIMED_OUT -> ToolCall TIMED_OUT / Audit FAILED
+FAILED    -> ToolCall FAILED    / Audit FAILED
+CANCELLED -> ToolCall FAILED    / Audit CANCELLED
+```
+
+- [ ] **Step 4: Add full terminal-state and allowlist tests**
+
+Cover unknown, undeclared, permission denied, invalid input, workspace violation, tool failure, timeout, and cancellation. Assert persisted JSON contains only allowlisted keys/counts/types/relative paths/sizes/truncation/error codes and excludes supplied secret markers, contents, matches, diffs, stderr, raw argument values, absolute roots, and environment values.
+
+- [ ] **Step 5: Add transaction and ownership tests**
+
+Instrument session events to prove no commit/rollback/close; prove caller rollback removes both records; reject foreign-session, already-finished, detached, or unknown handles; and prove append-only protection still rejects AuditEvent mutation/deletion.
+
+- [ ] **Step 6: Run PostgreSQL and neighboring suites**
+
+Run: `.venv/bin/pytest tests/database/test_tool_execution.py tests/database/test_append_only.py tests/tools -q`  
+Run: `.venv/bin/ruff check infrastructure/tools tests/database/test_tool_execution.py tests/tools`  
+Run: `.venv/bin/mypy infrastructure/tools tests/database/test_tool_execution.py tests/tools`
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add infrastructure/tools tests/database/test_tool_execution.py tests/database/tool_fixtures.py
+git commit -m "feat(tools): persist sanitized tool audits"
+```
+
+---
+
+### Task 8: Default registry, documentation, checklist, and complete verification
+
+**Files:**
+- Modify: `infrastructure/tools/__init__.py`
+- Create: `tests/tools/test_default_registry.py`
+- Create: `docs/tools.md`
+- Create: `docs/adr/0006-tool-registry-execution-boundary.md`
+- Modify: `docs/adr/README.md`
+- Modify: `README.md`
+- Modify: `AGENTS.md`
+- Modify: `SYNAPSEOS_DEVELOPMENT_CHECKLIST.md`
+
+**Interfaces:**
+- Produces `create_default_tool_registry() -> ToolRegistry` containing exactly the five approved read-only tools.
+- Documents the public API, composition, permissions, audit behavior, bounds, and deliberate Phase 6 exclusions.
+
+- [ ] **Step 1: Write failing default-registry acceptance test**
+
+```python
+def test_default_registry_contains_only_phase_6_tools() -> None:
+    registry = create_default_tool_registry()
+    assert registry.names == (
+        "git_diff", "git_status", "list_files", "read_file", "search_text"
+    )
+```
+
+Also assert exact required permissions, LOW risk, timeouts, strict input schemas, and absence of registration mutation methods.
+
+- [ ] **Step 2: Verify RED and implement explicit composition**
+
+Run: `.venv/bin/pytest tests/tools/test_default_registry.py -q`  
+Expected: failure because the factory does not exist. Then instantiate the five concrete tools explicitly and rerun GREEN.
+
+- [ ] **Step 3: Write documentation and ADR**
+
+Document examples using an injected recorder/session, the executor-only invocation rule, all hard limits, path/symlink behavior, fixed Git commands, status/error mapping, caller-owned transactions, cancellation, and the Phase 7 boundary. Record rejected alternatives: registry-executes-everything and per-tool security/audit.
+
+- [ ] **Step 4: Update repository status and only verified Phase 6 boxes**
+
+Update README and AGENTS in English. Check only Phase 6 items proven by tests and implementation. Leave every Phase 7 and later checkbox unchanged. Do not add Context Intelligence implementation.
+
+- [ ] **Step 5: Run fresh complete verification**
+
+Run: `.venv/bin/pytest`  
+Expected: all tests pass against real PostgreSQL with no warnings.
+
+Run: `.venv/bin/ruff check .`  
+Expected: `All checks passed!`
+
+Run: `.venv/bin/ruff format --check .`  
+Expected: every file already formatted.
+
+Run: `.venv/bin/mypy .`  
+Expected: no issues.
+
+Run: `.venv/bin/alembic current`  
+Expected: current revision is the repository head.
+
+Run: `.venv/bin/alembic check`  
+Expected: no new upgrade operations; Phase 6 requires no schema migration.
+
+- [ ] **Step 6: Verify container and API health**
+
+Run: `docker compose up -d --build`  
+Run: `docker compose ps`  
+Run: `curl --fail --silent http://localhost:8000/health`  
+Expected: database and API healthy; health response is `{"status":"ok"}`.
+
+- [ ] **Step 7: Perform scope, secret, and diff audit**
+
+Run: `git diff --check`  
+Run: `git status --short`  
+Run: `git diff --name-only phase-5/agent-core...HEAD`  
+Run a repository secret scan over tracked Phase 6 changes. Confirm no Phase 7 implementation, write/shell/MCP tool, raw-content persistence, generated report, or `CLAUDE.local.md` is tracked.
+
+- [ ] **Step 8: Commit verified documentation**
+
+```bash
+git add README.md AGENTS.md SYNAPSEOS_DEVELOPMENT_CHECKLIST.md docs infrastructure/tools tests/tools tests/database/test_tool_execution.py tests/database/tool_fixtures.py core/tools
+git commit -m "docs(tools): document Phase 6 tool registry"
+```
+
+Do not push or create a PR until the user explicitly requests branch integration.

--- a/docs/superpowers/plans/2026-08-26-phase-6-tool-registry.md
+++ b/docs/superpowers/plans/2026-08-26-phase-6-tool-registry.md
@@ -489,9 +489,7 @@ git commit -m "feat(tools): persist sanitized tool audits"
 ```python
 def test_default_registry_contains_only_phase_6_tools() -> None:
     registry = create_default_tool_registry()
-    assert registry.names == (
-        "git_diff", "git_status", "list_files", "read_file", "search_text"
-    )
+    assert registry.names == ("git_diff", "git_status", "list_files", "read_file", "search_text")
 ```
 
 Also assert exact required permissions, LOW risk, timeouts, strict input schemas, and absence of registration mutation methods.

--- a/docs/superpowers/plans/2026-08-26-phase-6-tool-registry.md
+++ b/docs/superpowers/plans/2026-08-26-phase-6-tool-registry.md
@@ -221,11 +221,11 @@ Expected: failure because the executor and audit port do not exist.
 
 - [ ] **Step 3: Implement one validated success path**
 
-Begin audit before lookup using only tool name and argument key/type metadata, revalidate the registered input model with strict/forbid settings, call the tool once under `asyncio.timeout(tool.timeout_seconds)`, validate output, finish audit, and return `ToolResult`.
+Begin audit before lookup using only tool name and argument count, revalidate the registered input model with strict/forbid settings, call the tool once under `asyncio.timeout(tool.timeout_seconds)`, validate output, finish audit, and return `ToolResult`.
 
 - [ ] **Step 4: Add deny-by-default tests**
 
-Prove unknown, undeclared, missing-permission, extra-input, coercible-input, and malformed-output requests never execute and each valid-scope attempt finishes one audit with the expected safe code. Verify audit metadata contains argument keys/types but no values.
+Prove unknown, undeclared, missing-permission, extra-input, coercible-input, and malformed-output requests never execute and each valid-scope attempt finishes one audit with the expected safe code. Verify initial audit metadata contains only argument count, never caller-controlled keys or values.
 
 - [ ] **Step 5: Implement denial and failure mappings**
 
@@ -285,7 +285,7 @@ Reject blank, absolute, NUL, and `..` components before joining. Resolve the roo
 
 - [ ] **Step 4: Add symlink, prefix-confusion, special-file, and race-oriented tests**
 
-Create internal symlinks, file symlinks escaping the root, directory symlinks escaping the root, a sibling named with the root prefix, broken symlinks, and a FIFO where supported. Assert allowed internal symlinks resolve safely and all escapes/special files fail without leaking either root or target path.
+Create internal symlinks, file symlinks escaping the root, directory symlinks escaping the root, a sibling named with the root prefix, broken symlinks, and a FIFO where supported. Assert every symlink and special file fails without leaking either root or target path; Phase 6 intentionally follows no symlinks to remove validation/open races.
 
 - [ ] **Step 5: Implement safe relative rendering**
 

--- a/docs/superpowers/specs/2026-08-26-phase-6-tool-registry-design.md
+++ b/docs/superpowers/specs/2026-08-26-phase-6-tool-registry-design.md
@@ -1,0 +1,371 @@
+# Phase 6 Tool Registry Design
+
+**Date:** 2026-08-26  
+**Status:** Approved in conversation  
+**Scope:** Phase 6 only
+
+## Objective
+
+Phase 6 introduces an explicit registry of bounded read-only capabilities. An agent may invoke only
+a registered tool that is declared on its profile and whose required permission identifiers are
+present in the execution context. Every attempt passes through one executor that applies validation,
+workspace containment, timeout, cancellation, output limits, and audit recording consistently.
+
+This phase does not connect tools to the Phase 5 `Agent` methods. It creates the independently
+testable boundary that a later orchestration phase can consume.
+
+## Included scope
+
+Phase 6 includes:
+
+- typed tool definitions and results;
+- a duplicate-safe `ToolRegistry`;
+- a single `ToolExecutor` enforcement point;
+- a typed `ToolExecutionContext`;
+- deterministic Phase 6 checks for declared tools and permission membership;
+- automatic `ToolCall` and `AuditEvent` persistence through an injected audit port;
+- `read_file`, `list_files`, `search_text`, `git_status`, and `git_diff`;
+- strict workspace containment, including symlink escape protection;
+- bounded inputs, outputs, directory traversal, search results, subprocess output, and execution time;
+- cancellation propagation and sanitized errors;
+- unit tests plus real-PostgreSQL audit integration tests.
+
+## Explicit exclusions
+
+Phase 6 does not include:
+
+- the Phase 7 Permission Engine or policy evaluation;
+- runtime attachment to `Agent`;
+- write, edit, delete, shell, network, MCP, or deployment tools;
+- arbitrary commands, command strings, `shell=True`, or user-controlled environment variables;
+- workspace creation or lifecycle management from Phase 9;
+- dynamic plugin discovery, entry points, or automatic imports;
+- retries, autonomous loops, background jobs, or concurrent tool scheduling;
+- persistence of file contents, diffs, search matches, prompts, or raw tool responses;
+- database triggers, RLS, or PostgreSQL permission hardening.
+
+## Architecture
+
+```text
+Caller
+  -> ToolExecutor
+     -> validate ToolExecutionContext
+     -> begin audit record
+     -> ToolRegistry lookup
+     -> declared-tool check
+     -> required-permission membership check
+     -> enforce timeout and propagate cancellation
+     -> registered Tool.execute()
+     -> validate and bound result
+     -> finish ToolCall and append AuditEvent
+  -> ToolResult
+```
+
+The registry discovers nothing. The application composition root constructs the five approved tools
+and registers them explicitly. The executor is the only public invocation path documented for normal
+application use.
+
+## Module boundaries
+
+```text
+core/tools/
+├── __init__.py       public Phase 6 API
+├── types.py          strict immutable values and tool-specific risk/status enums
+├── errors.py         sanitized domain errors
+├── tool.py           generic asynchronous Tool contract
+├── registry.py       explicit immutable registry
+├── executor.py       shared enforcement and lifecycle
+└── audit.py          persistence-neutral audit port and call handle
+
+infrastructure/tools/
+├── __init__.py       concrete tool exports and default registry factory
+├── paths.py          canonical workspace/path containment primitives
+├── filesystem.py     read_file, list_files, and search_text
+├── git.py            fixed-argument git_status and git_diff adapters
+└── audit.py          SQLAlchemy ToolCall/AuditEvent recorder
+```
+
+Core modules do not import SQLAlchemy or concrete infrastructure tools. Infrastructure implements the
+core contracts and may import the Phase 2 ORM models.
+
+## Core contracts
+
+### Identifiers and enums
+
+Tool names and permission identifiers use the existing lowercase identifier convention. Tool risk
+is local to the tools domain and therefore does not extend `core/enums.py`.
+
+```python
+class ToolRiskLevel(StrEnum):
+    LOW = "LOW"
+    MEDIUM = "MEDIUM"
+    HIGH = "HIGH"
+    CRITICAL = "CRITICAL"
+
+
+class ToolResultStatus(StrEnum):
+    SUCCEEDED = "SUCCEEDED"
+    FAILED = "FAILED"
+    DENIED = "DENIED"
+    TIMED_OUT = "TIMED_OUT"
+```
+
+All five Phase 6 tools are `LOW` risk because they are bounded and read-only. This classification does
+not grant permission by itself.
+
+### Tool execution context
+
+`ToolExecutionContext` is a strict frozen Pydantic model containing:
+
+- canonical `workspace_root` supplied by the caller;
+- `agent_id`, `agent_run_id`, `project_id`, and `task_id`;
+- `declared_tool_ids` copied from the agent profile;
+- `permission_ids` already granted to the run;
+- `correlation_id` for traceability.
+
+The context requires non-empty bounded identifiers, UUID run/project/task/correlation values, a
+present directory for `workspace_root`, and bounded immutable identifier sets. It contains no session,
+repository, provider client, secret, prompt, or mutable policy engine.
+
+The Phase 6 permission check is deliberately narrow:
+
+```text
+requested tool name in declared_tool_ids
+AND
+tool.required_permissions is a subset of permission_ids
+```
+
+No hierarchy, wildcard, role policy, approval flow, or autonomy calculation is introduced before
+Phase 7.
+
+### Tool definition
+
+Each concrete tool implements a generic asynchronous contract with:
+
+- `name`;
+- `description`;
+- `input_type`, a strict Pydantic model class;
+- `required_permissions`, an immutable set;
+- `risk_level`;
+- `timeout_seconds`, positive and no greater than 30 seconds;
+- `execute(arguments, context)`.
+
+The executor reconstructs the input with `strict=True` and `extra="forbid"` before execution. The
+input JSON schema is exposed through `input_type.model_json_schema()`; no second hand-written schema
+may diverge from validation.
+
+### Tool result
+
+`ToolResult` is strict and frozen. It contains:
+
+- tool name and result status;
+- a bounded JSON-compatible output mapping;
+- safe error code and safe error message when unsuccessful;
+- duration in milliseconds;
+- `truncated` flag;
+- the persisted `tool_call_id`.
+
+The complete serialized result is capped at 1 MiB, while concrete tools use lower limits. Error
+messages never contain raw input, file content, command output, host paths, environment values, or
+provider metadata. Cancellation raises `asyncio.CancelledError`; it is not converted into a normal
+result.
+
+### Registry
+
+`ToolRegistry` is built from an iterable of tool instances. Construction validates every descriptor
+and rejects duplicate names. It exposes only immutable lookup and listing operations. Registration or
+replacement after construction is absent from Phase 6, preventing runtime mutation races and hidden
+capability injection.
+
+### Executor
+
+`ToolExecutor` receives a registry and audit recorder through its constructor and does not own either
+resource. For each invocation it:
+
+1. validates the context and raw arguments without retaining them;
+2. asks the audit recorder to create a `RUNNING` `ToolCall` using only the requested tool name and
+   sanitized argument-shape metadata;
+3. obtains the registered tool or returns an audited, sanitized unknown-tool failure without
+   executing code;
+4. denies undeclared tools;
+5. denies missing required permission identifiers;
+6. runs exactly one `execute()` call under the tool timeout;
+7. validates and bounds the output;
+8. updates `ToolCall` to its terminal state and appends one `AuditEvent`;
+9. returns a structured result or propagates cancellation.
+
+Malformed execution contexts that cannot establish actor/run scope fail before audit creation and
+before any tool lookup or execution. All attempts with valid execution scope, including unknown,
+undeclared, unauthorized, and invalid-input requests, receive terminal `ToolCall` and `AuditEvent`
+records.
+
+There are no implicit retries. Timeout produces `TIMED_OUT`; validation, tool, and audit failures are
+distinguishable by safe error codes. A failure to create the initial audit record fails closed before
+the tool runs. The executor never closes an injected audit recorder or database session.
+
+## Audit contract
+
+The persistence-neutral recorder exposes start and finish operations. Its SQLAlchemy adapter stages
+changes in the injected session and flushes only when an identifier is required; it never commits,
+rolls back, or closes the caller-owned session.
+
+The initial `ToolCall` records:
+
+- agent run identifier;
+- tool name and fixed action name;
+- `RUNNING` status and start time;
+- sanitized input metadata only.
+
+Terminal completion records status, finish time, duration/size/truncation metadata, and a safe error
+code when applicable. It appends an `AuditEvent` with actor `AGENT`, project/task/run/correlation
+scope, event type `TOOL_EXECUTION`, a fixed action, and a mapped audit result.
+
+Persisted input/output metadata may contain relative path, requested limits, counts, byte sizes,
+hashes, exit codes, and truncation flags. It must not contain file contents, diff contents, search
+matches, raw subprocess streams, prompts, environment values, or absolute host paths.
+
+`AuditEvent` remains append-only. `ToolCall` is the mutable lifecycle projection already approved by
+the Phase 2 schema.
+
+## Workspace and path security
+
+Every filesystem request is relative to a mandatory canonical workspace root. Inputs reject absolute
+paths, NUL bytes, blank paths, and parent traversal components. The path guard resolves the nearest
+existing path and every selected entry with symlinks followed, then verifies containment using path
+semantics rather than string prefixes.
+
+Consequences:
+
+- `../secret`, absolute paths, prefix-confusion paths, and symlink escapes are denied;
+- the workspace root is resolved once during context validation and only that canonical root is used;
+- special files, sockets, devices, and FIFOs are not read;
+- generated output uses workspace-relative POSIX paths only;
+- permission errors become sanitized failures without leaking host paths.
+
+The guard is reusable by Phase 9 but does not create, mount, delete, or otherwise manage workspaces.
+
+## Concrete tools
+
+### `read_file`
+
+Input: relative file path, one-based `start_line`, and `max_lines` from 1 through 2,000. It accepts
+regular UTF-8 text files no larger than 8 MiB. It streams lines, returns at most 256 KiB of text, line
+range metadata, and a truncation flag. Binary or invalid UTF-8 files fail safely; automatic encoding
+guessing is excluded.
+
+Required permission: `workspace.read`.
+
+### `list_files`
+
+Input: relative directory path, `recursive` flag, and `max_entries` from 1 through 10,000. It uses
+bounded traversal, does not follow directory symlinks, sorts results deterministically, and returns
+workspace-relative paths plus entry kinds. Hidden files are included because silently hiding project
+configuration would make repository inspection unreliable. Escaping symlinks are never exposed as
+readable targets.
+
+Required permission: `workspace.list`.
+
+### `search_text`
+
+Input: non-blank literal query capped at 1,024 characters, relative directory/file path, optional
+case sensitivity, `max_results` from 1 through 1,000, and per-line output capped at 4,096 characters.
+It performs literal UTF-8 text search with bounded streaming, skips binary/special files, does not
+follow directory symlinks, limits each candidate file to 8 MiB, and returns deterministic relative
+path, line number, and bounded line text. Regex search is excluded from Phase 6 to avoid complexity
+and denial-of-service behavior.
+
+Required permission: `workspace.search`.
+
+### `git_status`
+
+Runs only `git status --short --branch --untracked-files=all` with a fixed argument vector, sanitized
+environment, canonical workspace working directory, no shell, and bounded stdout/stderr. It returns
+the bounded status text, exit code, and truncation metadata. The workspace must be inside a Git work
+tree.
+
+Required permission: `git.read`.
+
+### `git_diff`
+
+Input selects `WORKTREE` or `STAGED` and optional validated workspace-relative path filters. It runs
+only one fixed form of `git diff --no-ext-diff --no-color --src-prefix=a/ --dst-prefix=b/`, adding
+`--cached` for staged mode and `--` plus validated path filters. Git configuration disables external
+diff and text conversion. Output is capped at 512 KiB and explicitly reports truncation.
+
+Required permission: `git.read`.
+
+## Resource lifecycle and process safety
+
+- Each invocation executes one tool exactly once.
+- Each tool has an enforced timeout no greater than 30 seconds.
+- Cancellation is re-raised immediately after synchronous terminal audit staging; cleanup does not
+  launch another task or shield long-running work.
+- Git subprocesses use `asyncio.create_subprocess_exec`, a sanitized environment allowlist, a new
+  process session, bounded capture, and explicit termination on timeout or cancellation.
+- Files are opened with context managers and streamed; directory iterators are closed deterministically.
+- Injected registries, recorders, sessions, and future clients are never closed by tools or executor.
+- No retry, fallback command, network call, telemetry, or persistence occurs implicitly.
+
+## Error model
+
+Public failures use stable codes such as `TOOL_NOT_FOUND`, `TOOL_NOT_DECLARED`,
+`PERMISSION_DENIED`, `INVALID_INPUT`, `WORKSPACE_VIOLATION`, `UNSUPPORTED_FILE`, `OUTPUT_LIMIT`,
+`TOOL_FAILED`, `AUDIT_FAILED`, and `TOOL_TIMED_OUT`. Safe messages identify the class of failure, not
+the rejected value. Internal exceptions are chained only where they cannot leak through public or
+persisted representations.
+
+Denied, failed, and timed-out calls are never represented as success. Cancellation remains
+cancellation and is recorded as a cancelled audit result without changing the existing
+`ToolCallStatus` enum; the `ToolCall` uses `FAILED` with safe code `CANCELLED` until a future schema
+phase explicitly adds a cancellation state.
+
+## Testing strategy
+
+Tests follow strict red-green-refactor cycles.
+
+Unit tests prove:
+
+- strict models and schemas reject malformed or oversized data;
+- duplicate registration fails and registry views are immutable;
+- unknown, undeclared, and unauthorized tools never execute;
+- each registered tool executes exactly once;
+- timeout and cancellation stop execution without retry;
+- paths reject absolute values, traversal, prefix confusion, and symlink escapes;
+- filesystem tools enforce file, line, entry, result, and output limits;
+- Git commands use fixed arguments, no shell, safe environment, and bounded output;
+- errors and results do not expose absolute roots, raw rejected values, environment data, or secrets;
+- injected dependencies remain open and caller-owned.
+
+Real-PostgreSQL tests construct the schema exclusively through Alembic and prove:
+
+- successful, denied, failed, timed-out, and cancelled attempts create the expected `ToolCall` and
+  append-only `AuditEvent` records;
+- persisted records contain only allowlisted metadata;
+- raw file, diff, search, stderr, and argument contents are absent;
+- the adapter never commits, rolls back, or closes the injected session.
+
+The full repository test suite, Ruff check, Ruff format check, mypy, Alembic head verification, and
+Docker health check are required before Phase 6 checkboxes are updated.
+
+## Documentation and phase boundary
+
+Phase 6 adds a tool-system usage document and an ADR for the registry/executor boundary. README and
+`AGENTS.md` are updated to describe only verified Phase 6 behavior. Only Phase 6 checklist items are
+checked after their acceptance evidence exists.
+
+Phase 7 remains entirely unchecked and unimplemented. In particular, Phase 6 permission membership
+is a deny-by-default prerequisite check, not the future Permission Engine.
+
+## Acceptance criteria
+
+Phase 6 is complete only when:
+
+- the five approved read-only tools are explicitly registered and independently tested;
+- every invocation passes through uniform declaration, permission, workspace, timeout, output, and
+  audit enforcement;
+- no arbitrary shell, filesystem write, network, MCP, skill, or autonomous behavior exists;
+- all path and symlink escape tests pass;
+- all audit integration tests pass against real PostgreSQL migrated by Alembic;
+- the complete quality and container verification is green;
+- only verified Phase 6 checklist boxes are checked;
+- no Phase 7 behavior has been introduced.

--- a/docs/superpowers/specs/2026-08-26-phase-6-tool-registry-design.md
+++ b/docs/superpowers/specs/2026-08-26-phase-6-tool-registry-design.md
@@ -184,7 +184,7 @@ resource. For each invocation it:
 
 1. validates the context and raw arguments without retaining them;
 2. asks the audit recorder to create a `RUNNING` `ToolCall` using only the requested tool name and
-   sanitized argument-shape metadata;
+   argument count; caller-controlled keys and values are not retained;
 3. obtains the registered tool or returns an audited, sanitized unknown-tool failure without
    executing code;
 4. denies undeclared tools;
@@ -230,13 +230,14 @@ the Phase 2 schema.
 ## Workspace and path security
 
 Every filesystem request is relative to a mandatory canonical workspace root. Inputs reject absolute
-paths, NUL bytes, blank paths, and parent traversal components. The path guard resolves the nearest
-existing path and every selected entry with symlinks followed, then verifies containment using path
-semantics rather than string prefixes.
+paths, NUL bytes, blank paths, and parent traversal components. The path guard inspects every existing
+component with `lstat`, rejects all symlinks, resolves the selected path, then verifies containment
+using path semantics rather than string prefixes. The conservative no-symlink rule removes the
+validation/open race that would otherwise allow a link target to change after authorization.
 
 Consequences:
 
-- `../secret`, absolute paths, prefix-confusion paths, and symlink escapes are denied;
+- `../secret`, absolute paths, prefix-confusion paths, and all symlinks are denied;
 - the workspace root is resolved once during context validation and only that canonical root is used;
 - special files, sockets, devices, and FIFOs are not read;
 - generated output uses workspace-relative POSIX paths only;

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -1,0 +1,91 @@
+# Tool registry
+
+Phase 6 provides a small, deny-by-default execution boundary for five read-only repository tools:
+
+| Tool | Permission | Timeout | Main output limit |
+|---|---|---:|---:|
+| `read_file` | `workspace.read` | 5 s | 256 KiB |
+| `list_files` | `workspace.list` | 5 s | 512 KiB |
+| `search_text` | `workspace.search` | 10 s | 512 KiB |
+| `git_status` | `git.read` | 10 s | 256 KiB |
+| `git_diff` | `git.read` | 10 s | 512 KiB |
+
+The immutable default registry is created explicitly with `create_default_tool_registry()`. It has
+no runtime registration or removal API. A caller must invoke tools through `ToolExecutor`; calling
+a concrete tool directly bypasses the mandatory declaration, permission, timeout, output
+validation, and audit lifecycle and is not an approved application path.
+
+## Composition
+
+```python
+registry = create_default_tool_registry()
+recorder = SQLAlchemyToolAuditRecorder(caller_owned_session)
+executor = ToolExecutor(registry, recorder)
+
+result = await executor.execute(
+    "read_file",
+    {"path": "README.md"},
+    execution_context,
+)
+```
+
+The execution context identifies an existing agent run and contains a canonical workspace root,
+the agent's declared tool IDs, and its effective permission IDs. The executor performs exactly one
+attempt and never retries or falls back. Cancellation is audited and immediately re-raised.
+
+The SQLAlchemy recorder flushes a new `ToolCall` to obtain its ID, appends one terminal
+`AuditEvent`, and flushes that terminal state before returning. It never commits, rolls back, or
+closes the injected session. The caller therefore controls transaction atomicity and resource
+lifetime.
+
+## Filesystem boundary
+
+- Paths must be non-empty, relative workspace paths without `..` or NUL characters.
+- The workspace root must already exist and be canonical.
+- Every path component is inspected without following links. All symlinks, including links whose
+  targets remain inside the workspace, are rejected.
+- Files must be regular UTF-8 files. `read_file` and search candidates are at most 8 MiB.
+- `read_file` returns at most 256 KiB and supports bounded line ranges.
+- `list_files` scans at most 10,000 entries and returns at most 512 KiB. It may report a symlink as
+  an entry but never follows it.
+- `search_text` is literal, not regular-expression search. It inspects bounded lines, returns at
+  most 1,000 matches, and emits at most 512 KiB.
+- File descriptors use no-follow semantics where the operating system provides them, reducing the
+  validation/open race surface.
+
+Truncation is explicit in structured output. No result can exceed the global 1 MiB `ToolResult`
+limit.
+
+## Git boundary
+
+Git tools invoke the fixed `/usr/bin/git` executable without a shell and with a clean, fixed
+environment. User input can only select validated relative path filters and an enum-defined diff
+target. Commands disable color, text conversion, and external diff helpers. Standard output and
+standard error are drained concurrently under hard byte limits so a subprocess cannot deadlock on
+a full pipe. Timeout or cancellation terminates the process group and waits for cleanup.
+
+`git_status` uses porcelain output. `git_diff` supports only the predefined worktree, staged, and
+HEAD targets. These tools cannot commit, stage, reset, checkout, invoke hooks, or execute arbitrary
+commands.
+
+## Audit and data minimization
+
+Audit begins before registry lookup, so unknown and denied attempts are recorded. A valid database
+scope must link the supplied agent slug, agent run, task, and project. Forged or inconsistent scope
+is rejected before a `ToolCall` is created.
+
+Persisted input contains only `argument_count`. Terminal metadata is restricted to duration,
+truncation, output field count, output byte count, and an optional stable error code. Audit storage
+never receives argument names or values, file contents, search matches, Git diffs, subprocess
+streams, absolute host paths, prompts, provider responses, environment values, or exception text.
+
+Public results use stable statuses (`SUCCEEDED`, `FAILED`, `DENIED`, `TIMED_OUT`) and safe error
+codes. Propagated cancellation is represented as `CANCELLED` in the append-only audit event and as
+a failed tool-call record with the safe `CANCELLED` code.
+
+## Deliberate boundary
+
+Phase 6 checks only that the requested tool was declared and that every required permission ID is
+present. Policy evaluation, `ALLOW`/`DENY`/`ASK`, approval gates, risk-dependent autonomy, and
+permission provenance belong to the Phase 7 Permission Engine. This phase also excludes write
+tools, free-form shell execution, MCP, skill loading, agent loops, retries, and dynamic discovery.

--- a/infrastructure/tools/__init__.py
+++ b/infrastructure/tools/__init__.py
@@ -8,6 +8,13 @@ from infrastructure.tools.filesystem import (
     SearchTextInput,
     SearchTextTool,
 )
+from infrastructure.tools.git import (
+    GitDiffInput,
+    GitDiffTarget,
+    GitDiffTool,
+    GitStatusInput,
+    GitStatusTool,
+)
 
 __all__ = [
     "ListFilesInput",
@@ -16,4 +23,9 @@ __all__ = [
     "ReadFileTool",
     "SearchTextInput",
     "SearchTextTool",
+    "GitDiffInput",
+    "GitDiffTarget",
+    "GitDiffTool",
+    "GitStatusInput",
+    "GitStatusTool",
 ]

--- a/infrastructure/tools/__init__.py
+++ b/infrastructure/tools/__init__.py
@@ -1,0 +1,1 @@
+"""Concrete bounded tool adapters for SynapseOS."""

--- a/infrastructure/tools/__init__.py
+++ b/infrastructure/tools/__init__.py
@@ -1,5 +1,7 @@
 """Concrete bounded tool adapters for SynapseOS."""
 
+from core.tools import ToolRegistry
+from infrastructure.tools.audit import SQLAlchemyToolAuditRecorder
 from infrastructure.tools.filesystem import (
     ListFilesInput,
     ListFilesTool,
@@ -16,7 +18,23 @@ from infrastructure.tools.git import (
     GitStatusTool,
 )
 
+
+def create_default_tool_registry() -> ToolRegistry:
+    """Build the immutable registry of approved Phase 6 read-only tools."""
+    return ToolRegistry(
+        [
+            ReadFileTool(),
+            ListFilesTool(),
+            SearchTextTool(),
+            GitStatusTool(),
+            GitDiffTool(),
+        ]
+    )
+
+
 __all__ = [
+    "create_default_tool_registry",
+    "SQLAlchemyToolAuditRecorder",
     "ListFilesInput",
     "ListFilesTool",
     "ReadFileInput",

--- a/infrastructure/tools/__init__.py
+++ b/infrastructure/tools/__init__.py
@@ -1,1 +1,19 @@
 """Concrete bounded tool adapters for SynapseOS."""
+
+from infrastructure.tools.filesystem import (
+    ListFilesInput,
+    ListFilesTool,
+    ReadFileInput,
+    ReadFileTool,
+    SearchTextInput,
+    SearchTextTool,
+)
+
+__all__ = [
+    "ListFilesInput",
+    "ListFilesTool",
+    "ReadFileInput",
+    "ReadFileTool",
+    "SearchTextInput",
+    "SearchTextTool",
+]

--- a/infrastructure/tools/audit.py
+++ b/infrastructure/tools/audit.py
@@ -70,11 +70,7 @@ class SQLAlchemyToolAuditRecorder:
         validated_handle = self._validate_handle(handle)
         validated_finish = self._validate_finish(finish)
         pending = self._pending.get(validated_handle.tool_call_id)
-        if (
-            pending is None
-            or pending.finished
-            or object_session(pending.call) is not self._session
-        ):
+        if pending is None or pending.finished or object_session(pending.call) is not self._session:
             raise self._finalization_failed()
 
         call_status, audit_result = _status_mapping(validated_finish.outcome)
@@ -91,9 +87,7 @@ class SQLAlchemyToolAuditRecorder:
         pending.call.finished_at = datetime.now(UTC)
         pending.call.output_data = dict(terminal_data)
         pending.call.error_message = (
-            validated_finish.error_code.value
-            if validated_finish.error_code is not None
-            else None
+            validated_finish.error_code.value if validated_finish.error_code is not None else None
         )
         event = AuditEvent(
             actor_type=AuditActorType.AGENT,
@@ -111,6 +105,7 @@ class SQLAlchemyToolAuditRecorder:
         )
         try:
             self._session.add(event)
+            self._session.flush()
             pending.finished = True
         except Exception as error:
             error.__traceback__ = None

--- a/infrastructure/tools/audit.py
+++ b/infrastructure/tools/audit.py
@@ -1,0 +1,191 @@
+"""SQLAlchemy-backed, sanitized audit lifecycle for tool invocations."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import UTC, datetime
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session, object_session
+
+from core.enums import AuditActorType, AuditResult, ToolCallStatus
+from core.tools.audit import (
+    ToolAuditFinish,
+    ToolAuditHandle,
+    ToolAuditOutcome,
+    ToolAuditStart,
+)
+from core.tools.errors import ToolAuditError
+from core.tools.types import ToolErrorCode
+from infrastructure.database.models import Agent, AgentRun, AuditEvent, Task, ToolCall
+
+_ACTION = "execute_tool"
+_EVENT_TYPE = "TOOL_EXECUTION"
+_RESOURCE_TYPE = "TOOL"
+
+
+@dataclass(slots=True)
+class _PendingAudit:
+    call: ToolCall
+    start: ToolAuditStart
+    finished: bool = False
+
+
+class SQLAlchemyToolAuditRecorder:
+    """Record tool calls without owning the caller-provided session lifecycle."""
+
+    def __init__(self, session: Session) -> None:
+        self._session = session
+        self._pending: dict[object, _PendingAudit] = {}
+
+    def begin(self, start: ToolAuditStart) -> ToolAuditHandle:
+        """Validate invocation scope and persist a sanitized running record."""
+        validated = self._validate_start(start)
+        if not self._scope_exists(validated):
+            raise self._unavailable()
+
+        call = ToolCall(
+            agent_run_id=validated.agent_run_id,
+            tool_name=validated.tool_name,
+            action=_ACTION,
+            input_data={"argument_count": validated.argument_count},
+            output_data={},
+            status=ToolCallStatus.RUNNING,
+            started_at=datetime.now(UTC),
+        )
+        try:
+            self._session.add(call)
+            self._session.flush()
+        except Exception as error:
+            error.__traceback__ = None
+            del error
+            raise self._unavailable() from None
+
+        handle = ToolAuditHandle(tool_call_id=call.id)
+        self._pending[handle.tool_call_id] = _PendingAudit(call=call, start=validated)
+        return handle
+
+    def finish(self, handle: ToolAuditHandle, finish: ToolAuditFinish) -> None:
+        """Finalize one call and append its terminal audit event."""
+        validated_handle = self._validate_handle(handle)
+        validated_finish = self._validate_finish(finish)
+        pending = self._pending.get(validated_handle.tool_call_id)
+        if (
+            pending is None
+            or pending.finished
+            or object_session(pending.call) is not self._session
+        ):
+            raise self._finalization_failed()
+
+        call_status, audit_result = _status_mapping(validated_finish.outcome)
+        terminal_data: dict[str, object] = {
+            "duration_ms": validated_finish.duration_ms,
+            "truncated": validated_finish.truncated,
+            "output_field_count": validated_finish.output_field_count,
+            "output_bytes": validated_finish.output_bytes,
+        }
+        if validated_finish.error_code is not None:
+            terminal_data["error_code"] = validated_finish.error_code.value
+
+        pending.call.status = call_status
+        pending.call.finished_at = datetime.now(UTC)
+        pending.call.output_data = dict(terminal_data)
+        pending.call.error_message = (
+            validated_finish.error_code.value
+            if validated_finish.error_code is not None
+            else None
+        )
+        event = AuditEvent(
+            actor_type=AuditActorType.AGENT,
+            actor_id=pending.start.agent_id,
+            project_id=pending.start.project_id,
+            task_id=pending.start.task_id,
+            agent_run_id=pending.start.agent_run_id,
+            event_type=_EVENT_TYPE,
+            action=_ACTION,
+            resource_type=_RESOURCE_TYPE,
+            resource_id=pending.start.tool_name,
+            result=audit_result,
+            data=dict(terminal_data),
+            correlation_id=pending.start.correlation_id,
+        )
+        try:
+            self._session.add(event)
+            pending.finished = True
+        except Exception as error:
+            error.__traceback__ = None
+            del error
+            raise self._finalization_failed() from None
+
+    def _scope_exists(self, start: ToolAuditStart) -> bool:
+        statement = (
+            select(AgentRun.id)
+            .join(Agent, Agent.id == AgentRun.agent_id)
+            .join(Task, Task.id == AgentRun.task_id)
+            .where(
+                AgentRun.id == start.agent_run_id,
+                Agent.slug == start.agent_id,
+                AgentRun.task_id == start.task_id,
+                Task.project_id == start.project_id,
+            )
+        )
+        try:
+            return self._session.scalar(statement) is not None
+        except Exception as error:
+            error.__traceback__ = None
+            del error
+            raise self._unavailable() from None
+
+    @staticmethod
+    def _validate_start(start: ToolAuditStart) -> ToolAuditStart:
+        if type(start) is not ToolAuditStart:
+            raise SQLAlchemyToolAuditRecorder._unavailable()
+        try:
+            return ToolAuditStart.model_validate(start.__dict__, strict=True)
+        except Exception as error:
+            error.__traceback__ = None
+            del error
+            raise SQLAlchemyToolAuditRecorder._unavailable() from None
+
+    @staticmethod
+    def _validate_handle(handle: ToolAuditHandle) -> ToolAuditHandle:
+        if type(handle) is not ToolAuditHandle:
+            raise SQLAlchemyToolAuditRecorder._finalization_failed()
+        try:
+            return ToolAuditHandle.model_validate(handle.__dict__, strict=True)
+        except Exception as error:
+            error.__traceback__ = None
+            del error
+            raise SQLAlchemyToolAuditRecorder._finalization_failed() from None
+
+    @staticmethod
+    def _validate_finish(finish: ToolAuditFinish) -> ToolAuditFinish:
+        if type(finish) is not ToolAuditFinish:
+            raise SQLAlchemyToolAuditRecorder._finalization_failed()
+        try:
+            return ToolAuditFinish.model_validate(finish.__dict__, strict=True)
+        except Exception as error:
+            error.__traceback__ = None
+            del error
+            raise SQLAlchemyToolAuditRecorder._finalization_failed() from None
+
+    @staticmethod
+    def _unavailable() -> ToolAuditError:
+        return ToolAuditError(ToolErrorCode.AUDIT_FAILED, "Tool audit is unavailable.")
+
+    @staticmethod
+    def _finalization_failed() -> ToolAuditError:
+        return ToolAuditError(
+            ToolErrorCode.AUDIT_FAILED,
+            "Tool audit could not be finalized.",
+        )
+
+
+def _status_mapping(outcome: ToolAuditOutcome) -> tuple[ToolCallStatus, AuditResult]:
+    return {
+        ToolAuditOutcome.SUCCEEDED: (ToolCallStatus.SUCCEEDED, AuditResult.SUCCEEDED),
+        ToolAuditOutcome.FAILED: (ToolCallStatus.FAILED, AuditResult.FAILED),
+        ToolAuditOutcome.DENIED: (ToolCallStatus.DENIED, AuditResult.DENIED),
+        ToolAuditOutcome.TIMED_OUT: (ToolCallStatus.TIMED_OUT, AuditResult.FAILED),
+        ToolAuditOutcome.CANCELLED: (ToolCallStatus.FAILED, AuditResult.CANCELLED),
+    }[outcome]

--- a/infrastructure/tools/filesystem.py
+++ b/infrastructure/tools/filesystem.py
@@ -1,0 +1,343 @@
+"""Bounded read-only filesystem tools."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import stat
+from collections import deque
+from pathlib import Path
+from typing import Annotated
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+from core.tools import (
+    JsonValue,
+    Tool,
+    ToolErrorCode,
+    ToolExecutionContext,
+    ToolInputError,
+    ToolRiskLevel,
+)
+from infrastructure.tools.paths import relative_workspace_path, resolve_workspace_path
+
+_MAX_PATH_LENGTH = 4_096
+_MAX_FILE_BYTES = 8 * 1_024 * 1_024
+_MAX_READ_OUTPUT_BYTES = 256 * 1_024
+_MAX_COLLECTION_OUTPUT_BYTES = 512 * 1_024
+_MAX_SCAN_ENTRIES = 10_000
+_MAX_LINE_LENGTH = 4_096
+
+
+class _StrictInput(BaseModel):
+    model_config = ConfigDict(frozen=True, extra="forbid", hide_input_in_errors=True)
+
+
+class ReadFileInput(_StrictInput):
+    """Bounded line-range request for one UTF-8 text file."""
+
+    path: Annotated[str, Field(min_length=1, max_length=_MAX_PATH_LENGTH)]
+    start_line: Annotated[int, Field(ge=1)] = 1
+    max_lines: Annotated[int, Field(ge=1, le=2_000)] = 2_000
+
+
+class ListFilesInput(_StrictInput):
+    """Bounded directory-listing request."""
+
+    path: Annotated[str, Field(min_length=1, max_length=_MAX_PATH_LENGTH)] = "."
+    recursive: bool = False
+    max_entries: Annotated[int, Field(ge=1, le=10_000)] = 1_000
+
+
+class SearchTextInput(_StrictInput):
+    """Bounded literal text-search request."""
+
+    query: Annotated[str, Field(min_length=1, max_length=1_024)]
+    path: Annotated[str, Field(min_length=1, max_length=_MAX_PATH_LENGTH)] = "."
+    case_sensitive: bool = True
+    max_results: Annotated[int, Field(ge=1, le=1_000)] = 100
+
+    @field_validator("query")
+    @classmethod
+    def reject_blank_query(cls, value: str) -> str:
+        if not value.strip():
+            raise ValueError("query must not be blank")
+        return value
+
+
+def _read_regular_bytes(path: Path) -> bytes:
+    flags = os.O_RDONLY | getattr(os, "O_CLOEXEC", 0) | getattr(os, "O_NOFOLLOW", 0)
+    descriptor = -1
+    try:
+        descriptor = os.open(path, flags)
+        details = os.fstat(descriptor)
+        if not stat.S_ISREG(details.st_mode):
+            raise ToolInputError(
+                ToolErrorCode.UNSUPPORTED_FILE,
+                "Requested file type is not supported.",
+            )
+        if details.st_size > _MAX_FILE_BYTES:
+            raise ToolInputError(
+                ToolErrorCode.OUTPUT_LIMIT,
+                "Requested file exceeds the read limit.",
+            )
+        chunks: list[bytes] = []
+        remaining = _MAX_FILE_BYTES + 1
+        while remaining > 0:
+            chunk = os.read(descriptor, min(65_536, remaining))
+            if not chunk:
+                break
+            chunks.append(chunk)
+            remaining -= len(chunk)
+        data = b"".join(chunks)
+        if len(data) > _MAX_FILE_BYTES:
+            raise ToolInputError(
+                ToolErrorCode.OUTPUT_LIMIT,
+                "Requested file exceeds the read limit.",
+            )
+        return data
+    except ToolInputError:
+        raise
+    except OSError as error:
+        del error
+        raise ToolInputError(
+            ToolErrorCode.UNSUPPORTED_FILE,
+            "Requested file could not be read safely.",
+        ) from None
+    finally:
+        if descriptor >= 0:
+            os.close(descriptor)
+
+
+def _decode_utf8(data: bytes) -> str:
+    try:
+        return data.decode("utf-8", errors="strict")
+    except UnicodeDecodeError as error:
+        del error
+        raise ToolInputError(
+            ToolErrorCode.UNSUPPORTED_FILE,
+            "Requested file is not valid UTF-8 text.",
+        ) from None
+
+
+def _bounded_utf8(value: str, byte_limit: int) -> tuple[str, bool]:
+    encoded = value.encode("utf-8")
+    if len(encoded) <= byte_limit:
+        return value, False
+    return encoded[:byte_limit].decode("utf-8", errors="ignore"), True
+
+
+type _Entry = tuple[Path, str]
+
+
+def _entry_relative_path(root: Path, entry_path: Path) -> str:
+    try:
+        return entry_path.relative_to(root).as_posix()
+    except ValueError as error:
+        del error
+        raise ToolInputError(
+            ToolErrorCode.WORKSPACE_VIOLATION,
+            "Directory entry is outside the workspace.",
+        ) from None
+
+
+def _collect_entries(root: Path, directory: Path, *, recursive: bool) -> tuple[list[_Entry], bool]:
+    pending: deque[Path] = deque([directory])
+    collected: list[_Entry] = []
+    scan_limited = False
+    while pending and len(collected) <= _MAX_SCAN_ENTRIES:
+        current = pending.popleft()
+        try:
+            with os.scandir(current) as iterator:
+                entries = sorted(iterator, key=lambda item: item.name)
+        except OSError as error:
+            del error
+            raise ToolInputError(
+                ToolErrorCode.TOOL_FAILED,
+                "Directory could not be listed safely.",
+            ) from None
+        for entry in entries:
+            entry_path = Path(entry.path)
+            try:
+                if entry.is_symlink():
+                    kind = "symlink"
+                elif entry.is_dir(follow_symlinks=False):
+                    kind = "directory"
+                elif entry.is_file(follow_symlinks=False):
+                    kind = "file"
+                else:
+                    continue
+            except OSError:
+                continue
+            collected.append((entry_path, kind))
+            if recursive and kind == "directory":
+                pending.append(entry_path)
+            if len(collected) > _MAX_SCAN_ENTRIES:
+                scan_limited = True
+                break
+    collected.sort(key=lambda item: _entry_relative_path(root, item[0]))
+    return collected, scan_limited or bool(pending)
+
+
+class ReadFileTool(Tool[ReadFileInput]):
+    """Read a bounded line range from one UTF-8 regular file."""
+
+    name = "read_file"
+    description = "Read a bounded line range from one UTF-8 workspace file."
+    input_type = ReadFileInput
+    required_permissions = frozenset({"workspace.read"})
+    risk_level = ToolRiskLevel.LOW
+    timeout_seconds = 5.0
+
+    async def execute(
+        self,
+        arguments: ReadFileInput,
+        context: ToolExecutionContext,
+    ) -> dict[str, JsonValue]:
+        path = resolve_workspace_path(
+            context.workspace_root,
+            arguments.path,
+            must_exist=True,
+            expected_kind="file",
+        )
+        await asyncio.sleep(0)
+        text = _decode_utf8(_read_regular_bytes(path))
+        await asyncio.sleep(0)
+        lines = text.splitlines(keepends=True)
+        start_index = arguments.start_line - 1
+        selected_lines = lines[start_index : start_index + arguments.max_lines]
+        selected = "".join(selected_lines)
+        content, byte_truncated = _bounded_utf8(selected, _MAX_READ_OUTPUT_BYTES)
+        available_lines = max(0, len(lines) - start_index)
+        truncated = byte_truncated or len(selected_lines) < available_lines
+        end_line = arguments.start_line + len(selected_lines) - 1 if selected_lines else 0
+        return {
+            "path": relative_workspace_path(context.workspace_root, path),
+            "content": content,
+            "start_line": arguments.start_line,
+            "end_line": end_line,
+            "total_lines": len(lines),
+            "truncated": truncated,
+        }
+
+
+class ListFilesTool(Tool[ListFilesInput]):
+    """List bounded workspace entries without following symlinks."""
+
+    name = "list_files"
+    description = "List a bounded deterministic set of workspace entries."
+    input_type = ListFilesInput
+    required_permissions = frozenset({"workspace.list"})
+    risk_level = ToolRiskLevel.LOW
+    timeout_seconds = 5.0
+
+    async def execute(
+        self,
+        arguments: ListFilesInput,
+        context: ToolExecutionContext,
+    ) -> dict[str, JsonValue]:
+        directory = resolve_workspace_path(
+            context.workspace_root,
+            arguments.path,
+            must_exist=True,
+            expected_kind="directory",
+        )
+        collected, scan_limited = _collect_entries(
+            context.workspace_root,
+            directory,
+            recursive=arguments.recursive,
+        )
+        output: list[JsonValue] = []
+        output_bytes = 0
+        truncated = scan_limited
+        for entry_path, kind in collected:
+            await asyncio.sleep(0)
+            item: dict[str, JsonValue] = {
+                "path": _entry_relative_path(context.workspace_root, entry_path),
+                "kind": kind,
+            }
+            item_bytes = len(json.dumps(item, separators=(",", ":")).encode("utf-8"))
+            if len(output) >= arguments.max_entries or (
+                output_bytes + item_bytes > _MAX_COLLECTION_OUTPUT_BYTES
+            ):
+                truncated = True
+                break
+            output.append(item)
+            output_bytes += item_bytes
+        return {
+            "path": relative_workspace_path(context.workspace_root, directory),
+            "entries": output,
+            "truncated": truncated,
+        }
+
+
+class SearchTextTool(Tool[SearchTextInput]):
+    """Search UTF-8 workspace files for one bounded literal query."""
+
+    name = "search_text"
+    description = "Search bounded UTF-8 workspace files for a literal string."
+    input_type = SearchTextInput
+    required_permissions = frozenset({"workspace.search"})
+    risk_level = ToolRiskLevel.LOW
+    timeout_seconds = 10.0
+
+    async def execute(
+        self,
+        arguments: SearchTextInput,
+        context: ToolExecutionContext,
+    ) -> dict[str, JsonValue]:
+        target = resolve_workspace_path(
+            context.workspace_root,
+            arguments.path,
+            must_exist=True,
+            expected_kind="any",
+        )
+        if target.is_file():
+            candidates = [(target, "file")]
+            scan_limited = False
+        else:
+            entries, scan_limited = _collect_entries(
+                context.workspace_root,
+                target,
+                recursive=True,
+            )
+            candidates = [entry for entry in entries if entry[1] == "file"]
+
+        query = arguments.query if arguments.case_sensitive else arguments.query.casefold()
+        matches: list[JsonValue] = []
+        output_bytes = 0
+        truncated = scan_limited
+        for candidate, _kind in candidates:
+            await asyncio.sleep(0)
+            try:
+                text = _decode_utf8(_read_regular_bytes(candidate))
+            except ToolInputError:
+                continue
+            relative = relative_workspace_path(context.workspace_root, candidate)
+            for line_number, line in enumerate(text.splitlines(), start=1):
+                comparable = line if arguments.case_sensitive else line.casefold()
+                if query not in comparable:
+                    continue
+                item: dict[str, JsonValue] = {
+                    "path": relative,
+                    "line": line_number,
+                    "text": line[:_MAX_LINE_LENGTH],
+                }
+                item_bytes = len(json.dumps(item, separators=(",", ":")).encode("utf-8"))
+                if len(matches) >= arguments.max_results or (
+                    output_bytes + item_bytes > _MAX_COLLECTION_OUTPUT_BYTES
+                ):
+                    truncated = True
+                    return {
+                        "query": arguments.query,
+                        "matches": matches,
+                        "truncated": truncated,
+                    }
+                matches.append(item)
+                output_bytes += item_bytes
+        return {
+            "query": arguments.query,
+            "matches": matches,
+            "truncated": truncated,
+        }

--- a/infrastructure/tools/git.py
+++ b/infrastructure/tools/git.py
@@ -1,0 +1,244 @@
+"""Fixed-command bounded read-only Git tools."""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import signal
+from contextlib import suppress
+from enum import StrEnum
+from pathlib import Path
+from typing import Annotated
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+from core.tools import (
+    JsonValue,
+    Tool,
+    ToolErrorCode,
+    ToolExecutionContext,
+    ToolInputError,
+    ToolRiskLevel,
+)
+from infrastructure.tools.paths import relative_workspace_path, resolve_workspace_path
+
+_GIT_EXECUTABLE = Path("/usr/bin/git")
+_STATUS_OUTPUT_LIMIT = 256 * 1_024
+_DIFF_OUTPUT_LIMIT = 512 * 1_024
+_MAX_PATH_LENGTH = 4_096
+_GIT_ENVIRONMENT = {
+    "PATH": "/usr/bin:/bin",
+    "LC_ALL": "C",
+    "GIT_CONFIG_NOSYSTEM": "1",
+    "GIT_CONFIG_GLOBAL": "/dev/null",
+    "GIT_TERMINAL_PROMPT": "0",
+    "GIT_OPTIONAL_LOCKS": "0",
+    "GIT_PAGER": "",
+    "PAGER": "",
+}
+
+
+class _StrictGitInput(BaseModel):
+    model_config = ConfigDict(frozen=True, extra="forbid", hide_input_in_errors=True)
+
+
+class GitStatusInput(_StrictGitInput):
+    """No-argument request for repository status."""
+
+
+class GitDiffTarget(StrEnum):
+    """Approved diff source."""
+
+    WORKTREE = "WORKTREE"
+    STAGED = "STAGED"
+
+
+class GitDiffInput(_StrictGitInput):
+    """Bounded selection of one repository diff."""
+
+    target: GitDiffTarget = GitDiffTarget.WORKTREE
+    paths: Annotated[
+        tuple[Annotated[str, Field(min_length=1, max_length=_MAX_PATH_LENGTH)], ...],
+        Field(max_length=128),
+    ] = ()
+
+    @field_validator("paths", mode="before")
+    @classmethod
+    def freeze_paths(cls, value: object) -> object:
+        if isinstance(value, list):
+            return tuple(value)
+        return value
+
+
+async def _read_limited(
+    stream: asyncio.StreamReader,
+    limit: int,
+) -> tuple[bytes, bool]:
+    chunks: list[bytes] = []
+    retained = 0
+    truncated = False
+    while True:
+        chunk = await stream.read(65_536)
+        if not chunk:
+            break
+        available = max(0, limit - retained)
+        if available:
+            kept = chunk[:available]
+            chunks.append(kept)
+            retained += len(kept)
+        if len(chunk) > available:
+            truncated = True
+    return b"".join(chunks), truncated
+
+
+async def _terminate_process(process: asyncio.subprocess.Process) -> None:
+    if process.returncode is not None:
+        return
+    try:
+        os.killpg(process.pid, signal.SIGKILL)
+    except (OSError, ProcessLookupError):
+        with suppress(ProcessLookupError):
+            process.kill()
+    await process.wait()
+
+
+async def _run_git(
+    arguments: tuple[str, ...],
+    workspace_root: Path,
+    output_limit: int,
+) -> tuple[str, int, bool]:
+    """Run one adapter-owned Git argument vector with bounded output."""
+    if not _GIT_EXECUTABLE.is_file():
+        raise ToolInputError(
+            ToolErrorCode.TOOL_FAILED,
+            "Git executable is unavailable.",
+        )
+    process: asyncio.subprocess.Process | None = None
+    stdout_task: asyncio.Task[tuple[bytes, bool]] | None = None
+    stderr_task: asyncio.Task[tuple[bytes, bool]] | None = None
+    try:
+        process = await asyncio.create_subprocess_exec(
+            str(_GIT_EXECUTABLE),
+            *arguments,
+            cwd=workspace_root,
+            env=_GIT_ENVIRONMENT,
+            stdin=asyncio.subprocess.DEVNULL,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+            start_new_session=True,
+        )
+        assert process.stdout is not None
+        assert process.stderr is not None
+        stdout_task = asyncio.create_task(_read_limited(process.stdout, output_limit))
+        stderr_task = asyncio.create_task(_read_limited(process.stderr, 64 * 1_024))
+        exit_code, stdout_result, _stderr_result = await asyncio.gather(
+            process.wait(),
+            stdout_task,
+            stderr_task,
+        )
+        stdout, truncated = stdout_result
+        if exit_code != 0:
+            raise ToolInputError(
+                ToolErrorCode.TOOL_FAILED,
+                "Git command failed.",
+            )
+        return stdout.decode("utf-8", errors="ignore"), exit_code, truncated
+    except asyncio.CancelledError:
+        if process is not None:
+            await _terminate_process(process)
+        pending_tasks = [
+            task
+            for task in (stdout_task, stderr_task)
+            if task is not None and not task.done()
+        ]
+        for task in pending_tasks:
+            task.cancel()
+        if pending_tasks:
+            await asyncio.gather(*pending_tasks, return_exceptions=True)
+        raise
+    except ToolInputError:
+        raise
+    except (OSError, RuntimeError) as error:
+        del error
+        if process is not None:
+            await _terminate_process(process)
+        raise ToolInputError(
+            ToolErrorCode.TOOL_FAILED,
+            "Git command could not be executed safely.",
+        ) from None
+
+
+class GitStatusTool(Tool[GitStatusInput]):
+    """Return bounded porcelain repository status."""
+
+    name = "git_status"
+    description = "Read bounded Git branch and worktree status."
+    input_type = GitStatusInput
+    required_permissions = frozenset({"git.read"})
+    risk_level = ToolRiskLevel.LOW
+    timeout_seconds = 10.0
+
+    async def execute(
+        self,
+        arguments: GitStatusInput,
+        context: ToolExecutionContext,
+    ) -> dict[str, JsonValue]:
+        del arguments
+        status, exit_code, truncated = await _run_git(
+            ("status", "--short", "--branch", "--untracked-files=all"),
+            context.workspace_root,
+            _STATUS_OUTPUT_LIMIT,
+        )
+        return {
+            "status": status,
+            "exit_code": exit_code,
+            "truncated": truncated,
+        }
+
+
+class GitDiffTool(Tool[GitDiffInput]):
+    """Return one bounded worktree or staged diff."""
+
+    name = "git_diff"
+    description = "Read one bounded Git worktree or staged diff."
+    input_type = GitDiffInput
+    required_permissions = frozenset({"git.read"})
+    risk_level = ToolRiskLevel.LOW
+    timeout_seconds = 10.0
+
+    async def execute(
+        self,
+        arguments: GitDiffInput,
+        context: ToolExecutionContext,
+    ) -> dict[str, JsonValue]:
+        command: list[str] = [
+            "diff",
+            "--no-ext-diff",
+            "--no-textconv",
+            "--no-color",
+            "--src-prefix=a/",
+            "--dst-prefix=b/",
+        ]
+        if arguments.target is GitDiffTarget.STAGED:
+            command.append("--cached")
+        if arguments.paths:
+            command.append("--")
+            for requested_path in arguments.paths:
+                resolved = resolve_workspace_path(
+                    context.workspace_root,
+                    requested_path,
+                    must_exist=False,
+                    expected_kind="any",
+                )
+                command.append(relative_workspace_path(context.workspace_root, resolved))
+        diff, exit_code, truncated = await _run_git(
+            tuple(command),
+            context.workspace_root,
+            _DIFF_OUTPUT_LIMIT,
+        )
+        return {
+            "target": arguments.target.value,
+            "diff": diff,
+            "exit_code": exit_code,
+            "truncated": truncated,
+        }

--- a/infrastructure/tools/git.py
+++ b/infrastructure/tools/git.py
@@ -147,9 +147,7 @@ async def _run_git(
         if process is not None:
             await _terminate_process(process)
         pending_tasks = [
-            task
-            for task in (stdout_task, stderr_task)
-            if task is not None and not task.done()
+            task for task in (stdout_task, stderr_task) if task is not None and not task.done()
         ]
         for task in pending_tasks:
             task.cancel()

--- a/infrastructure/tools/paths.py
+++ b/infrastructure/tools/paths.py
@@ -1,0 +1,106 @@
+"""Canonical deny-by-default workspace path resolution."""
+
+from __future__ import annotations
+
+import os
+import stat
+from pathlib import Path
+from typing import Literal, Never
+
+from core.tools import ToolErrorCode, ToolWorkspaceError
+
+type ExpectedPathKind = Literal["file", "directory", "any"]
+
+_SAFE_PATH_ERROR = "The requested path is not allowed."
+
+
+def _raise_workspace_violation() -> Never:
+    raise ToolWorkspaceError(
+        ToolErrorCode.WORKSPACE_VIOLATION,
+        _SAFE_PATH_ERROR,
+    )
+
+
+def _canonical_root(workspace_root: Path) -> Path:
+    try:
+        root = workspace_root.resolve(strict=True)
+        if not root.is_dir():
+            _raise_workspace_violation()
+        return root
+    except ToolWorkspaceError:
+        raise
+    except (OSError, RuntimeError, ValueError) as error:
+        del error
+        _raise_workspace_violation()
+
+
+def _reject_symlink_components(root: Path, relative: Path) -> None:
+    current = root
+    for component in relative.parts:
+        if component == ".":
+            continue
+        current /= component
+        try:
+            mode = os.lstat(current).st_mode
+        except FileNotFoundError:
+            return
+        except OSError as error:
+            del error
+            _raise_workspace_violation()
+        if stat.S_ISLNK(mode):
+            _raise_workspace_violation()
+
+
+def resolve_workspace_path(
+    workspace_root: Path,
+    relative_path: str,
+    *,
+    must_exist: bool,
+    expected_kind: ExpectedPathKind,
+) -> Path:
+    """Resolve one relative non-symlink path contained by the workspace."""
+    try:
+        if not isinstance(relative_path, str) or not relative_path.strip():
+            _raise_workspace_violation()
+        if "\x00" in relative_path:
+            _raise_workspace_violation()
+        relative = Path(relative_path)
+        if relative.is_absolute() or ".." in relative.parts:
+            _raise_workspace_violation()
+        root = _canonical_root(workspace_root)
+        _reject_symlink_components(root, relative)
+        candidate = root.joinpath(relative)
+        resolved = candidate.resolve(strict=must_exist)
+        if not resolved.is_relative_to(root):
+            _raise_workspace_violation()
+        if resolved.exists():
+            if expected_kind == "file" and not resolved.is_file():
+                _raise_workspace_violation()
+            if expected_kind == "directory" and not resolved.is_dir():
+                _raise_workspace_violation()
+            if expected_kind == "any" and not (resolved.is_file() or resolved.is_dir()):
+                _raise_workspace_violation()
+        elif must_exist:
+            _raise_workspace_violation()
+        return resolved
+    except ToolWorkspaceError:
+        raise
+    except (OSError, RuntimeError, TypeError, ValueError) as error:
+        del error
+        _raise_workspace_violation()
+
+
+def relative_workspace_path(workspace_root: Path, resolved_path: Path) -> str:
+    """Render one contained canonical path without exposing its host root."""
+    try:
+        root = _canonical_root(workspace_root)
+        target = resolved_path.resolve(strict=False)
+        if not target.is_relative_to(root):
+            _raise_workspace_violation()
+        relative = target.relative_to(root).as_posix()
+        return relative or "."
+    except ToolWorkspaceError:
+        raise
+    except (OSError, RuntimeError, TypeError, ValueError) as error:
+        del error
+        _raise_workspace_violation()

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,1 @@
+"""SynapseOS test package."""

--- a/tests/database/test_tool_execution.py
+++ b/tests/database/test_tool_execution.py
@@ -1,0 +1,295 @@
+"""Real-PostgreSQL tests for sanitized tool execution auditing."""
+
+from __future__ import annotations
+
+import asyncio
+import uuid
+from collections.abc import Mapping
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from pydantic import BaseModel, ConfigDict
+from sqlalchemy import func, select
+from sqlalchemy.orm import Session
+
+from core.enums import AuditActorType, AuditResult, ToolCallStatus
+from core.tools import (
+    JsonValue,
+    Tool,
+    ToolAuditError,
+    ToolErrorCode,
+    ToolExecutionContext,
+    ToolExecutor,
+    ToolRegistry,
+    ToolRiskLevel,
+)
+from infrastructure.database.models import AuditEvent, ToolCall
+from infrastructure.tools.audit import SQLAlchemyToolAuditRecorder
+from infrastructure.tools.filesystem import ReadFileInput, ReadFileTool
+from tests.database.tool_fixtures import create_tool_run
+from tests.tools.fakes import FakeTool
+
+
+def _context(
+    session: Session,
+    workspace_root: Path,
+    *,
+    declared_tools: set[str] | None = None,
+    permissions: set[str] | None = None,
+) -> ToolExecutionContext:
+    project, agent, task, run = create_tool_run(session)
+    return ToolExecutionContext(
+        workspace_root=workspace_root,
+        agent_id=agent.slug,
+        agent_run_id=run.id,
+        project_id=project.id,
+        task_id=task.id,
+        declared_tool_ids=declared_tools or {"fake_read"},
+        permission_ids=permissions or {"workspace.read"},
+        correlation_id=uuid.uuid4(),
+    )
+
+
+def test_successful_tool_execution_is_audited(db_session: Session, tmp_path: Path) -> None:
+    context = _context(db_session, tmp_path)
+    recorder = SQLAlchemyToolAuditRecorder(db_session)
+
+    result = asyncio.run(
+        ToolExecutor(ToolRegistry([FakeTool()]), recorder).execute(
+            "fake_read", {"path": "README.md"}, context
+        )
+    )
+    db_session.flush()
+
+    call = db_session.get(ToolCall, result.tool_call_id)
+    assert call is not None
+    assert call.status is ToolCallStatus.SUCCEEDED
+    assert call.input_data == {"argument_count": 1}
+    assert call.output_data["output_field_count"] == 2
+    assert call.output_data["truncated"] is False
+    event = db_session.scalar(
+        select(AuditEvent).where(AuditEvent.agent_run_id == context.agent_run_id)
+    )
+    assert event is not None
+    assert event.actor_type is AuditActorType.AGENT
+    assert event.actor_id == "backend-agent-03"
+    assert event.project_id == context.project_id
+    assert event.task_id == context.task_id
+    assert event.correlation_id == context.correlation_id
+    assert event.result is AuditResult.SUCCEEDED
+    assert event.event_type == "TOOL_EXECUTION"
+
+
+@pytest.mark.parametrize(
+    ("tool_name", "declared_tools", "permissions", "expected_status", "expected_result"),
+    [
+        ("unknown", {"unknown"}, {"workspace.read"}, ToolCallStatus.DENIED, AuditResult.DENIED),
+        (
+            "fake_read",
+            {"another_tool"},
+            {"workspace.read"},
+            ToolCallStatus.DENIED,
+            AuditResult.DENIED,
+        ),
+        (
+            "fake_read",
+            {"fake_read"},
+            {"git.read"},
+            ToolCallStatus.DENIED,
+            AuditResult.DENIED,
+        ),
+    ],
+)
+def test_denied_attempts_are_persisted(
+    db_session: Session,
+    tmp_path: Path,
+    tool_name: str,
+    declared_tools: set[str],
+    permissions: set[str],
+    expected_status: ToolCallStatus,
+    expected_result: AuditResult,
+) -> None:
+    context = _context(
+        db_session,
+        tmp_path,
+        declared_tools=declared_tools,
+        permissions=permissions,
+    )
+    recorder = SQLAlchemyToolAuditRecorder(db_session)
+
+    result = asyncio.run(
+        ToolExecutor(ToolRegistry([FakeTool()]), recorder).execute(tool_name, {}, context)
+    )
+    db_session.flush()
+
+    call = db_session.get(ToolCall, result.tool_call_id)
+    assert call is not None
+    assert call.status is expected_status
+    event = db_session.scalar(
+        select(AuditEvent).where(AuditEvent.agent_run_id == context.agent_run_id)
+    )
+    assert event is not None
+    assert event.result is expected_result
+
+
+class _NoInput(BaseModel):
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+
+class _BlockingTool(Tool[_NoInput]):
+    name = "blocking"
+    description = "Wait until timed out or cancelled."
+    input_type = _NoInput
+    required_permissions = frozenset({"workspace.read"})
+    risk_level = ToolRiskLevel.LOW
+    timeout_seconds = 0.01
+
+    def __init__(self) -> None:
+        self.started: asyncio.Event | None = None
+
+    async def execute(
+        self,
+        arguments: _NoInput,
+        context: ToolExecutionContext,
+    ) -> Mapping[str, JsonValue]:
+        del arguments, context
+        self.started = asyncio.Event()
+        self.started.set()
+        await asyncio.Event().wait()
+        return {}
+
+
+def test_timeout_and_cancellation_have_terminal_audits(
+    db_session: Session,
+    tmp_path: Path,
+) -> None:
+    timeout_context = _context(
+        db_session,
+        tmp_path,
+        declared_tools={"blocking"},
+    )
+    timeout_recorder = SQLAlchemyToolAuditRecorder(db_session)
+    timeout_result = asyncio.run(
+        ToolExecutor(ToolRegistry([_BlockingTool()]), timeout_recorder).execute(
+            "blocking", {}, timeout_context
+        )
+    )
+
+    cancellation_context = _context(
+        db_session,
+        tmp_path,
+        declared_tools={"blocking"},
+    )
+    cancellation_tool = _BlockingTool()
+    cancellation_tool.timeout_seconds = 30.0
+    cancellation_recorder = SQLAlchemyToolAuditRecorder(db_session)
+
+    async def cancel() -> None:
+        operation = asyncio.create_task(
+            ToolExecutor(ToolRegistry([cancellation_tool]), cancellation_recorder).execute(
+                "blocking", {}, cancellation_context
+            )
+        )
+        while cancellation_tool.started is None:
+            await asyncio.sleep(0)
+        operation.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await operation
+
+    asyncio.run(cancel())
+    db_session.flush()
+
+    timeout_call = db_session.get(ToolCall, timeout_result.tool_call_id)
+    assert timeout_call is not None
+    assert timeout_call.status is ToolCallStatus.TIMED_OUT
+    cancelled_call = db_session.scalar(
+        select(ToolCall)
+        .where(ToolCall.agent_run_id == cancellation_context.agent_run_id)
+        .order_by(ToolCall.created_at.desc())
+    )
+    assert cancelled_call is not None
+    assert cancelled_call.status is ToolCallStatus.FAILED
+    assert cancelled_call.error_message == ToolErrorCode.CANCELLED.value
+    results = set(
+        db_session.scalars(
+            select(AuditEvent.result).where(
+                AuditEvent.agent_run_id.in_(
+                    [timeout_context.agent_run_id, cancellation_context.agent_run_id]
+                )
+            )
+        )
+    )
+    assert results == {AuditResult.FAILED, AuditResult.CANCELLED}
+
+
+def test_audit_persists_no_raw_file_or_host_content(
+    db_session: Session,
+    tmp_path: Path,
+) -> None:
+    secret = "secret-file-content-marker-b924"
+    (tmp_path / "client.txt").write_text(secret, encoding="utf-8")
+    context = _context(
+        db_session,
+        tmp_path,
+        declared_tools={"read_file"},
+        permissions={"workspace.read"},
+    )
+    recorder = SQLAlchemyToolAuditRecorder(db_session)
+
+    result = asyncio.run(
+        ToolExecutor(ToolRegistry([ReadFileTool()]), recorder).execute(
+            "read_file", ReadFileInput(path="client.txt").model_dump(), context
+        )
+    )
+    db_session.flush()
+
+    call = db_session.get(ToolCall, result.tool_call_id)
+    event = db_session.scalar(
+        select(AuditEvent).where(AuditEvent.agent_run_id == context.agent_run_id)
+    )
+    assert call is not None
+    assert event is not None
+    persisted = repr((call.input_data, call.output_data, call.error_message, event.data))
+    assert secret not in persisted
+    assert "client.txt" not in persisted
+    assert str(tmp_path) not in persisted
+
+
+def test_recorder_never_owns_session_transaction_or_lifecycle(
+    db_session: Session,
+    tmp_path: Path,
+) -> None:
+    context = _context(db_session, tmp_path)
+    recorder = SQLAlchemyToolAuditRecorder(db_session)
+
+    with (
+        patch.object(db_session, "commit", side_effect=AssertionError("commit called")),
+        patch.object(db_session, "rollback", side_effect=AssertionError("rollback called")),
+        patch.object(db_session, "close", side_effect=AssertionError("close called")),
+    ):
+        asyncio.run(
+            ToolExecutor(ToolRegistry([FakeTool()]), recorder).execute(
+                "fake_read", {"path": "README.md"}, context
+            )
+        )
+        db_session.flush()
+
+
+def test_recorder_rejects_forged_scope_before_tool_call(
+    db_session: Session,
+    tmp_path: Path,
+) -> None:
+    context = _context(db_session, tmp_path)
+    forged = context.model_copy(update={"project_id": uuid.uuid4()})
+
+    with pytest.raises(ToolAuditError, match="Tool audit is unavailable"):
+        asyncio.run(
+            ToolExecutor(
+                ToolRegistry([FakeTool()]),
+                SQLAlchemyToolAuditRecorder(db_session),
+            ).execute("fake_read", {"path": "README.md"}, forged)
+        )
+
+    assert db_session.scalar(select(func.count()).select_from(ToolCall)) == 0
+    assert db_session.scalar(select(func.count()).select_from(AuditEvent)) == 0

--- a/tests/database/tool_fixtures.py
+++ b/tests/database/tool_fixtures.py
@@ -1,0 +1,57 @@
+"""Real-model setup helpers for Phase 6 tool audit tests."""
+
+from __future__ import annotations
+
+from decimal import Decimal
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from core.enums import (
+    AgentRunStatus,
+    AgentSeniority,
+    AgentStatus,
+    ProjectStatus,
+    TaskStatus,
+)
+from infrastructure.database.models import Agent, AgentRun, Project, Task
+
+
+def create_tool_run(session: Session) -> tuple[Project, Agent, Task, AgentRun]:
+    """Persist one coherent project/agent/task/run scope for a tool invocation."""
+    project = Project(
+        name="Tool Audit Project",
+        status=ProjectStatus.IN_PROGRESS,
+    )
+    agent = session.scalar(select(Agent).where(Agent.slug == "backend-agent-03"))
+    if agent is None:
+        agent = Agent(
+            name="Backend Agent 03",
+            slug="backend-agent-03",
+            role="Backend Engineer",
+            department="engineering",
+            seniority=AgentSeniority.SENIOR,
+            status=AgentStatus.WORKING,
+            autonomy_level=2,
+            reputation_score=Decimal("0.9000"),
+            reliability_score=Decimal("0.9200"),
+        )
+    session.add_all([project, agent])
+    session.flush()
+    task = Task(
+        project_id=project.id,
+        assigned_agent_id=agent.id,
+        title="Exercise a read-only tool",
+        status=TaskStatus.IN_PROGRESS,
+    )
+    session.add(task)
+    session.flush()
+    run = AgentRun(
+        agent_id=agent.id,
+        task_id=task.id,
+        status=AgentRunStatus.RUNNING,
+        iteration=1,
+    )
+    session.add(run)
+    session.flush()
+    return project, agent, task, run

--- a/tests/tools/__init__.py
+++ b/tests/tools/__init__.py
@@ -1,0 +1,1 @@
+"""Phase 6 tool-system tests."""

--- a/tests/tools/conftest.py
+++ b/tests/tools/conftest.py
@@ -1,0 +1,14 @@
+"""Shared deterministic doubles for Phase 6 tool tests."""
+
+from __future__ import annotations
+
+import pytest
+
+from tests.tools.fakes import FakeTool
+
+
+@pytest.fixture
+def fake_tool() -> FakeTool:
+    """Return a fresh deterministic tool and reset its call count."""
+    FakeTool.calls = 0
+    return FakeTool()

--- a/tests/tools/fakes.py
+++ b/tests/tools/fakes.py
@@ -1,0 +1,38 @@
+"""Deterministic test tools shared by Phase 6 behavior tests."""
+
+from __future__ import annotations
+
+from typing import ClassVar
+
+from pydantic import BaseModel, ConfigDict
+
+from core.tools import JsonValue, Tool, ToolExecutionContext, ToolRiskLevel
+
+
+class FakeInput(BaseModel):
+    """Strict input used by the deterministic fake tool."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    path: str
+
+
+class FakeTool(Tool[FakeInput]):
+    """Small read-only tool whose output is independent of infrastructure."""
+
+    name = "fake_read"
+    description = "Read one deterministic fake resource."
+    input_type = FakeInput
+    required_permissions = frozenset({"workspace.read"})
+    risk_level = ToolRiskLevel.LOW
+    timeout_seconds = 1.0
+    calls: ClassVar[int] = 0
+
+    async def execute(
+        self,
+        arguments: FakeInput,
+        context: ToolExecutionContext,
+    ) -> dict[str, JsonValue]:
+        del context
+        type(self).calls += 1
+        return {"path": arguments.path, "content": "fake"}

--- a/tests/tools/test_default_registry.py
+++ b/tests/tools/test_default_registry.py
@@ -1,0 +1,36 @@
+"""Acceptance tests for the explicit Phase 6 tool composition."""
+
+from __future__ import annotations
+
+from infrastructure.tools import create_default_tool_registry
+
+
+def test_default_registry_contains_only_phase_6_tools() -> None:
+    registry = create_default_tool_registry()
+
+    assert registry.names == (
+        "git_diff",
+        "git_status",
+        "list_files",
+        "read_file",
+        "search_text",
+    )
+
+
+def test_default_registry_definitions_are_read_only_and_bounded() -> None:
+    registry = create_default_tool_registry()
+
+    definitions = {definition.name: definition for definition in registry.definitions}
+    assert definitions["read_file"].required_permissions == frozenset({"workspace.read"})
+    assert definitions["list_files"].required_permissions == frozenset({"workspace.list"})
+    assert definitions["search_text"].required_permissions == frozenset({"workspace.search"})
+    assert definitions["git_status"].required_permissions == frozenset({"git.read"})
+    assert definitions["git_diff"].required_permissions == frozenset({"git.read"})
+    assert all(definition.risk_level.value == "LOW" for definition in definitions.values())
+    assert all(0 < definition.timeout_seconds <= 30 for definition in definitions.values())
+    assert all(
+        definition.input_schema.get("additionalProperties") is False
+        for definition in definitions.values()
+    )
+    assert not hasattr(registry, "register")
+    assert not hasattr(registry, "unregister")

--- a/tests/tools/test_executor.py
+++ b/tests/tools/test_executor.py
@@ -1,0 +1,317 @@
+"""Behavior and safety tests for centralized tool execution."""
+
+from __future__ import annotations
+
+import asyncio
+import uuid
+from collections.abc import Mapping
+from pathlib import Path
+from typing import cast
+
+import pytest
+from pydantic import BaseModel, ConfigDict
+
+from core.tools import (
+    JsonValue,
+    Tool,
+    ToolAuditError,
+    ToolAuditFinish,
+    ToolAuditHandle,
+    ToolAuditOutcome,
+    ToolAuditStart,
+    ToolErrorCode,
+    ToolExecutionContext,
+    ToolExecutor,
+    ToolRegistry,
+    ToolResultStatus,
+    ToolRiskLevel,
+    ToolWorkspaceError,
+)
+from tests.tools.fakes import FakeTool
+
+
+class RecordingAuditRecorder:
+    """In-memory recorder that exposes lifecycle ordering as observable state."""
+
+    def __init__(self, *, fail_begin: bool = False, fail_finish: bool = False) -> None:
+        self.fail_begin = fail_begin
+        self.fail_finish = fail_finish
+        self.starts: list[ToolAuditStart] = []
+        self.finishes: list[ToolAuditFinish] = []
+        self.handle = ToolAuditHandle(tool_call_id=uuid.uuid4())
+
+    def begin(self, start: ToolAuditStart) -> ToolAuditHandle:
+        if self.fail_begin:
+            raise RuntimeError("secret-audit-begin-marker")
+        self.starts.append(start)
+        return self.handle
+
+    def finish(self, handle: ToolAuditHandle, finish: ToolAuditFinish) -> None:
+        assert handle == self.handle
+        if self.fail_finish:
+            raise RuntimeError("secret-audit-finish-marker")
+        self.finishes.append(finish)
+
+
+def _context(workspace_root: Path, **changes: object) -> ToolExecutionContext:
+    values: dict[str, object] = {
+        "workspace_root": workspace_root,
+        "agent_id": "backend-agent-03",
+        "agent_run_id": uuid.uuid4(),
+        "project_id": uuid.uuid4(),
+        "task_id": uuid.uuid4(),
+        "declared_tool_ids": {"fake_read"},
+        "permission_ids": {"workspace.read"},
+        "correlation_id": uuid.uuid4(),
+    }
+    values.update(changes)
+    return ToolExecutionContext.model_validate(values, strict=True)
+
+
+def test_executor_calls_registered_tool_once_and_audits_success(
+    tmp_path: Path,
+    fake_tool: FakeTool,
+) -> None:
+    recorder = RecordingAuditRecorder()
+
+    result = asyncio.run(
+        ToolExecutor(ToolRegistry([fake_tool]), recorder).execute(
+            "fake_read",
+            {"path": "README.md"},
+            _context(tmp_path),
+        )
+    )
+
+    assert result.status is ToolResultStatus.SUCCEEDED
+    assert result.output == {"path": "README.md", "content": "fake"}
+    assert result.tool_call_id == recorder.handle.tool_call_id
+    assert FakeTool.calls == 1
+    assert len(recorder.starts) == 1
+    assert recorder.starts[0].argument_count == 1
+    assert recorder.finishes[0].outcome is ToolAuditOutcome.SUCCEEDED
+
+
+@pytest.mark.parametrize(
+    ("tool_name", "context_changes", "expected_code"),
+    [
+        ("unknown", {}, ToolErrorCode.TOOL_NOT_FOUND),
+        (
+            "fake_read",
+            {"declared_tool_ids": {"another_tool"}},
+            ToolErrorCode.TOOL_NOT_DECLARED,
+        ),
+        ("fake_read", {"permission_ids": {"git.read"}}, ToolErrorCode.PERMISSION_DENIED),
+    ],
+)
+def test_executor_denies_before_tool_execution_and_audits_attempt(
+    tmp_path: Path,
+    fake_tool: FakeTool,
+    tool_name: str,
+    context_changes: dict[str, object],
+    expected_code: ToolErrorCode,
+) -> None:
+    recorder = RecordingAuditRecorder()
+
+    result = asyncio.run(
+        ToolExecutor(ToolRegistry([fake_tool]), recorder).execute(
+            tool_name,
+            {"secret-field-marker": "secret-value-marker"},
+            _context(tmp_path, **context_changes),
+        )
+    )
+
+    assert result.status is ToolResultStatus.DENIED
+    assert result.error_code is expected_code
+    assert FakeTool.calls == 0
+    assert recorder.starts[0].argument_count == 1
+    assert "secret-field-marker" not in repr(recorder.starts[0])
+    assert "secret-value-marker" not in repr(recorder.starts[0])
+    assert recorder.finishes[0].outcome is ToolAuditOutcome.DENIED
+
+
+@pytest.mark.parametrize(
+    "arguments",
+    [
+        {},
+        {"path": 12},
+        {"path": "README.md", "extra": "secret-extra-marker"},
+    ],
+)
+def test_executor_rejects_invalid_input_without_calling_tool(
+    tmp_path: Path,
+    fake_tool: FakeTool,
+    arguments: dict[str, object],
+) -> None:
+    recorder = RecordingAuditRecorder()
+
+    result = asyncio.run(
+        ToolExecutor(ToolRegistry([fake_tool]), recorder).execute(
+            "fake_read", arguments, _context(tmp_path)
+        )
+    )
+
+    assert result.status is ToolResultStatus.FAILED
+    assert result.error_code is ToolErrorCode.INVALID_INPUT
+    assert FakeTool.calls == 0
+    assert recorder.finishes[0].outcome is ToolAuditOutcome.FAILED
+    assert "secret-extra-marker" not in repr(recorder.finishes[0])
+
+
+class _NoInput(BaseModel):
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+
+class _BlockingTool(Tool[_NoInput]):
+    name = "blocking"
+    description = "Wait until cancelled or timed out."
+    input_type = _NoInput
+    required_permissions = frozenset({"workspace.read"})
+    risk_level = ToolRiskLevel.LOW
+    timeout_seconds = 0.01
+
+    def __init__(self) -> None:
+        self.started: asyncio.Event | None = None
+        self.calls = 0
+
+    async def execute(
+        self,
+        arguments: _NoInput,
+        context: ToolExecutionContext,
+    ) -> Mapping[str, JsonValue]:
+        del arguments, context
+        self.calls += 1
+        self.started = asyncio.Event()
+        self.started.set()
+        await asyncio.Event().wait()
+        return {}
+
+
+class _FailureTool(Tool[_NoInput]):
+    name = "failure"
+    description = "Produce one deterministic failure."
+    input_type = _NoInput
+    required_permissions = frozenset({"workspace.read"})
+    risk_level = ToolRiskLevel.LOW
+    timeout_seconds = 1.0
+
+    def __init__(self, mode: str) -> None:
+        self.mode = mode
+
+    async def execute(
+        self,
+        arguments: _NoInput,
+        context: ToolExecutionContext,
+    ) -> Mapping[str, JsonValue]:
+        del arguments, context
+        if self.mode == "domain":
+            raise ToolWorkspaceError(
+                ToolErrorCode.WORKSPACE_VIOLATION,
+                "secret-domain-marker",
+            )
+        if self.mode == "unexpected":
+            raise RuntimeError("secret-runtime-marker")
+        return {"bad": cast(JsonValue, object())}
+
+
+@pytest.mark.parametrize(
+    ("mode", "expected_code", "secret_marker"),
+    [
+        ("domain", ToolErrorCode.WORKSPACE_VIOLATION, "secret-domain-marker"),
+        ("unexpected", ToolErrorCode.TOOL_FAILED, "secret-runtime-marker"),
+        ("output", ToolErrorCode.OUTPUT_LIMIT, "object at"),
+    ],
+)
+def test_executor_sanitizes_tool_and_output_failures(
+    tmp_path: Path,
+    mode: str,
+    expected_code: ToolErrorCode,
+    secret_marker: str,
+) -> None:
+    tool = _FailureTool(mode)
+    recorder = RecordingAuditRecorder()
+    context = _context(tmp_path, declared_tool_ids={"failure"})
+
+    result = asyncio.run(
+        ToolExecutor(ToolRegistry([tool]), recorder).execute("failure", {}, context)
+    )
+
+    assert result.status is ToolResultStatus.FAILED
+    assert result.error_code is expected_code
+    assert secret_marker not in repr(result)
+    assert secret_marker not in repr(recorder.finishes[0])
+    assert recorder.finishes[0].outcome is ToolAuditOutcome.FAILED
+
+
+def test_executor_times_out_once_without_retry(tmp_path: Path) -> None:
+    tool = _BlockingTool()
+    recorder = RecordingAuditRecorder()
+    context = _context(
+        tmp_path,
+        declared_tool_ids={"blocking"},
+        permission_ids={"workspace.read"},
+    )
+
+    result = asyncio.run(
+        ToolExecutor(ToolRegistry([tool]), recorder).execute("blocking", {}, context)
+    )
+
+    assert result.status is ToolResultStatus.TIMED_OUT
+    assert result.error_code is ToolErrorCode.TOOL_TIMED_OUT
+    assert tool.calls == 1
+    assert recorder.finishes[0].outcome is ToolAuditOutcome.TIMED_OUT
+
+
+def test_executor_propagates_cancellation_after_audit(tmp_path: Path) -> None:
+    tool = _BlockingTool()
+    tool.timeout_seconds = 30.0
+    recorder = RecordingAuditRecorder()
+    context = _context(tmp_path, declared_tool_ids={"blocking"})
+
+    async def cancel_operation() -> None:
+        operation = asyncio.create_task(
+            ToolExecutor(ToolRegistry([tool]), recorder).execute("blocking", {}, context)
+        )
+        while tool.started is None:
+            await asyncio.sleep(0)
+        operation.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await operation
+
+    asyncio.run(cancel_operation())
+
+    assert tool.calls == 1
+    assert recorder.finishes[0].outcome is ToolAuditOutcome.CANCELLED
+
+
+def test_executor_fails_closed_when_audit_begin_fails(
+    tmp_path: Path,
+    fake_tool: FakeTool,
+) -> None:
+    recorder = RecordingAuditRecorder(fail_begin=True)
+
+    with pytest.raises(ToolAuditError, match="Tool audit is unavailable") as captured:
+        asyncio.run(
+            ToolExecutor(ToolRegistry([fake_tool]), recorder).execute(
+                "fake_read", {"path": "README.md"}, _context(tmp_path)
+            )
+        )
+
+    assert FakeTool.calls == 0
+    assert "secret-audit-begin-marker" not in str(captured.value)
+
+
+def test_executor_surfaces_sanitized_terminal_audit_failure(
+    tmp_path: Path,
+    fake_tool: FakeTool,
+) -> None:
+    recorder = RecordingAuditRecorder(fail_finish=True)
+
+    with pytest.raises(ToolAuditError, match="Tool audit could not be finalized") as captured:
+        asyncio.run(
+            ToolExecutor(ToolRegistry([fake_tool]), recorder).execute(
+                "fake_read", {"path": "README.md"}, _context(tmp_path)
+            )
+        )
+
+    assert FakeTool.calls == 1
+    assert "secret-audit-finish-marker" not in str(captured.value)

--- a/tests/tools/test_filesystem_tools.py
+++ b/tests/tools/test_filesystem_tools.py
@@ -1,0 +1,218 @@
+"""Behavior and resource-bound tests for read-only filesystem tools."""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import uuid
+from pathlib import Path
+from typing import cast
+
+import pytest
+from pydantic import ValidationError
+
+from core.tools import JsonValue, ToolError, ToolErrorCode, ToolExecutionContext, ToolWorkspaceError
+from infrastructure.tools.filesystem import (
+    ListFilesInput,
+    ListFilesTool,
+    ReadFileInput,
+    ReadFileTool,
+    SearchTextInput,
+    SearchTextTool,
+)
+
+
+def _context(workspace_root: Path) -> ToolExecutionContext:
+    return ToolExecutionContext(
+        workspace_root=workspace_root,
+        agent_id="backend-agent-03",
+        agent_run_id=uuid.uuid4(),
+        project_id=uuid.uuid4(),
+        task_id=uuid.uuid4(),
+        declared_tool_ids={"read_file", "list_files", "search_text"},
+        permission_ids={"workspace.read", "workspace.list", "workspace.search"},
+        correlation_id=uuid.uuid4(),
+    )
+
+
+def test_read_file_returns_requested_lines_and_relative_metadata(tmp_path: Path) -> None:
+    source = tmp_path / "src"
+    source.mkdir()
+    (source / "main.py").write_text("one\ntwo\nthree\nfour\n", encoding="utf-8")
+
+    output = asyncio.run(
+        ReadFileTool().execute(
+            ReadFileInput(path="src/main.py", start_line=2, max_lines=2),
+            _context(tmp_path),
+        )
+    )
+
+    assert output == {
+        "path": "src/main.py",
+        "content": "two\nthree\n",
+        "start_line": 2,
+        "end_line": 3,
+        "total_lines": 4,
+        "truncated": True,
+    }
+
+
+def test_read_file_bounds_content_without_splitting_utf8(tmp_path: Path) -> None:
+    marker = "é"
+    (tmp_path / "large.txt").write_text(marker * 200_000, encoding="utf-8")
+
+    output = asyncio.run(
+        ReadFileTool().execute(ReadFileInput(path="large.txt"), _context(tmp_path))
+    )
+
+    content = output["content"]
+    assert isinstance(content, str)
+    assert len(content.encode("utf-8")) <= 262_144
+    assert content.endswith(marker)
+    assert output["truncated"] is True
+
+
+def test_read_file_rejects_oversized_binary_and_symlink_files(tmp_path: Path) -> None:
+    oversized = tmp_path / "oversized.txt"
+    with oversized.open("wb") as stream:
+        stream.truncate(8 * 1_024 * 1_024 + 1)
+    (tmp_path / "binary.dat").write_bytes(b"\xff\xfe")
+    (tmp_path / "link.txt").symlink_to(tmp_path / "binary.dat")
+
+    for path in ("oversized.txt", "binary.dat", "link.txt"):
+        with pytest.raises(ToolError) as captured:
+            asyncio.run(
+                ReadFileTool().execute(ReadFileInput(path=path), _context(tmp_path))
+            )
+        assert captured.value.code in {
+            ToolErrorCode.OUTPUT_LIMIT,
+            ToolErrorCode.UNSUPPORTED_FILE,
+            ToolErrorCode.WORKSPACE_VIOLATION,
+        }
+        assert str(tmp_path) not in str(captured.value)
+
+
+def test_list_files_is_sorted_bounded_and_does_not_follow_symlinks(tmp_path: Path) -> None:
+    (tmp_path / ".hidden").write_text("hidden", encoding="utf-8")
+    nested = tmp_path / "nested"
+    nested.mkdir()
+    (nested / "z.txt").write_text("z", encoding="utf-8")
+    (nested / "a.txt").write_text("a", encoding="utf-8")
+    (tmp_path / "linked").symlink_to(nested, target_is_directory=True)
+
+    output = asyncio.run(
+        ListFilesTool().execute(
+            ListFilesInput(path=".", recursive=True, max_entries=4),
+            _context(tmp_path),
+        )
+    )
+
+    entries = output["entries"]
+    assert isinstance(entries, list)
+    typed_entries = cast(list[dict[str, JsonValue]], entries)
+    assert entries == [
+        {"path": ".hidden", "kind": "file"},
+        {"path": "linked", "kind": "symlink"},
+        {"path": "nested", "kind": "directory"},
+        {"path": "nested/a.txt", "kind": "file"},
+    ]
+    assert output["truncated"] is True
+    assert all(not str(item["path"]).startswith(str(tmp_path)) for item in typed_entries)
+
+
+def test_list_files_non_recursive_stops_at_requested_limit(tmp_path: Path) -> None:
+    for name in ("c.txt", "a.txt", "b.txt"):
+        (tmp_path / name).write_text(name, encoding="utf-8")
+
+    output = asyncio.run(
+        ListFilesTool().execute(
+            ListFilesInput(path=".", recursive=False, max_entries=2),
+            _context(tmp_path),
+        )
+    )
+
+    assert output["entries"] == [
+        {"path": "a.txt", "kind": "file"},
+        {"path": "b.txt", "kind": "file"},
+    ]
+    assert output["truncated"] is True
+
+
+def test_search_text_returns_literal_deterministic_matches(tmp_path: Path) -> None:
+    (tmp_path / "b.txt").write_text("Needle.*\nneedle.*\n", encoding="utf-8")
+    (tmp_path / "a.txt").write_text("first\nNeedle.* here\n", encoding="utf-8")
+    (tmp_path / "binary.dat").write_bytes(b"Needle.*\xff")
+
+    output = asyncio.run(
+        SearchTextTool().execute(
+            SearchTextInput(
+                query="Needle.*",
+                path=".",
+                case_sensitive=True,
+                max_results=10,
+            ),
+            _context(tmp_path),
+        )
+    )
+
+    assert output["matches"] == [
+        {"path": "a.txt", "line": 2, "text": "Needle.* here"},
+        {"path": "b.txt", "line": 1, "text": "Needle.*"},
+    ]
+    assert output["truncated"] is False
+
+
+def test_search_text_honors_case_result_and_line_limits(tmp_path: Path) -> None:
+    long_line = "prefix " + "x" * 5_000 + " needle"
+    (tmp_path / "matches.txt").write_text(
+        f"NEEDLE\n{long_line}\nneedle again\n",
+        encoding="utf-8",
+    )
+
+    output = asyncio.run(
+        SearchTextTool().execute(
+            SearchTextInput(
+                query="needle",
+                path="matches.txt",
+                case_sensitive=False,
+                max_results=2,
+            ),
+            _context(tmp_path),
+        )
+    )
+
+    matches = output["matches"]
+    assert isinstance(matches, list)
+    typed_matches = cast(list[dict[str, JsonValue]], matches)
+    assert len(matches) == 2
+    assert all(len(str(match["text"])) <= 4_096 for match in typed_matches)
+    assert output["truncated"] is True
+
+
+@pytest.mark.parametrize(
+    ("model", "values"),
+    [
+        (ReadFileInput, {"path": "file", "start_line": 0}),
+        (ReadFileInput, {"path": "file", "max_lines": 2_001}),
+        (ListFilesInput, {"path": ".", "max_entries": 10_001}),
+        (SearchTextInput, {"path": ".", "query": " "}),
+        (SearchTextInput, {"path": ".", "query": "x" * 1_025}),
+        (SearchTextInput, {"path": ".", "query": "x", "max_results": 1_001}),
+    ],
+)
+def test_filesystem_inputs_reject_unbounded_values(
+    model: type[ReadFileInput | ListFilesInput | SearchTextInput],
+    values: dict[str, object],
+) -> None:
+    with pytest.raises(ValidationError):
+        model.model_validate(values, strict=True)
+
+
+def test_list_files_rejects_special_directory(tmp_path: Path) -> None:
+    fifo = tmp_path / "pipe"
+    os.mkfifo(fifo)
+
+    with pytest.raises(ToolWorkspaceError):
+        asyncio.run(
+            ListFilesTool().execute(ListFilesInput(path="pipe"), _context(tmp_path))
+        )

--- a/tests/tools/test_filesystem_tools.py
+++ b/tests/tools/test_filesystem_tools.py
@@ -81,9 +81,7 @@ def test_read_file_rejects_oversized_binary_and_symlink_files(tmp_path: Path) ->
 
     for path in ("oversized.txt", "binary.dat", "link.txt"):
         with pytest.raises(ToolError) as captured:
-            asyncio.run(
-                ReadFileTool().execute(ReadFileInput(path=path), _context(tmp_path))
-            )
+            asyncio.run(ReadFileTool().execute(ReadFileInput(path=path), _context(tmp_path)))
         assert captured.value.code in {
             ToolErrorCode.OUTPUT_LIMIT,
             ToolErrorCode.UNSUPPORTED_FILE,
@@ -213,6 +211,4 @@ def test_list_files_rejects_special_directory(tmp_path: Path) -> None:
     os.mkfifo(fifo)
 
     with pytest.raises(ToolWorkspaceError):
-        asyncio.run(
-            ListFilesTool().execute(ListFilesInput(path="pipe"), _context(tmp_path))
-        )
+        asyncio.run(ListFilesTool().execute(ListFilesInput(path="pipe"), _context(tmp_path)))

--- a/tests/tools/test_git_tools.py
+++ b/tests/tools/test_git_tools.py
@@ -63,9 +63,7 @@ def test_git_status_returns_bounded_porcelain_output(tmp_path: Path) -> None:
     (repository / "tracked.txt").write_text("changed\n", encoding="utf-8")
     (repository / "untracked.txt").write_text("new\n", encoding="utf-8")
 
-    output = asyncio.run(
-        GitStatusTool().execute(GitStatusInput(), _context(repository))
-    )
+    output = asyncio.run(GitStatusTool().execute(GitStatusInput(), _context(repository)))
 
     status = output["status"]
     assert isinstance(status, str)
@@ -133,9 +131,7 @@ def test_git_diff_disables_repository_external_diff_and_textconv(tmp_path: Path)
     _git(repository, "config", "diff.unsafe.textconv", str(external))
     (repository / "tracked.txt").write_text("changed\n", encoding="utf-8")
 
-    output = asyncio.run(
-        GitDiffTool().execute(GitDiffInput(), _context(repository))
-    )
+    output = asyncio.run(GitDiffTool().execute(GitDiffInput(), _context(repository)))
 
     assert "+changed" in str(output["diff"])
     assert not marker.exists()
@@ -153,9 +149,7 @@ def test_git_tools_do_not_inherit_secret_environment(
     monkeypatch.setenv("GIT_CONFIG_KEY_0", "alias.status")
     monkeypatch.setenv("GIT_CONFIG_VALUE_0", f"!echo {secret}")
 
-    output = asyncio.run(
-        GitStatusTool().execute(GitStatusInput(), _context(repository))
-    )
+    output = asyncio.run(GitStatusTool().execute(GitStatusInput(), _context(repository)))
 
     assert output["exit_code"] == 0
     assert secret not in repr(output)
@@ -165,9 +159,7 @@ def test_git_diff_caps_large_output(tmp_path: Path) -> None:
     repository = _repository(tmp_path)
     (repository / "tracked.txt").write_text("x" * 700_000 + "\n", encoding="utf-8")
 
-    output = asyncio.run(
-        GitDiffTool().execute(GitDiffInput(), _context(repository))
-    )
+    output = asyncio.run(GitDiffTool().execute(GitDiffInput(), _context(repository)))
 
     diff = output["diff"]
     assert isinstance(diff, str)
@@ -216,9 +208,7 @@ def test_git_process_environment_cannot_use_host_path(tmp_path: Path) -> None:
     old_path = os.environ.get("PATH")
     os.environ["PATH"] = str(repository)
     try:
-        output = asyncio.run(
-            GitStatusTool().execute(GitStatusInput(), _context(repository))
-        )
+        output = asyncio.run(GitStatusTool().execute(GitStatusInput(), _context(repository)))
     finally:
         if old_path is None:
             os.environ.pop("PATH", None)

--- a/tests/tools/test_git_tools.py
+++ b/tests/tools/test_git_tools.py
@@ -1,0 +1,265 @@
+"""Integration and security tests for fixed-command Git tools."""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import signal
+import subprocess
+import uuid
+from contextlib import suppress
+from pathlib import Path
+
+import pytest
+from pydantic import ValidationError
+
+from core.tools import ToolError, ToolErrorCode, ToolExecutionContext
+from infrastructure.tools import git as git_module
+from infrastructure.tools.git import (
+    GitDiffInput,
+    GitDiffTarget,
+    GitDiffTool,
+    GitStatusInput,
+    GitStatusTool,
+)
+
+
+def _git(repository: Path, *arguments: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["/usr/bin/git", *arguments],
+        cwd=repository,
+        check=True,
+        capture_output=True,
+        text=True,
+        env={"PATH": "/usr/bin:/bin", "LC_ALL": "C", "GIT_CONFIG_NOSYSTEM": "1"},
+    )
+
+
+def _repository(tmp_path: Path) -> Path:
+    _git(tmp_path, "init", "--initial-branch=main")
+    _git(tmp_path, "config", "user.name", "SynapseOS Test")
+    _git(tmp_path, "config", "user.email", "tests@example.invalid")
+    (tmp_path / "tracked.txt").write_text("before\n", encoding="utf-8")
+    _git(tmp_path, "add", "tracked.txt")
+    _git(tmp_path, "commit", "-m", "initial")
+    return tmp_path
+
+
+def _context(workspace_root: Path) -> ToolExecutionContext:
+    return ToolExecutionContext(
+        workspace_root=workspace_root,
+        agent_id="backend-agent-03",
+        agent_run_id=uuid.uuid4(),
+        project_id=uuid.uuid4(),
+        task_id=uuid.uuid4(),
+        declared_tool_ids={"git_status", "git_diff"},
+        permission_ids={"git.read"},
+        correlation_id=uuid.uuid4(),
+    )
+
+
+def test_git_status_returns_bounded_porcelain_output(tmp_path: Path) -> None:
+    repository = _repository(tmp_path)
+    (repository / "tracked.txt").write_text("changed\n", encoding="utf-8")
+    (repository / "untracked.txt").write_text("new\n", encoding="utf-8")
+
+    output = asyncio.run(
+        GitStatusTool().execute(GitStatusInput(), _context(repository))
+    )
+
+    status = output["status"]
+    assert isinstance(status, str)
+    assert "## main" in status
+    assert " M tracked.txt" in status
+    assert "?? untracked.txt" in status
+    assert output["exit_code"] == 0
+    assert output["truncated"] is False
+    assert str(repository) not in status
+
+
+def test_git_diff_selects_worktree_and_staged_changes(tmp_path: Path) -> None:
+    repository = _repository(tmp_path)
+    (repository / "tracked.txt").write_text("staged\n", encoding="utf-8")
+    _git(repository, "add", "tracked.txt")
+    (repository / "tracked.txt").write_text("worktree\n", encoding="utf-8")
+
+    worktree = asyncio.run(
+        GitDiffTool().execute(
+            GitDiffInput(target=GitDiffTarget.WORKTREE),
+            _context(repository),
+        )
+    )
+    staged = asyncio.run(
+        GitDiffTool().execute(
+            GitDiffInput(target=GitDiffTarget.STAGED),
+            _context(repository),
+        )
+    )
+
+    assert "+worktree" in str(worktree["diff"])
+    assert "+staged" not in str(worktree["diff"])
+    assert "+staged" in str(staged["diff"])
+    assert "+worktree" not in str(staged["diff"])
+
+
+def test_git_diff_treats_hostile_path_as_data_not_command(tmp_path: Path) -> None:
+    repository = _repository(tmp_path)
+    hostile_name = "-$(touch injected-marker).txt"
+    hostile = repository / hostile_name
+    hostile.write_text("before\n", encoding="utf-8")
+    _git(repository, "add", "--", hostile_name)
+    _git(repository, "commit", "-m", "hostile path")
+    hostile.write_text("after\n", encoding="utf-8")
+
+    output = asyncio.run(
+        GitDiffTool().execute(
+            GitDiffInput(target=GitDiffTarget.WORKTREE, paths=(hostile_name,)),
+            _context(repository),
+        )
+    )
+
+    assert "+after" in str(output["diff"])
+    assert not (repository / "injected-marker").exists()
+
+
+def test_git_diff_disables_repository_external_diff_and_textconv(tmp_path: Path) -> None:
+    repository = _repository(tmp_path)
+    marker = repository / "external-command-ran"
+    external = repository / "external.sh"
+    external.write_text(f"#!/bin/sh\ntouch '{marker}'\n", encoding="utf-8")
+    external.chmod(0o755)
+    _git(repository, "config", "diff.external", str(external))
+    (repository / ".gitattributes").write_text("*.txt diff=unsafe\n", encoding="utf-8")
+    _git(repository, "config", "diff.unsafe.textconv", str(external))
+    (repository / "tracked.txt").write_text("changed\n", encoding="utf-8")
+
+    output = asyncio.run(
+        GitDiffTool().execute(GitDiffInput(), _context(repository))
+    )
+
+    assert "+changed" in str(output["diff"])
+    assert not marker.exists()
+
+
+def test_git_tools_do_not_inherit_secret_environment(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repository = _repository(tmp_path)
+    secret = "secret-environment-marker-71a9"
+    monkeypatch.setenv("SYNAPSE_SECRET", secret)
+    monkeypatch.setenv("GIT_EXTERNAL_DIFF", secret)
+    monkeypatch.setenv("GIT_CONFIG_COUNT", "1")
+    monkeypatch.setenv("GIT_CONFIG_KEY_0", "alias.status")
+    monkeypatch.setenv("GIT_CONFIG_VALUE_0", f"!echo {secret}")
+
+    output = asyncio.run(
+        GitStatusTool().execute(GitStatusInput(), _context(repository))
+    )
+
+    assert output["exit_code"] == 0
+    assert secret not in repr(output)
+
+
+def test_git_diff_caps_large_output(tmp_path: Path) -> None:
+    repository = _repository(tmp_path)
+    (repository / "tracked.txt").write_text("x" * 700_000 + "\n", encoding="utf-8")
+
+    output = asyncio.run(
+        GitDiffTool().execute(GitDiffInput(), _context(repository))
+    )
+
+    diff = output["diff"]
+    assert isinstance(diff, str)
+    assert len(diff.encode("utf-8")) <= 524_288
+    assert output["truncated"] is True
+
+
+def test_git_tool_failure_is_sanitized(tmp_path: Path) -> None:
+    secret_path = str(tmp_path)
+
+    with pytest.raises(ToolError) as captured:
+        asyncio.run(GitStatusTool().execute(GitStatusInput(), _context(tmp_path)))
+
+    assert captured.value.code is ToolErrorCode.TOOL_FAILED
+    assert secret_path not in str(captured.value)
+    assert "fatal:" not in str(captured.value)
+
+
+@pytest.mark.parametrize("path", ["../escape", "/etc/passwd", "link"])
+def test_git_diff_rejects_unsafe_path_filters(tmp_path: Path, path: str) -> None:
+    repository = _repository(tmp_path)
+    if path == "link":
+        (repository / "link").symlink_to(repository / "tracked.txt")
+
+    with pytest.raises(ToolError) as captured:
+        asyncio.run(
+            GitDiffTool().execute(
+                GitDiffInput(paths=(path,)),
+                _context(repository),
+            )
+        )
+    assert captured.value.code is ToolErrorCode.WORKSPACE_VIOLATION
+
+
+def test_git_inputs_reject_extra_and_unbounded_values() -> None:
+    with pytest.raises(ValidationError):
+        GitStatusInput.model_validate({"extra": True}, strict=True)
+    with pytest.raises(ValidationError):
+        GitDiffInput.model_validate({"paths": tuple("x" for _ in range(129))}, strict=True)
+    with pytest.raises(ValidationError):
+        GitDiffInput.model_validate({"target": "UNKNOWN"}, strict=True)
+
+
+def test_git_process_environment_cannot_use_host_path(tmp_path: Path) -> None:
+    repository = _repository(tmp_path)
+    old_path = os.environ.get("PATH")
+    os.environ["PATH"] = str(repository)
+    try:
+        output = asyncio.run(
+            GitStatusTool().execute(GitStatusInput(), _context(repository))
+        )
+    finally:
+        if old_path is None:
+            os.environ.pop("PATH", None)
+        else:
+            os.environ["PATH"] = old_path
+    assert output["exit_code"] == 0
+
+
+def test_git_process_is_killed_when_execution_is_cancelled(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repository = _repository(tmp_path)
+    pid_file = repository / "git-process.pid"
+    executable = repository / "fake-git"
+    executable.write_text(
+        f"#!/bin/sh\necho $$ > '{pid_file}'\nsleep 30\n",
+        encoding="utf-8",
+    )
+    executable.chmod(0o755)
+    monkeypatch.setattr(git_module, "_GIT_EXECUTABLE", executable)
+
+    async def cancel_running_process() -> int:
+        operation = asyncio.create_task(
+            GitStatusTool().execute(GitStatusInput(), _context(repository))
+        )
+        for _ in range(1_000):
+            if pid_file.exists():
+                break
+            await asyncio.sleep(0.001)
+        assert pid_file.exists()
+        process_id = int(pid_file.read_text(encoding="utf-8"))
+        operation.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await operation
+        return process_id
+
+    process_id = asyncio.run(cancel_running_process())
+    try:
+        with pytest.raises(ProcessLookupError):
+            os.kill(process_id, 0)
+    finally:
+        with suppress(ProcessLookupError):
+            os.killpg(process_id, signal.SIGKILL)

--- a/tests/tools/test_paths.py
+++ b/tests/tools/test_paths.py
@@ -1,0 +1,127 @@
+"""Security tests for canonical workspace path resolution."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Literal
+
+import pytest
+
+from core.tools import ToolErrorCode, ToolWorkspaceError
+from infrastructure.tools.paths import relative_workspace_path, resolve_workspace_path
+
+
+@pytest.mark.parametrize(
+    "path",
+    ["", "../secret", "a/../../secret", "/etc/passwd", "\x00bad"],
+)
+def test_path_guard_rejects_unsafe_lexical_paths(tmp_path: Path, path: str) -> None:
+    with pytest.raises(ToolWorkspaceError) as captured:
+        resolve_workspace_path(tmp_path, path, must_exist=True, expected_kind="file")
+
+    assert captured.value.code is ToolErrorCode.WORKSPACE_VIOLATION
+    assert str(tmp_path) not in str(captured.value)
+    if path:
+        assert path not in str(captured.value)
+
+
+def test_path_guard_resolves_regular_workspace_resources(tmp_path: Path) -> None:
+    directory = tmp_path / "src"
+    directory.mkdir()
+    file_path = directory / "main.py"
+    file_path.write_text("print('safe')", encoding="utf-8")
+
+    assert resolve_workspace_path(
+        tmp_path, "src", must_exist=True, expected_kind="directory"
+    ) == directory.resolve()
+    resolved_file = resolve_workspace_path(
+        tmp_path, "src/main.py", must_exist=True, expected_kind="file"
+    )
+    assert resolved_file == file_path.resolve()
+    assert relative_workspace_path(tmp_path, resolved_file) == "src/main.py"
+
+
+def test_path_guard_allows_dot_as_workspace_directory(tmp_path: Path) -> None:
+    assert resolve_workspace_path(
+        tmp_path, ".", must_exist=True, expected_kind="directory"
+    ) == tmp_path.resolve()
+
+
+@pytest.mark.parametrize("target_kind", ["file", "directory"])
+def test_path_guard_rejects_all_symlinks(
+    tmp_path: Path,
+    target_kind: Literal["file", "directory"],
+) -> None:
+    target = tmp_path / "target"
+    if target_kind == "file":
+        target.write_text("content", encoding="utf-8")
+    else:
+        target.mkdir()
+    link = tmp_path / "link"
+    link.symlink_to(target, target_is_directory=target_kind == "directory")
+
+    with pytest.raises(ToolWorkspaceError, match="requested path is not allowed"):
+        resolve_workspace_path(
+            tmp_path,
+            "link",
+            must_exist=True,
+            expected_kind=target_kind,
+        )
+
+
+def test_path_guard_rejects_symlinked_parent_escape(tmp_path: Path) -> None:
+    outside = tmp_path.parent / f"{tmp_path.name}-outside"
+    outside.mkdir()
+    (outside / "secret.txt").write_text("secret", encoding="utf-8")
+    (tmp_path / "escape").symlink_to(outside, target_is_directory=True)
+
+    try:
+        with pytest.raises(ToolWorkspaceError, match="requested path is not allowed") as captured:
+            resolve_workspace_path(
+                tmp_path,
+                "escape/secret.txt",
+                must_exist=True,
+                expected_kind="file",
+            )
+        assert str(outside) not in str(captured.value)
+    finally:
+        (outside / "secret.txt").unlink()
+        outside.rmdir()
+
+
+def test_path_guard_rejects_broken_symlink(tmp_path: Path) -> None:
+    (tmp_path / "broken").symlink_to(tmp_path / "missing")
+
+    with pytest.raises(ToolWorkspaceError, match="requested path is not allowed"):
+        resolve_workspace_path(tmp_path, "broken", must_exist=True, expected_kind="file")
+
+
+def test_path_guard_rejects_special_file(tmp_path: Path) -> None:
+    fifo = tmp_path / "pipe"
+    os.mkfifo(fifo)
+
+    with pytest.raises(ToolWorkspaceError, match="requested path is not allowed"):
+        resolve_workspace_path(tmp_path, "pipe", must_exist=True, expected_kind="file")
+
+
+def test_path_guard_validates_nonexistent_git_filter_without_escape(tmp_path: Path) -> None:
+    expected = tmp_path / "future.txt"
+
+    assert resolve_workspace_path(
+        tmp_path,
+        "future.txt",
+        must_exist=False,
+        expected_kind="any",
+    ) == expected
+
+
+def test_relative_renderer_rejects_sibling_prefix_confusion(tmp_path: Path) -> None:
+    sibling = tmp_path.parent / f"{tmp_path.name}-sibling"
+    sibling.mkdir()
+
+    try:
+        with pytest.raises(ToolWorkspaceError, match="requested path is not allowed"):
+            relative_workspace_path(tmp_path, sibling)
+    finally:
+        sibling.rmdir()

--- a/tests/tools/test_paths.py
+++ b/tests/tools/test_paths.py
@@ -32,9 +32,10 @@ def test_path_guard_resolves_regular_workspace_resources(tmp_path: Path) -> None
     file_path = directory / "main.py"
     file_path.write_text("print('safe')", encoding="utf-8")
 
-    assert resolve_workspace_path(
-        tmp_path, "src", must_exist=True, expected_kind="directory"
-    ) == directory.resolve()
+    assert (
+        resolve_workspace_path(tmp_path, "src", must_exist=True, expected_kind="directory")
+        == directory.resolve()
+    )
     resolved_file = resolve_workspace_path(
         tmp_path, "src/main.py", must_exist=True, expected_kind="file"
     )
@@ -43,9 +44,10 @@ def test_path_guard_resolves_regular_workspace_resources(tmp_path: Path) -> None
 
 
 def test_path_guard_allows_dot_as_workspace_directory(tmp_path: Path) -> None:
-    assert resolve_workspace_path(
-        tmp_path, ".", must_exist=True, expected_kind="directory"
-    ) == tmp_path.resolve()
+    assert (
+        resolve_workspace_path(tmp_path, ".", must_exist=True, expected_kind="directory")
+        == tmp_path.resolve()
+    )
 
 
 @pytest.mark.parametrize("target_kind", ["file", "directory"])
@@ -108,12 +110,15 @@ def test_path_guard_rejects_special_file(tmp_path: Path) -> None:
 def test_path_guard_validates_nonexistent_git_filter_without_escape(tmp_path: Path) -> None:
     expected = tmp_path / "future.txt"
 
-    assert resolve_workspace_path(
-        tmp_path,
-        "future.txt",
-        must_exist=False,
-        expected_kind="any",
-    ) == expected
+    assert (
+        resolve_workspace_path(
+            tmp_path,
+            "future.txt",
+            must_exist=False,
+            expected_kind="any",
+        )
+        == expected
+    )
 
 
 def test_relative_renderer_rejects_sibling_prefix_confusion(tmp_path: Path) -> None:

--- a/tests/tools/test_registry.py
+++ b/tests/tools/test_registry.py
@@ -1,0 +1,93 @@
+"""Behavior tests for the immutable explicit Tool Registry."""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import BaseModel
+
+from core.tools import (
+    ToolDefinitionError,
+    ToolErrorCode,
+    ToolRegistry,
+    ToolRiskLevel,
+)
+from tests.tools.fakes import FakeTool
+
+
+def test_registry_exposes_one_explicit_tool(fake_tool: FakeTool) -> None:
+    registry = ToolRegistry([fake_tool])
+
+    assert registry.get("fake_read") is fake_tool
+    assert registry.names == ("fake_read",)
+    definition = registry.definitions[0]
+    assert definition.name == "fake_read"
+    assert definition.input_schema == FakeTool.input_type.model_json_schema()
+    assert definition.required_permissions == frozenset({"workspace.read"})
+    assert definition.risk_level is ToolRiskLevel.LOW
+    assert definition.timeout_seconds == 1.0
+
+
+def test_registry_sorts_names_without_mutating_source(fake_tool: FakeTool) -> None:
+    class AlphaTool(FakeTool):
+        name = "alpha"
+
+    supplied = [fake_tool, AlphaTool()]
+    registry = ToolRegistry(supplied)
+    supplied.clear()
+
+    assert registry.names == ("alpha", "fake_read")
+    alpha = registry.get("alpha")
+    assert alpha is not None
+    assert alpha.name == "alpha"
+
+
+def test_registry_returns_none_for_unknown_name(fake_tool: FakeTool) -> None:
+    assert ToolRegistry([fake_tool]).get("unknown") is None
+
+
+def test_registry_rejects_duplicate_names_without_exposing_name(fake_tool: FakeTool) -> None:
+    with pytest.raises(ToolDefinitionError) as captured:
+        ToolRegistry([fake_tool, FakeTool()])
+
+    assert captured.value.code is ToolErrorCode.INVALID_INPUT
+    assert "fake_read" not in str(captured.value)
+
+
+@pytest.mark.parametrize(
+    ("attribute", "value"),
+    [
+        ("name", "INVALID"),
+        ("description", " "),
+        ("required_permissions", frozenset()),
+        ("required_permissions", frozenset({"../escape"})),
+        ("risk_level", "LOW"),
+        ("timeout_seconds", 0.0),
+        ("timeout_seconds", 30.1),
+        ("input_type", BaseModel),
+    ],
+)
+def test_registry_rejects_invalid_tool_descriptors(
+    fake_tool: FakeTool,
+    attribute: str,
+    value: object,
+) -> None:
+    setattr(fake_tool, attribute, value)
+
+    with pytest.raises(ToolDefinitionError, match="Tool definition is invalid"):
+        ToolRegistry([fake_tool])
+
+
+def test_registry_has_no_runtime_mutation_api(fake_tool: FakeTool) -> None:
+    registry = ToolRegistry([fake_tool])
+
+    assert not hasattr(registry, "register")
+    assert not hasattr(registry, "replace")
+    assert not hasattr(registry, "remove")
+
+
+def test_mutating_returned_schema_does_not_change_registry(fake_tool: FakeTool) -> None:
+    registry = ToolRegistry([fake_tool])
+    schema = registry.definitions[0].input_schema
+    schema["title"] = "tampered"
+
+    assert registry.definitions[0].input_schema["title"] == "FakeInput"

--- a/tests/tools/test_types.py
+++ b/tests/tools/test_types.py
@@ -1,0 +1,114 @@
+"""Tests for strict Phase 6 tool value objects."""
+
+from __future__ import annotations
+
+import uuid
+from pathlib import Path
+
+import pytest
+from pydantic import ValidationError
+
+from core.tools import (
+    ToolErrorCode,
+    ToolExecutionContext,
+    ToolResult,
+    ToolResultStatus,
+)
+
+
+def _context(workspace_root: Path, **changes: object) -> ToolExecutionContext:
+    values: dict[str, object] = {
+        "workspace_root": workspace_root,
+        "agent_id": "backend-agent-03",
+        "agent_run_id": uuid.uuid4(),
+        "project_id": uuid.uuid4(),
+        "task_id": uuid.uuid4(),
+        "declared_tool_ids": {"read_file"},
+        "permission_ids": {"workspace.read"},
+        "correlation_id": uuid.uuid4(),
+    }
+    values.update(changes)
+    return ToolExecutionContext.model_validate(values, strict=True)
+
+
+def test_execution_context_canonicalizes_root_and_freezes_capabilities(tmp_path: Path) -> None:
+    nested = tmp_path / "nested"
+    nested.mkdir()
+
+    context = _context(nested / ".." / "nested")
+
+    assert context.workspace_root == nested.resolve()
+    assert context.declared_tool_ids == frozenset({"read_file"})
+    assert context.permission_ids == frozenset({"workspace.read"})
+    with pytest.raises(ValidationError):
+        context.agent_id = "changed"  # type: ignore[misc]
+
+
+@pytest.mark.parametrize(
+    ("changes", "secret_marker"),
+    [
+        ({"agent_id": "UPPERCASE"}, "UPPERCASE"),
+        ({"declared_tool_ids": {"../escape"}}, "../escape"),
+        ({"permission_ids": set()}, "unused-marker"),
+    ],
+)
+def test_execution_context_rejects_invalid_identifiers(
+    tmp_path: Path,
+    changes: dict[str, object],
+    secret_marker: str,
+) -> None:
+    with pytest.raises(ValidationError) as captured:
+        _context(tmp_path, **changes)
+    assert secret_marker not in str(captured.value)
+
+
+def test_execution_context_requires_an_existing_directory(tmp_path: Path) -> None:
+    file_path = tmp_path / "file.txt"
+    file_path.write_text("content", encoding="utf-8")
+
+    for invalid_root in (tmp_path / "missing", file_path):
+        with pytest.raises(ValidationError, match="workspace root") as captured:
+            _context(invalid_root)
+        assert str(invalid_root) not in str(captured.value)
+
+
+def test_success_result_rejects_error_fields() -> None:
+    with pytest.raises(ValidationError, match="successful tool result"):
+        ToolResult(
+            tool_name="read_file",
+            status=ToolResultStatus.SUCCEEDED,
+            output={},
+            error_code=ToolErrorCode.TOOL_FAILED,
+            error_message="Tool execution failed.",
+            duration_ms=1.0,
+            truncated=False,
+            tool_call_id=uuid.uuid4(),
+        )
+
+
+def test_failed_result_requires_safe_error_fields() -> None:
+    with pytest.raises(ValidationError, match="unsuccessful tool result"):
+        ToolResult(
+            tool_name="read_file",
+            status=ToolResultStatus.FAILED,
+            output={},
+            duration_ms=1.0,
+            truncated=False,
+            tool_call_id=uuid.uuid4(),
+        )
+
+
+def test_result_rejects_non_json_and_oversized_output() -> None:
+    common = {
+        "tool_name": "read_file",
+        "status": ToolResultStatus.SUCCEEDED,
+        "duration_ms": 1.0,
+        "truncated": False,
+        "tool_call_id": uuid.uuid4(),
+    }
+
+    with pytest.raises(ValidationError) as captured:
+        ToolResult(output={"bad": object()}, **common)
+    assert "object at" not in str(captured.value)
+    with pytest.raises(ValidationError, match="1048576 bytes"):
+        ToolResult(output={"content": "x" * 1_048_577}, **common)


### PR DESCRIPTION
## Summary

- add strict provider-neutral tool contracts and an immutable registry
- add a deny-by-default executor with declaration checks, permission membership, timeouts, cancellation propagation, bounded output, and no retries
- add the five Phase 6 read-only tools: `read_file`, `list_files`, `search_text`, `git_status`, and `git_diff`
- enforce canonical workspace containment and reject all symlinks
- persist sanitized `ToolCall` and append-only `AuditEvent` records through a caller-owned SQLAlchemy session
- document the execution boundary and keep the Phase 7 Permission Engine explicitly out of scope

## Security and resource guarantees

- no free-form shell execution
- fixed Git executable, arguments, and environment
- no retries or duplicated calls
- mandatory timeout and immediate cancellation cleanup
- bounded files, scans, subprocess pipes, and structured results
- no raw arguments, source content, diffs, prompts, absolute host paths, environment values, or exception text persisted
- injected sessions remain caller-owned

## Verification

- 517 tests passed against real PostgreSQL
- Ruff check passed
- Ruff format check passed
- mypy strict passed
- Alembic at head with no pending schema operations
- Docker API and PostgreSQL services healthy
- `/health` returned `{"status":"ok"}`
- Git verified inside the API container

## Scope

Phase 6 only. No Permission Engine, write tools, shell tool, MCP, skills runtime, agent loops, or Phase 7 behavior is included.
