### PR TITLE
feat(permissions): add database-backed permission engine

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,17 +6,18 @@ This file provides guidance to Codex (Codex.ai/code) when working with code in t
 
 The repository has completed **Phase 1 — repository initialization**, **Phase 2 — fundamental data
 model**, **Phase 3 — task state machine**, **Phase 4 — LLM provider boundary**, **Phase 5 — agent
-core**, and **Phase 6 — tool registry**. It contains a minimal FastAPI application, typed
+core**, **Phase 6 — tool registry**, and **Phase 7 — permission engine**. It contains a minimal FastAPI application, typed
 SQLAlchemy models, Alembic migrations, append-only history protection, an audited task workflow,
 bounded provider-neutral LLM contracts, an Ollama adapter, a bounded runtime agent with four
-strict structured operations, five bounded read-only repository tools, a PostgreSQL Docker
+strict structured operations, five bounded read-only repository tools, a PostgreSQL-backed
+permission engine with audited `ALLOW`/`DENY`/`ASK` decisions, a PostgreSQL Docker
 Compose service, and real-PostgreSQL integration tests.
 
-Phase 6 includes only `read_file`, `list_files`, `search_text`, `git_status`, and `git_diff` behind
-the central executor. It does not include autonomous loops, write tools, free-form shell, skill
+Phase 7 authorizes the Phase 6 tools exclusively from active persisted `AgentPermission` grants;
+runtime profile/context declarations are not execution authority. It does not include autonomous loops, write tools, free-form shell, skill
 loading, MCP access, provider routing, or multi-agent behavior. `skill_ids` are inert declarations;
-do not read or execute `SKILL.md` before the Phase 8 Skills Registry. Phase 7 and later phases are
-not implemented. In particular, there is no policy-based permission engine, MCP integration,
+do not read or execute `SKILL.md` before the Phase 8 Skills Registry. Phase 8 and later phases are
+not implemented. In particular, there is no approval workflow, MCP integration,
 QA/security engine, provider router, or frontend. Do not implement work from a later phase unless
 the user explicitly starts that phase.
 
@@ -58,10 +59,10 @@ For repository acceptance against the Docker PostgreSQL port, run:
 TEST_POSTGRES_PORT=55432 make test
 ```
 
-For the focused Phase 6 tool tests, run:
+For the focused Phase 7 permission and tool tests, run:
 
 ```bash
-.venv/bin/pytest tests/tools tests/database/test_tool_execution.py -q
+.venv/bin/pytest tests/permissions tests/tools tests/database/test_permission_tool_execution.py -q
 ```
 
 Run a single test with:

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 > The operating system for autonomous AI organizations.
 
-[![Status](https://img.shields.io/badge/status-Phase_6-orange)](SYNAPSEOS_DEVELOPMENT_CHECKLIST.md)
+[![Status](https://img.shields.io/badge/status-Phase_7-orange)](SYNAPSEOS_DEVELOPMENT_CHECKLIST.md)
 [![Python](https://img.shields.io/badge/python-3.12%2B-blue)](https://www.python.org/)
 [![Code style: Ruff](https://img.shields.io/badge/code_style-ruff-blueviolet)](https://docs.astral.sh/ruff/)
 [![Types: mypy](https://img.shields.io/badge/types-mypy-blue)](https://mypy-lang.org/)
@@ -48,10 +48,10 @@ See [`docs/cahier de charges.md`](docs/cahier%20de%20charges.md) for the full pr
 
 ## Status
 
-**Phase 6 — Tool registry completed.** The repository now provides the persistence foundation, an
+**Phase 7 — Permission engine completed.** The repository now provides the persistence foundation, an
 audited task workflow, provider-neutral LLM contracts with an Ollama adapter, a bounded runtime
-agent, and five deny-by-default read-only repository tools. Write tools, shell access, rich
-permission policy, skill loading, MCP, autonomous loops, multi-agent coordination, QA and security
+agent, five read-only repository tools, and deny-by-default PostgreSQL permission enforcement.
+Write tools, shell access, skill loading, MCP, autonomous loops, multi-agent coordination, QA and security
 engines, and the frontend remain intentionally unimplemented.
 
 What exists today:
@@ -71,8 +71,10 @@ What exists today:
   `decide()`, and `report()` operations, strict structured validation, and bounded metadata-only
   history.
 - An immutable registry and central executor for bounded file reads, file listing, literal search,
-  Git status, and Git diff, with workspace isolation, permission membership, timeout, cancellation,
+  Git status, and Git diff, with workspace isolation, persisted permission policy, timeout, cancellation,
   safe output limits, and sanitized PostgreSQL audit records.
+- Eleven canonical permissions, scoped expiring/revocable grants, deterministic
+  `ALLOW`/`DENY`/`ASK` decisions, autonomy gates, and mandatory append-only permission audits.
 - A full tooling baseline: `pytest`, `Ruff`, `mypy` (strict), plus `Dockerfile` and
   `docker-compose.yml` for the API + PostgreSQL.
 
@@ -150,10 +152,10 @@ The complete suite uses the Docker PostgreSQL service when it is exposed on the 
 TEST_POSTGRES_PORT=55432 make test
 ```
 
-The focused Phase 6 tool suite uses deterministic adapters plus real PostgreSQL audit tests:
+The focused Phase 7 suite uses deterministic adapters plus real PostgreSQL enforcement tests:
 
 ```bash
-.venv/bin/pytest tests/tools tests/database/test_tool_execution.py -q
+.venv/bin/pytest tests/permissions tests/tools tests/database/test_permission_tool_execution.py -q
 ```
 
 Run `make help` to list every available target.
@@ -172,7 +174,8 @@ validated pull request. The near-term sequence is:
 4. **LLM provider abstraction (Ollama first)** — completed
 5. **Agent core** — completed
 6. **Tool registry** — completed
-7. Permission engine — not started
+7. **Permission engine** — completed
+8. Skills registry — not started
 
 The complete phased plan (up to a full engineering organisation) lives in
 [`SYNAPSEOS_DEVELOPMENT_CHECKLIST.md`](SYNAPSEOS_DEVELOPMENT_CHECKLIST.md).
@@ -184,6 +187,7 @@ The complete phased plan (up to a full engineering organisation) lives in
 - **LLM providers:** [`docs/llm-providers.md`](docs/llm-providers.md)
 - **Agent core:** [`docs/agent-core.md`](docs/agent-core.md)
 - **Tool registry:** [`docs/tools.md`](docs/tools.md)
+- **Permission engine:** [`docs/permissions.md`](docs/permissions.md)
 - **Architecture decisions (ADRs):** [`docs/adr/`](docs/adr/)
 - **Repository working agreement:** [`AGENTS.md`](AGENTS.md)
 

--- a/SYNAPSEOS_DEVELOPMENT_CHECKLIST.md
+++ b/SYNAPSEOS_DEVELOPMENT_CHECKLIST.md
@@ -647,27 +647,27 @@ Empêcher un agent d'utiliser une capacité qu'il ne possède pas.
 
 ## Permissions V1
 
-- [ ] `filesystem.read`
-- [ ] `filesystem.write`
-- [ ] `git.read`
-- [ ] `git.write`
-- [ ] `shell.execute`
-- [ ] `tests.execute`
-- [ ] `network.access`
-- [ ] `database.read`
-- [ ] `database.write`
-- [ ] `deployment.staging`
-- [ ] `deployment.production`
+- [x] `filesystem.read`
+- [x] `filesystem.write`
+- [x] `git.read`
+- [x] `git.write`
+- [x] `shell.execute`
+- [x] `tests.execute`
+- [x] `network.access`
+- [x] `database.read`
+- [x] `database.write`
+- [x] `deployment.staging`
+- [x] `deployment.production`
 
 ## Checklist
 
-- [ ] Permission enum.
-- [ ] Permission policy.
-- [ ] AgentPermission.
-- [ ] ToolPermission.
-- [ ] Deny by default.
-- [ ] Audit refus.
-- [ ] Tests.
+- [x] Permission enum.
+- [x] Permission policy.
+- [x] AgentPermission.
+- [x] ToolPermission.
+- [x] Deny by default.
+- [x] Audit refus.
+- [x] Tests.
 
 ## Prompt Claude Code — Phase 7
 

--- a/alembic/versions/20260826_0003_permission_engine.py
+++ b/alembic/versions/20260826_0003_permission_engine.py
@@ -1,0 +1,130 @@
+"""add scoped agent permissions
+
+Revision ID: 20260826_0003
+Revises: 20260825_0002
+Create Date: 2026-08-26
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+from alembic import op
+
+revision: str = "20260826_0003"
+down_revision: str | None = "20260825_0002"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+PERMISSIONS = (
+    "FILESYSTEM_READ",
+    "FILESYSTEM_WRITE",
+    "GIT_READ",
+    "GIT_WRITE",
+    "SHELL_EXECUTE",
+    "TESTS_EXECUTE",
+    "NETWORK_ACCESS",
+    "DATABASE_READ",
+    "DATABASE_WRITE",
+    "DEPLOYMENT_STAGING",
+    "DEPLOYMENT_PRODUCTION",
+)
+
+
+def upgrade() -> None:
+    permission_enum = postgresql.ENUM(*PERMISSIONS, name="permission", create_type=False)
+    op.execute(
+        "CREATE TYPE permission AS ENUM ("
+        + ", ".join(f"'{permission}'" for permission in PERMISSIONS)
+        + ")"
+    )
+    op.create_table(
+        "agent_permissions",
+        sa.Column("agent_id", sa.UUID(), nullable=False),
+        sa.Column("permission", permission_enum, nullable=False),
+        sa.Column("project_id", sa.UUID(), nullable=True),
+        sa.Column(
+            "granted_by_actor_type",
+            postgresql.ENUM(name="audit_actor_type", create_type=False),
+            nullable=False,
+        ),
+        sa.Column("granted_by_actor_id", sa.String(length=255), nullable=False),
+        sa.Column("reason", sa.String(length=1024), nullable=False),
+        sa.Column("expires_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("revoked_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("id", sa.UUID(), nullable=False),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.CheckConstraint(
+            "granted_by_actor_type <> 'AGENT'",
+            name=op.f("ck_agent_permissions_grantor_not_agent"),
+        ),
+        sa.CheckConstraint(
+            "expires_at IS NULL OR expires_at > created_at",
+            name=op.f("ck_agent_permissions_expiry_after_creation"),
+        ),
+        sa.CheckConstraint(
+            "revoked_at IS NULL OR revoked_at >= created_at",
+            name=op.f("ck_agent_permissions_revocation_not_before_creation"),
+        ),
+        sa.ForeignKeyConstraint(
+            ["agent_id"],
+            ["agents.id"],
+            name=op.f("fk_agent_permissions_agent_id_agents"),
+            ondelete="RESTRICT",
+        ),
+        sa.ForeignKeyConstraint(
+            ["project_id"],
+            ["projects.id"],
+            name=op.f("fk_agent_permissions_project_id_projects"),
+            ondelete="RESTRICT",
+        ),
+        sa.PrimaryKeyConstraint("id", name=op.f("pk_agent_permissions")),
+    )
+    op.create_index(
+        "ix_agent_permissions_lookup",
+        "agent_permissions",
+        ["agent_id", "project_id", "permission"],
+        unique=False,
+    )
+    op.create_index(
+        "ix_agent_permissions_expires_at",
+        "agent_permissions",
+        ["expires_at"],
+        unique=False,
+    )
+    op.create_index(
+        "ix_agent_permissions_revoked_at",
+        "agent_permissions",
+        ["revoked_at"],
+        unique=False,
+    )
+    op.create_index(
+        "uq_agent_permissions_global",
+        "agent_permissions",
+        ["agent_id", "permission"],
+        unique=True,
+        postgresql_where=sa.text("project_id IS NULL"),
+    )
+    op.create_index(
+        "uq_agent_permissions_project",
+        "agent_permissions",
+        ["agent_id", "project_id", "permission"],
+        unique=True,
+        postgresql_where=sa.text("project_id IS NOT NULL"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("uq_agent_permissions_project", table_name="agent_permissions")
+    op.drop_index("uq_agent_permissions_global", table_name="agent_permissions")
+    op.drop_index("ix_agent_permissions_revoked_at", table_name="agent_permissions")
+    op.drop_index("ix_agent_permissions_expires_at", table_name="agent_permissions")
+    op.drop_index("ix_agent_permissions_lookup", table_name="agent_permissions")
+    op.drop_table("agent_permissions")
+    op.execute("DROP TYPE permission")

--- a/core/enums.py
+++ b/core/enums.py
@@ -21,6 +21,15 @@ class Permission(StrEnum):
     DEPLOYMENT_PRODUCTION = "deployment.production"
 
 
+class ToolRiskLevel(StrEnum):
+    """Risk classification shared by tool definitions and permission policy."""
+
+    LOW = "LOW"
+    MEDIUM = "MEDIUM"
+    HIGH = "HIGH"
+    CRITICAL = "CRITICAL"
+
+
 class AgentSeniority(StrEnum):
     TRAINEE = "TRAINEE"
     JUNIOR = "JUNIOR"

--- a/core/enums.py
+++ b/core/enums.py
@@ -5,6 +5,22 @@ from __future__ import annotations
 from enum import StrEnum
 
 
+class Permission(StrEnum):
+    """Canonical capabilities shared by agents, tools, and persistence."""
+
+    FILESYSTEM_READ = "filesystem.read"
+    FILESYSTEM_WRITE = "filesystem.write"
+    GIT_READ = "git.read"
+    GIT_WRITE = "git.write"
+    SHELL_EXECUTE = "shell.execute"
+    TESTS_EXECUTE = "tests.execute"
+    NETWORK_ACCESS = "network.access"
+    DATABASE_READ = "database.read"
+    DATABASE_WRITE = "database.write"
+    DEPLOYMENT_STAGING = "deployment.staging"
+    DEPLOYMENT_PRODUCTION = "deployment.production"
+
+
 class AgentSeniority(StrEnum):
     TRAINEE = "TRAINEE"
     JUNIOR = "JUNIOR"

--- a/core/permissions/__init__.py
+++ b/core/permissions/__init__.py
@@ -1,1 +1,29 @@
-"""Permission engine (placeholder — implemented in Phase 7)."""
+"""Public contracts for the Phase 7 Permission Engine."""
+
+from core.permissions.errors import (
+    PermissionAuditError,
+    PermissionError,
+    PermissionInputError,
+    PermissionPolicyError,
+)
+from core.permissions.types import (
+    PermissionDecision,
+    PermissionOutcome,
+    PermissionReasonCode,
+    PermissionRequest,
+    PolicyRequest,
+    ToolPermission,
+)
+
+__all__ = [
+    "PermissionAuditError",
+    "PermissionDecision",
+    "PermissionError",
+    "PermissionInputError",
+    "PermissionOutcome",
+    "PermissionPolicyError",
+    "PermissionReasonCode",
+    "PermissionRequest",
+    "PolicyRequest",
+    "ToolPermission",
+]

--- a/core/permissions/__init__.py
+++ b/core/permissions/__init__.py
@@ -1,11 +1,14 @@
 """Public contracts for the Phase 7 Permission Engine."""
 
+from core.permissions.audit import PermissionAuditRecorder
+from core.permissions.engine import PermissionEngine
 from core.permissions.errors import (
     PermissionAuditError,
     PermissionError,
     PermissionInputError,
     PermissionPolicyError,
 )
+from core.permissions.policy import PermissionPolicy
 from core.permissions.types import (
     PermissionDecision,
     PermissionOutcome,
@@ -17,11 +20,14 @@ from core.permissions.types import (
 
 __all__ = [
     "PermissionAuditError",
+    "PermissionAuditRecorder",
     "PermissionDecision",
     "PermissionError",
+    "PermissionEngine",
     "PermissionInputError",
     "PermissionOutcome",
     "PermissionPolicyError",
+    "PermissionPolicy",
     "PermissionReasonCode",
     "PermissionRequest",
     "PolicyRequest",

--- a/core/permissions/audit.py
+++ b/core/permissions/audit.py
@@ -1,0 +1,15 @@
+"""Persistence-neutral permission decision audit contract."""
+
+from __future__ import annotations
+
+from typing import Protocol
+
+from core.permissions.types import PermissionDecision
+
+
+class PermissionAuditRecorder(Protocol):
+    """Append one completed policy decision to caller-owned persistence."""
+
+    def record(self, decision: PermissionDecision) -> None:
+        """Persist one sanitized terminal decision."""
+        ...

--- a/core/permissions/engine.py
+++ b/core/permissions/engine.py
@@ -1,0 +1,130 @@
+"""Central validation, policy, and mandatory audit lifecycle."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from datetime import UTC, datetime
+
+from pydantic import ValidationError
+
+from core.enums import Permission
+from core.permissions.audit import PermissionAuditRecorder
+from core.permissions.errors import (
+    PermissionAuditError,
+    PermissionInputError,
+    PermissionPolicyError,
+)
+from core.permissions.policy import PermissionPolicy
+from core.permissions.types import (
+    PermissionDecision,
+    PermissionOutcome,
+    PermissionReasonCode,
+    PermissionRequest,
+    PolicyRequest,
+)
+
+
+class PermissionEngine:
+    """Evaluate exactly one deny-by-default policy and audit its decision."""
+
+    def __init__(
+        self,
+        policy: PermissionPolicy,
+        audit_recorder: PermissionAuditRecorder,
+        *,
+        clock: Callable[[], datetime] | None = None,
+    ) -> None:
+        self._policy = policy
+        self._audit_recorder = audit_recorder
+        self._clock = clock or (lambda: datetime.now(UTC))
+
+    def evaluate(self, request: PermissionRequest) -> PermissionDecision:
+        """Return one audited decision or fail closed with a sanitized error."""
+        validated = self._validate_request(request)
+        evaluated_at = self._evaluated_at()
+        try:
+            permissions = frozenset(
+                Permission(identifier) for identifier in validated.required_permission_ids
+            )
+        except ValueError as error:
+            error.__traceback__ = None
+            del error
+            decision = PermissionDecision.from_request(
+                validated,
+                outcome=PermissionOutcome.DENY,
+                required_permissions=frozenset(),
+                reason_code=PermissionReasonCode.UNKNOWN_PERMISSION,
+                safe_message="A required permission is unknown.",
+                evaluated_at=evaluated_at,
+            )
+            self._record(decision)
+            return decision
+
+        policy_request = PolicyRequest.from_request(validated, permissions)
+        try:
+            raw_decision = self._policy.evaluate(policy_request, evaluated_at)
+        except Exception as error:
+            error.__traceback__ = None
+            del error
+            raise PermissionPolicyError("Permission policy is unavailable.") from None
+
+        decision = self._validate_decision(raw_decision, policy_request, evaluated_at)
+        self._record(decision)
+        return decision
+
+    @staticmethod
+    def _validate_request(request: PermissionRequest) -> PermissionRequest:
+        try:
+            if type(request) is not PermissionRequest:
+                raise ValueError
+            return PermissionRequest.model_validate(request.__dict__, strict=True)
+        except (AttributeError, TypeError, ValueError, ValidationError) as error:
+            error.__traceback__ = None
+            del error
+            raise PermissionInputError("Permission request is invalid.") from None
+
+    def _evaluated_at(self) -> datetime:
+        try:
+            value = self._clock()
+            if value.tzinfo is None or value.utcoffset() is None:
+                raise ValueError
+            return value.astimezone(UTC)
+        except Exception as error:
+            error.__traceback__ = None
+            del error
+            raise PermissionInputError("Permission evaluation time is invalid.") from None
+
+    @staticmethod
+    def _validate_decision(
+        decision: PermissionDecision,
+        request: PolicyRequest,
+        evaluated_at: datetime,
+    ) -> PermissionDecision:
+        try:
+            if type(decision) is not PermissionDecision:
+                raise ValueError
+            validated = PermissionDecision.model_validate(decision.__dict__, strict=True)
+            if (
+                validated.agent_id != request.agent_id
+                or validated.agent_run_id != request.agent_run_id
+                or validated.project_id != request.project_id
+                or validated.task_id != request.task_id
+                or validated.tool_name != request.tool_name
+                or frozenset(validated.required_permissions) != request.required_permissions
+                or validated.correlation_id != request.correlation_id
+                or validated.evaluated_at != evaluated_at
+            ):
+                raise ValueError
+            return validated
+        except (AttributeError, TypeError, ValueError, ValidationError) as error:
+            error.__traceback__ = None
+            del error
+            raise PermissionPolicyError("Permission policy returned an invalid decision.") from None
+
+    def _record(self, decision: PermissionDecision) -> None:
+        try:
+            self._audit_recorder.record(decision)
+        except Exception as error:
+            error.__traceback__ = None
+            del error
+            raise PermissionAuditError("Permission audit is unavailable.") from None

--- a/core/permissions/errors.py
+++ b/core/permissions/errors.py
@@ -1,0 +1,19 @@
+"""Sanitized errors for the Phase 7 permission boundary."""
+
+from __future__ import annotations
+
+
+class PermissionError(Exception):
+    """Base permission failure carrying only a constant-safe message."""
+
+
+class PermissionInputError(PermissionError):
+    """Raised when an authorization request cannot be accepted safely."""
+
+
+class PermissionPolicyError(PermissionError):
+    """Raised when policy authority cannot be evaluated safely."""
+
+
+class PermissionAuditError(PermissionError):
+    """Raised when mandatory permission auditing cannot be completed."""

--- a/core/permissions/policy.py
+++ b/core/permissions/policy.py
@@ -1,0 +1,20 @@
+"""Persistence-neutral permission policy contract."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Protocol
+
+from core.permissions.types import PermissionDecision, PolicyRequest
+
+
+class PermissionPolicy(Protocol):
+    """Resolve one canonical permission request without side effects."""
+
+    def evaluate(
+        self,
+        request: PolicyRequest,
+        evaluated_at: datetime,
+    ) -> PermissionDecision:
+        """Return one deterministic policy decision."""
+        ...

--- a/core/permissions/types.py
+++ b/core/permissions/types.py
@@ -9,8 +9,7 @@ from uuid import UUID
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
-from core.enums import Permission
-from core.tools.types import ToolRiskLevel
+from core.enums import Permission, ToolRiskLevel
 
 Identifier = Annotated[str, Field(pattern=r"^[a-z0-9][a-z0-9._:-]{0,127}$")]
 IdentifierSet = Annotated[frozenset[Identifier], Field(min_length=1, max_length=128)]

--- a/core/permissions/types.py
+++ b/core/permissions/types.py
@@ -1,0 +1,196 @@
+"""Strict immutable values for deny-by-default permission evaluation."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from enum import StrEnum
+from typing import Annotated, Self
+from uuid import UUID
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+
+from core.enums import Permission
+from core.tools.types import ToolRiskLevel
+
+Identifier = Annotated[str, Field(pattern=r"^[a-z0-9][a-z0-9._:-]{0,127}$")]
+IdentifierSet = Annotated[frozenset[Identifier], Field(min_length=1, max_length=128)]
+PermissionSet = Annotated[frozenset[Permission], Field(min_length=1, max_length=11)]
+PermissionTuple = Annotated[tuple[Permission, ...], Field(max_length=11)]
+SafeMessage = Annotated[str, Field(min_length=1, max_length=255)]
+
+
+class PermissionOutcome(StrEnum):
+    """A policy decision; only ALLOW carries execution authority."""
+
+    ALLOW = "ALLOW"
+    DENY = "DENY"
+    ASK = "ASK"
+
+
+class PermissionReasonCode(StrEnum):
+    """Stable, non-sensitive explanations for policy decisions."""
+
+    GRANTED = "GRANTED"
+    UNKNOWN_PERMISSION = "UNKNOWN_PERMISSION"
+    INVALID_SCOPE = "INVALID_SCOPE"
+    MISSING_PERMISSION = "MISSING_PERMISSION"
+    HUMAN_APPROVAL_REQUIRED = "HUMAN_APPROVAL_REQUIRED"
+    AUTONOMY_APPROVAL_REQUIRED = "AUTONOMY_APPROVAL_REQUIRED"
+
+
+class _ImmutablePermissionModel(BaseModel):
+    """Shared strict, frozen, and leak-resistant model configuration."""
+
+    model_config = ConfigDict(
+        frozen=True,
+        extra="forbid",
+        strict=True,
+        hide_input_in_errors=True,
+    )
+
+
+class PermissionRequest(_ImmutablePermissionModel):
+    """Outer authorization request that can represent an unknown identifier safely."""
+
+    agent_id: Identifier
+    agent_run_id: UUID
+    project_id: UUID
+    task_id: UUID
+    tool_name: Identifier
+    risk_level: ToolRiskLevel
+    required_permission_ids: IdentifierSet
+    correlation_id: UUID
+
+    @field_validator("required_permission_ids", mode="before")
+    @classmethod
+    def freeze_permission_ids(cls, value: object) -> object:
+        """Copy common collection inputs before strict validation."""
+        if isinstance(value, (set, frozenset, tuple, list)):
+            return frozenset(value)
+        return value
+
+
+class PolicyRequest(_ImmutablePermissionModel):
+    """Canonical request accepted by a trusted policy implementation."""
+
+    agent_id: Identifier
+    agent_run_id: UUID
+    project_id: UUID
+    task_id: UUID
+    tool_name: Identifier
+    risk_level: ToolRiskLevel
+    required_permissions: PermissionSet
+    correlation_id: UUID
+
+    @field_validator("required_permissions", mode="before")
+    @classmethod
+    def freeze_permissions(cls, value: object) -> object:
+        if isinstance(value, (set, frozenset, tuple, list)):
+            return frozenset(value)
+        return value
+
+    @classmethod
+    def from_request(
+        cls,
+        request: PermissionRequest,
+        permissions: frozenset[Permission],
+    ) -> Self:
+        """Build a canonical policy request from an already validated outer request."""
+        return cls(
+            agent_id=request.agent_id,
+            agent_run_id=request.agent_run_id,
+            project_id=request.project_id,
+            task_id=request.task_id,
+            tool_name=request.tool_name,
+            risk_level=request.risk_level,
+            required_permissions=permissions,
+            correlation_id=request.correlation_id,
+        )
+
+
+class ToolPermission(_ImmutablePermissionModel):
+    """Immutable canonical requirements derived from one registered tool."""
+
+    tool_name: Identifier
+    required_permissions: PermissionSet
+
+    @field_validator("required_permissions", mode="before")
+    @classmethod
+    def freeze_permissions(cls, value: object) -> object:
+        if isinstance(value, (set, frozenset, tuple, list)):
+            return frozenset(value)
+        return value
+
+
+class PermissionDecision(_ImmutablePermissionModel):
+    """A bounded explainable policy outcome without unrelated grant details."""
+
+    agent_id: Identifier
+    agent_run_id: UUID
+    project_id: UUID
+    task_id: UUID
+    tool_name: Identifier
+    outcome: PermissionOutcome
+    required_permissions: PermissionTuple
+    reason_code: PermissionReasonCode
+    safe_message: SafeMessage
+    correlation_id: UUID
+    evaluated_at: datetime
+
+    @field_validator("required_permissions", mode="before")
+    @classmethod
+    def sort_permissions(cls, value: object) -> object:
+        if isinstance(value, (set, frozenset, tuple, list)):
+            return tuple(sorted(value, key=lambda item: item.value))
+        return value
+
+    @field_validator("evaluated_at")
+    @classmethod
+    def require_utc_timestamp(cls, value: datetime) -> datetime:
+        if value.tzinfo is None or value.utcoffset() is None:
+            raise ValueError("evaluated_at must be timezone-aware")
+        return value.astimezone(UTC)
+
+    @model_validator(mode="after")
+    def require_consistent_outcome_and_reason(self) -> Self:
+        allowed_reasons = {
+            PermissionOutcome.ALLOW: {PermissionReasonCode.GRANTED},
+            PermissionOutcome.DENY: {
+                PermissionReasonCode.UNKNOWN_PERMISSION,
+                PermissionReasonCode.INVALID_SCOPE,
+                PermissionReasonCode.MISSING_PERMISSION,
+            },
+            PermissionOutcome.ASK: {
+                PermissionReasonCode.HUMAN_APPROVAL_REQUIRED,
+                PermissionReasonCode.AUTONOMY_APPROVAL_REQUIRED,
+            },
+        }
+        if self.reason_code not in allowed_reasons[self.outcome]:
+            raise ValueError("permission outcome and reason are inconsistent")
+        return self
+
+    @classmethod
+    def from_request(
+        cls,
+        request: PermissionRequest | PolicyRequest,
+        *,
+        outcome: PermissionOutcome,
+        required_permissions: frozenset[Permission],
+        reason_code: PermissionReasonCode,
+        safe_message: str,
+        evaluated_at: datetime,
+    ) -> Self:
+        """Create a decision while preserving only the validated execution scope."""
+        return cls(
+            agent_id=request.agent_id,
+            agent_run_id=request.agent_run_id,
+            project_id=request.project_id,
+            task_id=request.task_id,
+            tool_name=request.tool_name,
+            outcome=outcome,
+            required_permissions=tuple(required_permissions),
+            reason_code=reason_code,
+            safe_message=safe_message,
+            correlation_id=request.correlation_id,
+            evaluated_at=evaluated_at,
+        )

--- a/core/tools/__init__.py
+++ b/core/tools/__init__.py
@@ -1,5 +1,6 @@
 """Public contracts for the Phase 6 tool registry."""
 
+from core.enums import ToolRiskLevel
 from core.tools.audit import (
     ToolAuditFinish,
     ToolAuditHandle,
@@ -23,7 +24,6 @@ from core.tools.types import (
     ToolExecutionContext,
     ToolResult,
     ToolResultStatus,
-    ToolRiskLevel,
 )
 
 __all__ = [

--- a/core/tools/executor.py
+++ b/core/tools/executor.py
@@ -11,6 +11,9 @@ from typing import cast
 
 from pydantic import ValidationError
 
+from core.permissions.engine import PermissionEngine
+from core.permissions.errors import PermissionError
+from core.permissions.types import PermissionOutcome, PermissionRequest
 from core.tools.audit import (
     ToolAuditFinish,
     ToolAuditHandle,
@@ -34,6 +37,8 @@ _SAFE_MESSAGES: dict[ToolErrorCode, str] = {
     ToolErrorCode.TOOL_NOT_FOUND: "Requested tool is not registered.",
     ToolErrorCode.TOOL_NOT_DECLARED: "Requested tool is not declared for this agent.",
     ToolErrorCode.PERMISSION_DENIED: "Required tool permission is missing.",
+    ToolErrorCode.APPROVAL_REQUIRED: "Human approval is required for this tool.",
+    ToolErrorCode.PERMISSION_AUDIT_FAILED: "Permission evaluation is unavailable.",
     ToolErrorCode.INVALID_INPUT: "Tool input is invalid.",
     ToolErrorCode.WORKSPACE_VIOLATION: "Requested workspace resource is not allowed.",
     ToolErrorCode.UNSUPPORTED_FILE: "Requested file type is not supported.",
@@ -48,9 +53,15 @@ _SAFE_MESSAGES: dict[ToolErrorCode, str] = {
 class ToolExecutor:
     """Apply uniform safety and audit controls around exactly one tool call."""
 
-    def __init__(self, registry: ToolRegistry, audit_recorder: ToolAuditRecorder) -> None:
+    def __init__(
+        self,
+        registry: ToolRegistry,
+        audit_recorder: ToolAuditRecorder,
+        permission_engine: PermissionEngine,
+    ) -> None:
         self._registry = registry
         self._audit_recorder = audit_recorder
+        self._permission_engine = permission_engine
 
     async def execute(
         self,
@@ -83,14 +94,43 @@ class ToolExecutor:
                 ToolAuditOutcome.DENIED,
                 ToolErrorCode.TOOL_NOT_DECLARED,
             )
-        if not tool.required_permissions.issubset(validated_context.permission_ids):
+        try:
+            permission_decision = self._permission_engine.evaluate(
+                PermissionRequest(
+                    agent_id=validated_context.agent_id,
+                    agent_run_id=validated_context.agent_run_id,
+                    project_id=validated_context.project_id,
+                    task_id=validated_context.task_id,
+                    tool_name=validated_name,
+                    risk_level=tool.risk_level,
+                    required_permission_ids=frozenset(
+                        permission.value for permission in tool.required_permissions
+                    ),
+                    correlation_id=validated_context.correlation_id,
+                )
+            )
+        except PermissionError:
+            return self._failure_result(
+                handle,
+                validated_name,
+                started_at,
+                ToolResultStatus.FAILED,
+                ToolAuditOutcome.FAILED,
+                ToolErrorCode.PERMISSION_AUDIT_FAILED,
+            )
+        if permission_decision.outcome is not PermissionOutcome.ALLOW:
+            error_code = (
+                ToolErrorCode.APPROVAL_REQUIRED
+                if permission_decision.outcome is PermissionOutcome.ASK
+                else ToolErrorCode.PERMISSION_DENIED
+            )
             return self._failure_result(
                 handle,
                 validated_name,
                 started_at,
                 ToolResultStatus.DENIED,
                 ToolAuditOutcome.DENIED,
-                ToolErrorCode.PERMISSION_DENIED,
+                error_code,
             )
 
         try:

--- a/core/tools/registry.py
+++ b/core/tools/registry.py
@@ -10,13 +10,14 @@ from typing import Any, cast
 
 from pydantic import BaseModel, ConfigDict, Field
 
+from core.enums import Permission, ToolRiskLevel
 from core.tools.errors import ToolDefinitionError
 from core.tools.tool import Tool
-from core.tools.types import JsonValue, ToolErrorCode, ToolRiskLevel
+from core.tools.types import JsonValue, ToolErrorCode
 
 _IDENTIFIER_PATTERN = re.compile(r"^[a-z0-9][a-z0-9._:-]{0,127}$")
 _MAX_DESCRIPTION_LENGTH = 1_024
-_MAX_PERMISSIONS = 128
+_MAX_PERMISSIONS = len(Permission)
 _MAX_TIMEOUT_SECONDS = 30.0
 _INVALID_DEFINITION_MESSAGE = "Tool definition is invalid."
 
@@ -29,7 +30,10 @@ class ToolDefinition(BaseModel):
     name: str
     description: str
     input_schema: dict[str, JsonValue]
-    required_permissions: frozenset[str] = Field(min_length=1, max_length=128)
+    required_permissions: frozenset[Permission] = Field(
+        min_length=1,
+        max_length=_MAX_PERMISSIONS,
+    )
     risk_level: ToolRiskLevel
     timeout_seconds: float = Field(gt=0.0, le=30.0, allow_inf_nan=False)
 
@@ -87,11 +91,7 @@ class ToolRegistry:
             if (
                 not isinstance(permissions, frozenset)
                 or not 1 <= len(permissions) <= _MAX_PERMISSIONS
-                or any(
-                    not isinstance(permission, str)
-                    or _IDENTIFIER_PATTERN.fullmatch(permission) is None
-                    for permission in permissions
-                )
+                or any(type(permission) is not Permission for permission in permissions)
             ):
                 raise ValueError
             if type(tool.risk_level) is not ToolRiskLevel:

--- a/core/tools/tool.py
+++ b/core/tools/tool.py
@@ -7,7 +7,8 @@ from collections.abc import Mapping
 
 from pydantic import BaseModel
 
-from core.tools.types import JsonValue, ToolExecutionContext, ToolRiskLevel
+from core.enums import Permission, ToolRiskLevel
+from core.tools.types import JsonValue, ToolExecutionContext
 
 
 class Tool[InputT: BaseModel](ABC):
@@ -16,7 +17,7 @@ class Tool[InputT: BaseModel](ABC):
     name: str
     description: str
     input_type: type[InputT]
-    required_permissions: frozenset[str]
+    required_permissions: frozenset[Permission]
     risk_level: ToolRiskLevel
     timeout_seconds: float
 

--- a/core/tools/types.py
+++ b/core/tools/types.py
@@ -19,15 +19,6 @@ SafeMessage = Annotated[str, Field(min_length=1, max_length=255)]
 _MAX_RESULT_BYTES = 1_048_576
 
 
-class ToolRiskLevel(StrEnum):
-    """Risk classification declared by a tool definition."""
-
-    LOW = "LOW"
-    MEDIUM = "MEDIUM"
-    HIGH = "HIGH"
-    CRITICAL = "CRITICAL"
-
-
 class ToolResultStatus(StrEnum):
     """Public terminal outcome of one tool invocation."""
 
@@ -43,6 +34,8 @@ class ToolErrorCode(StrEnum):
     TOOL_NOT_FOUND = "TOOL_NOT_FOUND"
     TOOL_NOT_DECLARED = "TOOL_NOT_DECLARED"
     PERMISSION_DENIED = "PERMISSION_DENIED"
+    APPROVAL_REQUIRED = "APPROVAL_REQUIRED"
+    PERMISSION_AUDIT_FAILED = "PERMISSION_AUDIT_FAILED"
     INVALID_INPUT = "INVALID_INPUT"
     WORKSPACE_VIOLATION = "WORKSPACE_VIOLATION"
     UNSUPPORTED_FILE = "UNSUPPORTED_FILE"
@@ -60,7 +53,7 @@ class _ImmutableToolModel(BaseModel):
 
 
 class ToolExecutionContext(_ImmutableToolModel):
-    """Bounded caller-supplied authority and workspace scope for one invocation."""
+    """Bounded caller identity and workspace scope for one invocation."""
 
     workspace_root: Path
     agent_id: Identifier
@@ -68,7 +61,6 @@ class ToolExecutionContext(_ImmutableToolModel):
     project_id: UUID
     task_id: UUID
     declared_tool_ids: IdentifierSet
-    permission_ids: IdentifierSet
     correlation_id: UUID
 
     @field_validator("workspace_root")
@@ -84,7 +76,7 @@ class ToolExecutionContext(_ImmutableToolModel):
             raise ValueError("workspace root must be an existing directory") from None
         return resolved
 
-    @field_validator("declared_tool_ids", "permission_ids", mode="before")
+    @field_validator("declared_tool_ids", mode="before")
     @classmethod
     def freeze_identifier_sets(cls, value: object) -> object:
         """Copy common set inputs into immutable capability declarations."""

--- a/docs/adr/0007-database-backed-permission-authority.md
+++ b/docs/adr/0007-database-backed-permission-authority.md
@@ -1,0 +1,39 @@
+# ADR-0007 — Database-backed permission authority
+
+- **Status:** Accepted
+- **Date:** 2026-08-26
+- **Deciders:** SynapseOS owner and engineering agent
+
+## Context
+
+Tool execution needs a deny-by-default authority that remains valid across processes and cannot be
+forged by caller-supplied runtime data. Decisions must be explainable, project-scoped, revocable,
+expirable, auditable, and compatible with future human approval without implementing that workflow
+in Phase 7.
+
+## Options considered
+
+- Runtime permission IDs in `AgentProfile` or `ToolExecutionContext` — simple but caller-controlled,
+  stale, and unsuitable as execution authority.
+- Role inheritance — convenient for administration but implicit, difficult to audit, and premature.
+- PostgreSQL `AgentPermission` grants with explicit global or project scope — persistent,
+  queryable, constrained, and transactionally auditable.
+
+## Decision
+
+PostgreSQL `AgentPermission` rows are the sole execution authority. A provider-neutral permission
+engine validates canonical identifiers, delegates to an injected SQLAlchemy policy, and requires a
+sanitized append-only audit before returning. The policy verifies coherent agent/run/task/project
+scope, active grants, and autonomy. Only `ALLOW` authorizes execution; `DENY` and `ASK` do not.
+Production deployment always returns `ASK` even with a grant and sufficient autonomy.
+
+The caller owns the shared transaction and session. No adapter commits, rolls back, closes,
+retries, caches, or performs network work.
+
+## Consequences
+
+- Runtime profiles can describe permissions but cannot grant authority.
+- Grant changes take effect on the next evaluation without cache invalidation.
+- Each attempted registered and declared tool call has separate permission and tool audit records.
+- Phase 7 has no grant mutation API or approval continuation mechanism.
+- Database-level update/delete restrictions, RLS, and triggers remain future defense-in-depth work.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -39,3 +39,4 @@ Trade-offs, risks, follow-ups.
 - [ADR-0004 — Provider-neutral LLM boundary](0004-provider-neutral-llm-boundary.md)
 - [ADR-0005 — Agent runtime boundary](0005-agent-runtime-boundary.md)
 - [ADR-0006 — Tool registry execution boundary](0006-tool-registry-execution-boundary.md)
+- [ADR-0007 — Database-backed permission authority](0007-database-backed-permission-authority.md)

--- a/docs/permissions.md
+++ b/docs/permissions.md
@@ -1,0 +1,55 @@
+# Permission engine
+
+Phase 7 makes PostgreSQL `AgentPermission` rows the sole source of execution authority. Runtime
+profiles and tool contexts may describe capabilities, but they cannot grant them. Every registered
+tool declares one or more canonical `Permission` enum values, and `ToolExecutor` executes only an
+audited `ALLOW` decision.
+
+## Composition
+
+All adapters share one caller-owned SQLAlchemy session so the permission decision, permission
+audit, tool call, and terminal tool audit participate in the same transaction:
+
+```python
+permission_engine = PermissionEngine(
+    SQLAlchemyPermissionPolicy(caller_owned_session),
+    SQLAlchemyPermissionAuditRecorder(caller_owned_session),
+)
+executor = ToolExecutor(
+    create_default_tool_registry(),
+    SQLAlchemyToolAuditRecorder(caller_owned_session),
+    permission_engine,
+)
+```
+
+None of these components commits, rolls back, closes the session, retries, caches grants, or owns
+network resources.
+
+## Decision order
+
+1. Validate the invocation and begin the tool audit.
+2. Reject an unknown or undeclared tool without consulting permission policy.
+3. Verify the agent slug, run, task, assigned agent, and project as one coherent persisted scope.
+4. Resolve every required active global or matching-project grant.
+5. Deny missing, partial, expired, revoked, or cross-project grants.
+6. Apply the minimum autonomy level after grant verification.
+7. Return `ASK` for insufficient autonomy and always for production deployment.
+8. Append `PERMISSION_EVALUATED`; only then may an `ALLOW` execute the tool.
+
+`DENY` and `ASK` are terminal and non-executing in Phase 7. There is no approval workflow yet.
+Unknown permission identifiers are audited and denied. Agents cannot create their own grants: the
+database rejects `AGENT` as a grantor actor type.
+
+## Audit minimization
+
+Permission audit data is allowlisted to the decision, sorted required permission identifiers, and
+stable reason code. It excludes arguments, paths, source content, prompts, outputs, exceptions,
+credentials, grantor identity, expiry details, and unrelated grants. Permission and tool audits are
+separate append-only events linked by execution scope and correlation ID.
+
+## Deliberate boundary
+
+Phase 7 provides the permission enum, persisted grants, policy evaluation, mandatory audit, and
+tool enforcement. It intentionally provides no grant administration API, role inheritance,
+wildcards, approval workflow, RLS, PostgreSQL triggers, permission cache, write/shell/network/
+database/deployment tools, skills, or MCP integration. Those remain later-phase work.

--- a/docs/superpowers/plans/2026-08-26-phase-7-permission-engine.md
+++ b/docs/superpowers/plans/2026-08-26-phase-7-permission-engine.md
@@ -46,9 +46,17 @@
 ```python
 def test_permission_enum_contains_exactly_v1_values() -> None:
     assert tuple(permission.value for permission in Permission) == (
-        "filesystem.read", "filesystem.write", "git.read", "git.write",
-        "shell.execute", "tests.execute", "network.access", "database.read",
-        "database.write", "deployment.staging", "deployment.production",
+        "filesystem.read",
+        "filesystem.write",
+        "git.read",
+        "git.write",
+        "shell.execute",
+        "tests.execute",
+        "network.access",
+        "database.read",
+        "database.write",
+        "deployment.staging",
+        "deployment.production",
     )
 ```
 
@@ -127,8 +135,16 @@ git commit -m "feat(permissions): add strict permission contracts"
 def test_agent_permission_has_required_columns_and_indexes() -> None:
     table = AgentPermission.__table__
     assert set(table.columns) == {
-        "id", "agent_id", "permission", "project_id", "granted_by_actor_type",
-        "granted_by_actor_id", "reason", "expires_at", "revoked_at", "created_at",
+        "id",
+        "agent_id",
+        "permission",
+        "project_id",
+        "granted_by_actor_type",
+        "granted_by_actor_id",
+        "reason",
+        "expires_at",
+        "revoked_at",
+        "created_at",
     }
     assert table.c.permission.type.name == "permission"
 ```
@@ -196,7 +212,9 @@ git commit -m "feat(database): persist scoped agent permissions"
 - [ ] **Step 1: Write a failing allowed-decision lifecycle test**
 
 ```python
-def test_engine_canonicalizes_evaluates_once_and_audits_allow(valid_request: PermissionRequest) -> None:
+def test_engine_canonicalizes_evaluates_once_and_audits_allow(
+    valid_request: PermissionRequest,
+) -> None:
     policy = RecordingPolicy(PermissionOutcome.ALLOW, PermissionReasonCode.GRANTED)
     audit = RecordingPermissionAudit()
     decision = PermissionEngine(policy, audit, clock=fixed_clock).evaluate(valid_request)
@@ -328,13 +346,19 @@ git commit -m "feat(permissions): resolve scoped PostgreSQL grants"
 - [ ] **Step 1: Write a failing sanitized ALLOW audit test**
 
 ```python
-def test_allow_decision_appends_sanitized_event(db_session: Session, allowed_decision: PermissionDecision) -> None:
+def test_allow_decision_appends_sanitized_event(
+    db_session: Session, allowed_decision: PermissionDecision
+) -> None:
     SQLAlchemyPermissionAuditRecorder(db_session).record(allowed_decision)
-    event = db_session.scalar(select(AuditEvent).where(AuditEvent.event_type == "PERMISSION_EVALUATED"))
+    event = db_session.scalar(
+        select(AuditEvent).where(AuditEvent.event_type == "PERMISSION_EVALUATED")
+    )
     assert event is not None
     assert event.result is AuditResult.SUCCEEDED
     assert event.data == {
-        "decision": "ALLOW", "required_permissions": ["filesystem.read"], "reason_code": "GRANTED"
+        "decision": "ALLOW",
+        "required_permissions": ["filesystem.read"],
+        "reason_code": "GRANTED",
     }
 ```
 
@@ -415,7 +439,9 @@ change the generic tool contract, descriptors, and five concrete definitions to 
 def test_executor_runs_once_only_after_allow(executable_context: ToolExecutionContext) -> None:
     permission_engine = RecordingPermissionEngine(PermissionOutcome.ALLOW)
     tool = CountingTool()
-    result = asyncio.run(executor(tool, permission_engine).execute("fake_read", {}, executable_context))
+    result = asyncio.run(
+        executor(tool, permission_engine).execute("fake_read", {}, executable_context)
+    )
     assert result.status is ToolResultStatus.SUCCEEDED
     assert tool.calls == 1
     assert permission_engine.calls == 1

--- a/docs/superpowers/plans/2026-08-26-phase-7-permission-engine.md
+++ b/docs/superpowers/plans/2026-08-26-phase-7-permission-engine.md
@@ -1,0 +1,582 @@
+# Phase 7 Permission Engine Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace caller-supplied tool permission membership with a database-backed, deny-by-default, explainable, and audited Permission Engine.
+
+**Architecture:** Core permission value objects, policy/audit ports, and a central engine remain independent of SQLAlchemy. Infrastructure verifies the complete agent/run/task/project scope, resolves active PostgreSQL grants, and appends sanitized permission audit events; `ToolExecutor` executes only an `ALLOW` decision.
+
+**Tech Stack:** Python 3.12, Pydantic v2, SQLAlchemy 2, PostgreSQL 16, Alembic, asyncio, pytest, Ruff, mypy strict.
+
+**Spec:** `docs/superpowers/specs/2026-08-26-phase-7-permission-engine-design.md`
+
+## Global Constraints
+
+- Implement Phase 7 only; do not add Phase 8 skills, write/shell/network/database/deployment tools, approval workflows, role inheritance, MCP, RLS, triggers, or permission administration APIs.
+- Keep code, comments, docstrings, migrations, tests, and new documentation in English.
+- Follow strict TDD: write one behavior test, observe the expected failure, implement the minimum, and rerun focused plus neighboring tests.
+- Use real PostgreSQL migrated through Alembic for every persistence test; never use SQLite or `metadata.create_all()`.
+- Treat PostgreSQL `AgentPermission` rows as the only execution authority; profile/context permission sets cannot grant authority.
+- Use exactly the eleven V1 permission values from the approved specification.
+- Resolve permission scope with agent slug, agent run, task, and project in one coherent query.
+- Execute a tool only for `ALLOW`; both `DENY` and `ASK` are non-executing terminal outcomes.
+- Audit every completed policy decision before tool execution and fail closed if policy or permission auditing fails.
+- Persist no tool arguments, paths, source content, prompts, raw results, environment values, credentials, exception text, absolute host paths, unrelated grants, grantor identity, or expiry values in permission audit data.
+- Perform no retries, fallback, network calls, caches, implicit grants, wildcard matching, background work, commit, rollback, or resource close.
+- Preserve `CLAUDE.local.md` as untracked local state; never stage it.
+
+---
+
+### Task 1: Canonical permission types and safe errors
+
+**Files:**
+- Modify: `core/enums.py`
+- Replace: `core/permissions/__init__.py`
+- Create: `core/permissions/types.py`
+- Create: `core/permissions/errors.py`
+- Create: `tests/permissions/__init__.py`
+- Create: `tests/permissions/test_types.py`
+
+**Interfaces:**
+- Produces: `Permission`, `PermissionOutcome`, `PermissionReasonCode`, `PermissionRequest`, `PolicyRequest`, `PermissionDecision`, and `ToolPermission`.
+- Produces: sanitized `PermissionError`, `PermissionInputError`, `PermissionPolicyError`, and `PermissionAuditError`.
+
+- [ ] **Step 1: Write the failing canonical-enum test**
+
+```python
+def test_permission_enum_contains_exactly_v1_values() -> None:
+    assert tuple(permission.value for permission in Permission) == (
+        "filesystem.read", "filesystem.write", "git.read", "git.write",
+        "shell.execute", "tests.execute", "network.access", "database.read",
+        "database.write", "deployment.staging", "deployment.production",
+    )
+```
+
+- [ ] **Step 2: Run the focused test and verify RED**
+
+Run: `.venv/bin/pytest tests/permissions/test_types.py::test_permission_enum_contains_exactly_v1_values -q`  
+Expected: collection fails because `Permission` and Phase 7 types do not exist.
+
+- [ ] **Step 3: Add the shared enum and strict immutable models**
+
+Implement uppercase enum names with the exact lowercase values. Use `ConfigDict(frozen=True,
+extra="forbid", hide_input_in_errors=True)`, existing identifier syntax, bounded immutable sets,
+UUID scope fields, timezone-aware UTC timestamps, and constant-safe messages.
+
+```python
+class PermissionOutcome(StrEnum):
+    ALLOW = "ALLOW"
+    DENY = "DENY"
+    ASK = "ASK"
+
+
+class PermissionRequest(_ImmutablePermissionModel):
+    agent_id: Identifier
+    agent_run_id: UUID
+    project_id: UUID
+    task_id: UUID
+    tool_name: Identifier
+    risk_level: ToolRiskLevel
+    required_permission_ids: IdentifierSet
+    correlation_id: UUID
+```
+
+- [ ] **Step 4: Add strictness, immutability, unknown, and leak-resistance tests**
+
+Cover mutable inputs copied to frozensets, blank/oversized identifiers, extras, malformed UUIDs,
+naive timestamps, model mutation, unknown permission IDs retained only at the outer request, and
+validation messages that do not echo rejected marker values.
+
+- [ ] **Step 5: Implement canonical policy values and error hierarchy**
+
+`PolicyRequest` contains `frozenset[Permission]`; `ToolPermission` maps one tool to canonical
+permissions; `PermissionDecision` requires consistent outcome/reason combinations and contains only
+scope, sorted required permission values, one reason, safe message, correlation ID, and UTC time.
+
+- [ ] **Step 6: Run focused quality checks**
+
+Run: `.venv/bin/pytest tests/permissions/test_types.py -q`  
+Run: `.venv/bin/ruff check core/enums.py core/permissions tests/permissions`  
+Run: `.venv/bin/mypy core/enums.py core/permissions tests/permissions`
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add core/enums.py core/permissions tests/permissions
+git commit -m "feat(permissions): add strict permission contracts"
+```
+
+---
+
+### Task 2: AgentPermission model and reversible Alembic migration
+
+**Files:**
+- Modify: `infrastructure/database/models/organization.py`
+- Modify: `infrastructure/database/models/__init__.py`
+- Create: `alembic/versions/20260826_0003_permission_engine.py`
+- Create: `tests/database/test_permission_models.py`
+- Modify: `tests/database/test_migrations.py`
+
+**Interfaces:**
+- Consumes: `core.enums.Permission`, existing `AuditActorType`, ORM base mixins, `Agent`, and `Project`.
+- Produces: ORM `AgentPermission` and migration revision `20260826_0003`.
+
+- [ ] **Step 1: Write failing ORM metadata and constraint tests**
+
+```python
+def test_agent_permission_has_required_columns_and_indexes() -> None:
+    table = AgentPermission.__table__
+    assert set(table.columns) == {
+        "id", "agent_id", "permission", "project_id", "granted_by_actor_type",
+        "granted_by_actor_id", "reason", "expires_at", "revoked_at", "created_at",
+    }
+    assert table.c.permission.type.name == "permission"
+```
+
+Add real-PostgreSQL tests proving an `AGENT` grantor, expiry before creation, revocation before
+creation, duplicate global grants, and duplicate project grants fail; matching permissions across
+different projects remain valid.
+
+- [ ] **Step 2: Run the model test and verify RED**
+
+Run: `.venv/bin/pytest tests/database/test_permission_models.py -q`  
+Expected: collection fails because `AgentPermission` does not exist.
+
+- [ ] **Step 3: Implement the minimal ORM model and relationships**
+
+Use UUID/UTC primitives from `database/base.py`, `Enum(Permission, name="permission")`, bounded
+strings, timezone-aware timestamps, check constraints, partial unique indexes for global/project
+scope, and lookup/expiry indexes. Add `permissions` relationships to `Agent` and `Project` without
+delete cascades.
+
+- [ ] **Step 4: Write migration upgrade/downgrade tests before the migration**
+
+Extend the migration suite to upgrade from `20260825_0002` to head, inspect the enum/table/indexes,
+downgrade to `20260825_0002`, verify both table and enum are absent, and re-upgrade to head.
+
+- [ ] **Step 5: Run the migration test and verify RED**
+
+Run: `.venv/bin/pytest tests/database/test_migrations.py -q`  
+Expected: failure because revision `20260826_0003` and `agent_permissions` are absent.
+
+- [ ] **Step 6: Implement the reversible migration**
+
+Create the enum before the table; create named foreign keys, checks, lookup indexes, and two partial
+unique indexes. Downgrade in reverse dependency order and explicitly drop the PostgreSQL enum.
+
+- [ ] **Step 7: Run model, migration, and schema checks**
+
+Run: `.venv/bin/pytest tests/database/test_permission_models.py tests/database/test_migrations.py tests/database/test_constraints.py -q`  
+Run: `.venv/bin/ruff check infrastructure/database alembic/versions tests/database`  
+Run: `.venv/bin/mypy infrastructure/database alembic/versions tests/database`
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add core/enums.py infrastructure/database/models alembic/versions tests/database
+git commit -m "feat(database): persist scoped agent permissions"
+```
+
+---
+
+### Task 3: Provider-neutral policy and deterministic policy engine
+
+**Files:**
+- Create: `core/permissions/policy.py`
+- Create: `core/permissions/audit.py`
+- Create: `core/permissions/engine.py`
+- Modify: `core/permissions/__init__.py`
+- Create: `tests/permissions/fakes.py`
+- Create: `tests/permissions/test_engine.py`
+
+**Interfaces:**
+- Consumes: Task 1 value objects.
+- Produces: `PermissionPolicy.evaluate(request, evaluated_at) -> PermissionDecision`, `PermissionAuditRecorder.record(decision)`, and `PermissionEngine.evaluate(request) -> PermissionDecision`.
+
+- [ ] **Step 1: Write a failing allowed-decision lifecycle test**
+
+```python
+def test_engine_canonicalizes_evaluates_once_and_audits_allow(valid_request: PermissionRequest) -> None:
+    policy = RecordingPolicy(PermissionOutcome.ALLOW, PermissionReasonCode.GRANTED)
+    audit = RecordingPermissionAudit()
+    decision = PermissionEngine(policy, audit, clock=fixed_clock).evaluate(valid_request)
+    assert decision.outcome is PermissionOutcome.ALLOW
+    assert policy.calls == 1
+    assert audit.decisions == [decision]
+```
+
+- [ ] **Step 2: Run the focused test and verify RED**
+
+Run: `.venv/bin/pytest tests/permissions/test_engine.py::test_engine_canonicalizes_evaluates_once_and_audits_allow -q`  
+Expected: failure because policy, audit, and engine contracts do not exist.
+
+- [ ] **Step 3: Implement one canonical ALLOW path**
+
+Capture the injected UTC clock once, reconstruct the strict request, convert every ID with
+`Permission(identifier)`, build `PolicyRequest`, call the policy exactly once, strictly revalidate
+its decision, call audit exactly once, and return it. Injected dependencies are never closed.
+
+- [ ] **Step 4: Add unknown, failure, ownership, and no-retry tests**
+
+Prove unknown permission returns audited `DENY/UNKNOWN_PERMISSION` without policy invocation;
+malformed requests fail before policy; policy errors raise sanitized `PermissionPolicyError`;
+audit errors raise sanitized `PermissionAuditError`; mismatched or malformed policy decisions fail
+closed; and no retry/commit/rollback/close methods are called.
+
+- [ ] **Step 5: Implement deny-by-default and sanitized failures**
+
+Unknown permission decisions contain no rejected identifier. Clear references to raw request
+values in failure paths. Do not audit an evaluation that failed before a coherent decision exists;
+do require audit success before returning any completed decision.
+
+- [ ] **Step 6: Run focused and neighboring checks**
+
+Run: `.venv/bin/pytest tests/permissions -q`  
+Run: `.venv/bin/ruff check core/permissions tests/permissions`  
+Run: `.venv/bin/mypy core/permissions tests/permissions`
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add core/permissions tests/permissions
+git commit -m "feat(permissions): enforce audited policy evaluation"
+```
+
+---
+
+### Task 4: SQLAlchemy scope and grant policy
+
+**Files:**
+- Create: `infrastructure/permissions/__init__.py`
+- Create: `infrastructure/permissions/policy.py`
+- Create: `tests/database/permission_fixtures.py`
+- Create: `tests/database/test_permission_policy.py`
+
+**Interfaces:**
+- Consumes: `PermissionPolicy`, `PolicyRequest`, `PermissionDecision`, `AgentPermission`, `AgentRun`, `Agent`, `Task`, and caller-owned `Session`.
+- Produces: `SQLAlchemyPermissionPolicy.evaluate(request, evaluated_at) -> PermissionDecision`.
+
+- [ ] **Step 1: Write failing global and project ALLOW tests**
+
+```python
+def test_policy_allows_active_global_grant(db_session: Session, policy_scope: PolicyScope) -> None:
+    add_permission(db_session, policy_scope.agent, Permission.FILESYSTEM_READ)
+    decision = SQLAlchemyPermissionPolicy(db_session).evaluate(
+        policy_scope.request({Permission.FILESYSTEM_READ}), policy_scope.now
+    )
+    assert decision.outcome is PermissionOutcome.ALLOW
+    assert decision.reason_code is PermissionReasonCode.GRANTED
+```
+
+- [ ] **Step 2: Run the focused test and verify RED**
+
+Run: `.venv/bin/pytest tests/database/test_permission_policy.py::test_policy_allows_active_global_grant -q`  
+Expected: import failure because the SQLAlchemy policy does not exist.
+
+- [ ] **Step 3: Implement coherent scope verification and active-grant resolution**
+
+Use one joined scope query over `AgentRun`, `Agent`, and `Task` constrained by all supplied IDs and
+slug. Load only required permission rows where project scope is global or matches, `revoked_at IS
+NULL`, and expiry is absent or after the single evaluation timestamp. Return constant-safe
+decisions and never expose grant rows.
+
+- [ ] **Step 4: Add complete policy matrix tests**
+
+Cover no grant, one missing permission from a multi-permission request, expired, revoked,
+cross-project, wrong agent slug, wrong run/task/project, missing rows, global/project union,
+autonomy levels 0–4, and mandatory `deployment.production` `ASK`. Prove rule precedence exactly
+matches the specification.
+
+- [ ] **Step 5: Implement autonomy and approval rules**
+
+Keep the minimum-level mapping immutable and exhaustive for all eleven enum values. Missing grants
+must return `DENY` before autonomy is considered. Production returns human `ASK` even at autonomy 4
+or 5. No query is retried or cached.
+
+- [ ] **Step 6: Add transaction/resource ownership and sanitization tests**
+
+Patch session `commit`, `rollback`, and `close` to fail if called. Force a SQLAlchemy error and
+assert only `PermissionPolicyError` with a constant message escapes; no UUID, slug, SQL, password,
+or database URL appears.
+
+- [ ] **Step 7: Run PostgreSQL and quality checks**
+
+Run: `.venv/bin/pytest tests/database/test_permission_policy.py tests/database/test_permission_models.py -q`  
+Run: `.venv/bin/ruff check infrastructure/permissions tests/database/permission_fixtures.py tests/database/test_permission_policy.py`  
+Run: `.venv/bin/mypy infrastructure/permissions tests/database/permission_fixtures.py tests/database/test_permission_policy.py`
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add infrastructure/permissions tests/database
+git commit -m "feat(permissions): resolve scoped PostgreSQL grants"
+```
+
+---
+
+### Task 5: Append-only permission decision audit
+
+**Files:**
+- Create: `infrastructure/permissions/audit.py`
+- Modify: `infrastructure/permissions/__init__.py`
+- Create: `tests/database/test_permission_audit.py`
+
+**Interfaces:**
+- Consumes: `PermissionAuditRecorder`, `PermissionDecision`, caller-owned `Session`, and `AuditEvent`.
+- Produces: `SQLAlchemyPermissionAuditRecorder.record(decision) -> None`.
+
+- [ ] **Step 1: Write a failing sanitized ALLOW audit test**
+
+```python
+def test_allow_decision_appends_sanitized_event(db_session: Session, allowed_decision: PermissionDecision) -> None:
+    SQLAlchemyPermissionAuditRecorder(db_session).record(allowed_decision)
+    event = db_session.scalar(select(AuditEvent).where(AuditEvent.event_type == "PERMISSION_EVALUATED"))
+    assert event is not None
+    assert event.result is AuditResult.SUCCEEDED
+    assert event.data == {
+        "decision": "ALLOW", "required_permissions": ["filesystem.read"], "reason_code": "GRANTED"
+    }
+```
+
+- [ ] **Step 2: Run the focused test and verify RED**
+
+Run: `.venv/bin/pytest tests/database/test_permission_audit.py::test_allow_decision_appends_sanitized_event -q`  
+Expected: import failure because the recorder does not exist.
+
+- [ ] **Step 3: Implement strict event mapping and mandatory flush**
+
+Map `ALLOW` to `AuditResult.SUCCEEDED`; map `DENY` and `ASK` to `AuditResult.DENIED`. Use fixed
+event/action/resource names and only decision, sorted required permissions, and reason code in
+JSON. Strictly reconstruct the decision, append, and flush; never commit, rollback, or close.
+
+- [ ] **Step 4: Add denial, ASK, leakage, rollback, and append-only tests**
+
+Persist each outcome; include secret/path/SQL markers in nearby objects and exception causes;
+assert none appear in event repr or public errors. Prove caller rollback removes the event and
+existing append-only protection rejects event update/delete.
+
+- [ ] **Step 5: Implement safe audit failure mapping**
+
+Convert invalid decisions and persistence failures to constant `PermissionAuditError` messages,
+without attempting rollback or a compensating audit event.
+
+- [ ] **Step 6: Run focused and neighboring checks**
+
+Run: `.venv/bin/pytest tests/database/test_permission_audit.py tests/database/test_append_only.py -q`  
+Run: `.venv/bin/ruff check infrastructure/permissions tests/database/test_permission_audit.py`  
+Run: `.venv/bin/mypy infrastructure/permissions tests/database/test_permission_audit.py`
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add infrastructure/permissions tests/database/test_permission_audit.py
+git commit -m "feat(permissions): append sanitized policy audits"
+```
+
+---
+
+### Task 6: Tool registry and executor integration
+
+**Files:**
+- Modify: `core/tools/tool.py`
+- Modify: `core/tools/registry.py`
+- Modify: `core/tools/types.py`
+- Modify: `core/tools/executor.py`
+- Modify: `core/tools/errors.py`
+- Modify: `infrastructure/tools/filesystem.py`
+- Modify: `infrastructure/tools/git.py`
+- Modify: `infrastructure/tools/__init__.py`
+- Modify: `tests/tools/fakes.py`
+- Modify: `tests/tools/test_registry.py`
+- Modify: `tests/tools/test_default_registry.py`
+- Modify: `tests/tools/test_executor.py`
+- Modify: `tests/tools/test_filesystem_tools.py`
+- Modify: `tests/tools/test_git_tools.py`
+
+**Interfaces:**
+- Consumes: `Permission`, `PermissionEngine`, existing registry/audit/tool contracts.
+- Produces: `ToolExecutor(registry, audit_recorder, permission_engine)` where only `ALLOW` reaches `Tool.execute()`.
+
+- [ ] **Step 1: Write failing canonical registry tests**
+
+Assert `required_permissions` are strict `frozenset[Permission]`, all three filesystem tools require
+only `Permission.FILESYSTEM_READ`, both Git tools require only `Permission.GIT_READ`, and string or
+unknown permission definitions fail registry construction safely.
+
+- [ ] **Step 2: Verify RED and migrate tool definitions**
+
+Run: `.venv/bin/pytest tests/tools/test_registry.py tests/tools/test_default_registry.py -q`  
+Expected: failures because definitions still contain strings and workspace-specific aliases. Then
+change the generic tool contract, descriptors, and five concrete definitions to canonical enums.
+
+- [ ] **Step 3: Write failing executor ALLOW/DENY/ASK tests**
+
+```python
+def test_executor_runs_once_only_after_allow(executable_context: ToolExecutionContext) -> None:
+    permission_engine = RecordingPermissionEngine(PermissionOutcome.ALLOW)
+    tool = CountingTool()
+    result = asyncio.run(executor(tool, permission_engine).execute("fake_read", {}, executable_context))
+    assert result.status is ToolResultStatus.SUCCEEDED
+    assert tool.calls == 1
+    assert permission_engine.calls == 1
+```
+
+Add tests proving `DENY`, `ASK`, unknown permission, policy failure, and permission-audit failure
+execute zero times; `ASK` returns `APPROVAL_REQUIRED`; permission failures finish the existing tool
+audit safely; unknown/undeclared tools do not call permission evaluation.
+
+- [ ] **Step 4: Verify focused RED**
+
+Run: `.venv/bin/pytest tests/tools/test_executor.py -q`  
+Expected: constructor/signature and behavior failures because the executor still reads context
+membership directly.
+
+- [ ] **Step 5: Integrate the permission engine and remove runtime authority**
+
+Remove `permission_ids` from `ToolExecutionContext`. After lookup and declared-tool checks, build
+one `PermissionRequest` from validated scope plus registered requirements. Map outcomes exactly;
+add safe tool error codes `APPROVAL_REQUIRED` and `PERMISSION_AUDIT_FAILED`. Preserve one attempt,
+timeout, cancellation, output validation, and tool audit semantics.
+
+- [ ] **Step 6: Add forged-context and regression tests**
+
+Prove `model_copy` cannot inject permissions; AgentProfile permission IDs cannot bypass the engine;
+raw arguments never reach permission evaluation/audit; cancellation still propagates immediately;
+and all five concrete tools retain path, process, size, and timeout guarantees.
+
+- [ ] **Step 7: Run all tool and permission tests**
+
+Run: `.venv/bin/pytest tests/tools tests/permissions -q`  
+Run: `.venv/bin/ruff check core/tools core/permissions infrastructure/tools tests/tools tests/permissions`  
+Run: `.venv/bin/mypy core/tools core/permissions infrastructure/tools tests/tools tests/permissions`
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add core/tools infrastructure/tools tests/tools
+git commit -m "feat(tools): require Permission Engine authorization"
+```
+
+---
+
+### Task 7: Real-PostgreSQL end-to-end permission enforcement
+
+**Files:**
+- Modify: `tests/database/tool_fixtures.py`
+- Modify: `tests/database/test_tool_execution.py`
+- Create: `tests/database/test_permission_tool_execution.py`
+
+**Interfaces:**
+- Consumes: real migrated PostgreSQL, `SQLAlchemyPermissionPolicy`, `SQLAlchemyPermissionAuditRecorder`, `PermissionEngine`, `SQLAlchemyToolAuditRecorder`, and `ToolExecutor`.
+- Produces: acceptance evidence that persisted grants—not runtime input—control tool execution atomically.
+
+- [ ] **Step 1: Write failing end-to-end ALLOW test**
+
+Create a real project/agent/task/run, persist one active `filesystem.read` grant, execute
+`ReadFileTool`, and assert one `PERMISSION_EVALUATED` event precedes successful terminal tool audit.
+Assert no source content, relative filename, or absolute temporary root appears in either audit row.
+
+- [ ] **Step 2: Run the focused test and verify RED**
+
+Run: `.venv/bin/pytest tests/database/test_permission_tool_execution.py::test_persisted_grant_allows_audited_read -q`  
+Expected: failure until the real adapters are composed correctly.
+
+- [ ] **Step 3: Add the complete enforcement matrix**
+
+Cover missing, expired, revoked, cross-project, partial, forged scope, insufficient autonomy,
+production `ASK`, unknown/undeclared tools, audit failure, and caller rollback. For every non-ALLOW
+case assert the concrete tool executed zero times and terminal records contain stable codes only.
+
+- [ ] **Step 4: Implement only composition/helper corrections required by acceptance tests**
+
+Keep production composition explicit. Do not add a global session, singleton engine, permission
+cache, grant mutation service, or Agent loop.
+
+- [ ] **Step 5: Run PostgreSQL and append-only regression suites**
+
+Run: `.venv/bin/pytest tests/database/test_permission_tool_execution.py tests/database/test_tool_execution.py tests/database/test_permission_policy.py tests/database/test_permission_audit.py tests/database/test_append_only.py -q`  
+Run: `.venv/bin/ruff check tests/database`  
+Run: `.venv/bin/mypy tests/database`
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add tests/database
+git commit -m "test(permissions): verify PostgreSQL tool enforcement"
+```
+
+---
+
+### Task 8: Documentation, checklist, and complete verification
+
+**Files:**
+- Create: `docs/permissions.md`
+- Create: `docs/adr/0007-database-backed-permission-authority.md`
+- Modify: `docs/adr/README.md`
+- Modify: `docs/tools.md`
+- Modify: `README.md`
+- Modify: `AGENTS.md`
+- Modify: `SYNAPSEOS_DEVELOPMENT_CHECKLIST.md`
+
+**Interfaces:**
+- Documents: public contracts, composition, policy order, scopes, expiry/revocation, autonomy, `ASK`, audit minimization, transaction ownership, and deliberate Phase 8 boundary.
+
+- [ ] **Step 1: Write permission documentation and ADR**
+
+Document a composition example with one caller-owned session shared by policy and both audit
+recorders. Record the selected database-authority approach and rejected runtime-context and role
+inheritance alternatives. State clearly that Phase 7 provides no permission mutation API and no
+approval workflow.
+
+- [ ] **Step 2: Update repository status and only verified Phase 7 boxes**
+
+Update README and AGENTS in English. Mark exactly the eleven Phase 7 permissions and seven Phase 7
+checklist items only after tests prove them. Leave every Phase 8 and later checkbox unchanged.
+
+- [ ] **Step 3: Run fresh complete verification**
+
+Run: `.venv/bin/pytest`  
+Expected: all tests pass against real PostgreSQL with no warnings.
+
+Run: `.venv/bin/ruff check .`  
+Expected: `All checks passed!`
+
+Run: `.venv/bin/ruff format --check .`  
+Expected: every file already formatted.
+
+Run: `.venv/bin/mypy .`  
+Expected: no issues.
+
+Run: `docker compose exec -T api alembic current`  
+Expected: `20260826_0003 (head)`.
+
+Run: `docker compose exec -T api alembic check`  
+Expected: no new upgrade operations.
+
+- [ ] **Step 4: Verify container and API health**
+
+Run: `docker compose up -d --build`  
+Run: `docker compose ps`  
+Run: `curl --fail --silent http://localhost:8000/health`  
+Expected: database and API healthy; response `{"status":"ok"}`.
+
+- [ ] **Step 5: Perform scope, secret, contributor, and diff audit**
+
+Run: `git diff --check`  
+Run: `git status --short`  
+Run: `git diff --name-only phase-6/tool-registry...HEAD`  
+Scan tracked Phase 7 changes for high-confidence secret patterns and `Co-Authored-By` trailers.
+Confirm no Phase 8 implementation, permission administration API, write/shell/MCP tool, generated
+report, raw-content persistence, or `CLAUDE.local.md` is tracked.
+
+- [ ] **Step 6: Commit verified documentation**
+
+```bash
+git add README.md AGENTS.md SYNAPSEOS_DEVELOPMENT_CHECKLIST.md docs
+git commit -m "docs(permissions): document verified Phase 7 authority"
+```
+
+- [ ] **Step 7: Push and open the stacked Pull Request**
+
+Push `phase-7/permission-engine` and open a PR with base `phase-6/tool-registry`. Include test,
+Alembic, Docker, security, and scope evidence. Do not merge or start Phase 8.

--- a/docs/superpowers/specs/2026-08-26-phase-7-permission-engine-design.md
+++ b/docs/superpowers/specs/2026-08-26-phase-7-permission-engine-design.md
@@ -1,0 +1,375 @@
+# Phase 7 Permission Engine Design
+
+**Date:** 2026-08-26  
+**Status:** Approved in conversation  
+**Scope:** Phase 7 only
+
+## Objective
+
+Phase 7 replaces the caller-supplied permission membership check from Phase 6 with a
+deny-by-default, explainable, audited permission engine. An agent may use a tool only when the
+registered tool requires known Phase 7 permissions, the database contains active grants for that
+agent and scope, the agent run belongs to the same agent/task/project, and the policy returns
+`ALLOW`.
+
+The database is the source of execution authority. Permission identifiers declared on an
+`AgentProfile` or supplied in a tool execution context are descriptive inputs and cannot grant
+authority. Agents receive no API that creates, edits, revokes, or extends their own grants.
+
+## Included scope
+
+Phase 7 includes:
+
+- the eleven canonical V1 permissions;
+- strict immutable permission requests and decisions;
+- `AgentPermission` persistence with optional project scope and expiry;
+- immutable `ToolPermission` requirements derived from registered tools;
+- a provider-neutral `PermissionPolicy` contract;
+- a central `PermissionEngine` that validates, evaluates, and audits each decision;
+- a SQLAlchemy policy adapter that verifies run scope and resolves active grants;
+- `ALLOW`, `DENY`, and non-executing `ASK` outcomes with stable reason codes;
+- migration of Phase 6 filesystem tools to canonical `filesystem.read`;
+- integration with `ToolExecutor` before tool input validation or execution;
+- append-only permission decision audit events with allowlisted metadata;
+- unit tests and real-PostgreSQL integration tests built through Alembic.
+
+## Explicit exclusions
+
+Phase 7 does not include:
+
+- a permission administration API, dashboard, CLI, or agent-accessible grant method;
+- an approval workflow or approval token that can turn `ASK` into `ALLOW`;
+- role templates, department inheritance, wildcard permissions, capability bundles, or delegation;
+- automatic reputation, seniority, or confidence-based permission changes;
+- PostgreSQL RLS, database roles, triggers, or production credential enforcement;
+- write, shell, test, network, database, or deployment tools;
+- Agent runtime orchestration, skills, MCP, workspace management, retries, or Phase 8 behavior.
+
+The enum contains permissions for later tools, but this phase does not implement those tools.
+
+## Approaches considered
+
+### Database-backed source of authority — selected
+
+Resolve permissions from persisted `AgentPermission` rows after verifying the complete execution
+scope. This prevents an agent or caller from gaining authority by modifying a runtime profile or
+request object and supports expiry, project scoping, and audit reconstruction.
+
+### Execution-context membership only — rejected
+
+Keeping `permission_ids` in `ToolExecutionContext` as authority would be small, but the set is
+caller-provided and therefore forgeable. It cannot satisfy “agents must never grant themselves a
+permission.”
+
+### Role templates plus persisted overrides — deferred
+
+Role inheritance would reduce grant administration for a mature company model, but introduces
+precedence, revocation, department scope, and policy migration before any permission administration
+workflow exists. Explicit grants are safer and sufficient for Phase 7.
+
+## Architecture
+
+```text
+Caller
+  -> ToolExecutor
+     -> begin ToolCall audit
+     -> ToolRegistry lookup
+     -> declared-tool check
+     -> PermissionEngine.evaluate(request)
+        -> validate known Permission values
+        -> SQLAlchemyPermissionPolicy.evaluate(request)
+           -> verify agent/run/task/project scope
+           -> load active global + project AgentPermission grants
+           -> apply autonomy and approval policy
+        -> PermissionAuditRecorder.record(decision)
+     -> execute only when decision is ALLOW
+     -> finish ToolCall audit
+  -> ToolResult or propagated cancellation
+```
+
+`PermissionEngine` lives in core and imports neither SQLAlchemy nor tool adapters. The SQLAlchemy
+policy and audit recorder live in infrastructure. The executor receives the permission engine as an
+injected dependency and owns none of its resources.
+
+## Module boundaries
+
+```text
+core/permissions/
+├── __init__.py       public Phase 7 API
+├── types.py          Permission, request, decision, outcomes, reason codes
+├── errors.py         sanitized permission boundary errors
+├── policy.py         PermissionPolicy and grant-resolution contracts
+├── audit.py          permission audit port
+└── engine.py         validation, policy invocation, and mandatory audit
+
+infrastructure/permissions/
+├── __init__.py       concrete adapter exports
+├── policy.py         SQLAlchemy scope/grant resolver
+└── audit.py          append-only AuditEvent recorder
+
+infrastructure/database/models/
+└── organization.py   AgentPermission ORM model and relationships
+```
+
+The canonical `Permission` enum is genuinely shared by persistence, tools, agents, and policy, so
+it belongs in `core/enums.py`. Permission-specific outcomes and reason codes remain in
+`core/permissions/types.py` because they are not persisted as PostgreSQL enum columns.
+
+## Canonical permissions
+
+The persisted enum names are uppercase Python identifiers with the following lowercase values:
+
+```python
+class Permission(StrEnum):
+    FILESYSTEM_READ = "filesystem.read"
+    FILESYSTEM_WRITE = "filesystem.write"
+    GIT_READ = "git.read"
+    GIT_WRITE = "git.write"
+    SHELL_EXECUTE = "shell.execute"
+    TESTS_EXECUTE = "tests.execute"
+    NETWORK_ACCESS = "network.access"
+    DATABASE_READ = "database.read"
+    DATABASE_WRITE = "database.write"
+    DEPLOYMENT_STAGING = "deployment.staging"
+    DEPLOYMENT_PRODUCTION = "deployment.production"
+```
+
+Unknown identifiers never degrade to strings. Direct engine evaluation returns an audited `DENY`
+with reason `UNKNOWN_PERMISSION`; persisted unknown values are rejected by PostgreSQL and strict
+model validation.
+
+Phase 6 permission names are normalized as follows:
+
+| Tool | Phase 7 requirement |
+|---|---|
+| `read_file` | `filesystem.read` |
+| `list_files` | `filesystem.read` |
+| `search_text` | `filesystem.read` |
+| `git_status` | `git.read` |
+| `git_diff` | `git.read` |
+
+Listing and literal search are forms of filesystem read authority rather than separate V1
+permissions. No compatibility alias is accepted after migration because aliases create ambiguous
+authority.
+
+## Persistence model
+
+`AgentPermission` is the materialized source of active permission grants:
+
+- `id`: UUID primary key;
+- `agent_id`: required foreign key to `agents`, `RESTRICT` on delete;
+- `permission`: required PostgreSQL `permission` enum;
+- `project_id`: nullable foreign key to `projects`, `RESTRICT` on delete;
+- `granted_by_actor_type`: required existing `AuditActorType`;
+- `granted_by_actor_id`: required bounded identifier;
+- `reason`: required bounded text;
+- `expires_at`: nullable timezone-aware timestamp;
+- `revoked_at`: nullable timezone-aware timestamp;
+- `created_at`: UTC timestamp.
+
+Database constraints require:
+
+- `granted_by_actor_type <> AGENT` so an agent-authored grant cannot be persisted;
+- `expires_at IS NULL OR expires_at > created_at`;
+- `revoked_at IS NULL OR revoked_at >= created_at`;
+- one global row per `(agent_id, permission)` where `project_id IS NULL`;
+- one project row per `(agent_id, project_id, permission)` where `project_id IS NOT NULL`.
+
+Indexes support lookup by `(agent_id, project_id, permission)`, expiry, and active/revoked state.
+An active grant has `revoked_at IS NULL` and `expires_at IS NULL OR expires_at > evaluation_time`.
+Global and matching-project grants are unioned; grants for another project never apply.
+
+Phase 7 intentionally provides read-only permission repositories and policy adapters. Tests and
+migrations may construct rows directly, but normal agent-facing code has no grant, update, delete,
+or revoke operation. A future human-governed administration phase will own mutation workflows and
+their separate audit requirements.
+
+## Core value objects
+
+### ToolPermission
+
+`ToolPermission` is a strict frozen mapping of a validated tool name to a non-empty bounded set of
+canonical `Permission` values. It is derived from the immutable registered tool definition, never
+from invocation arguments or an agent response.
+
+Concrete `Tool.required_permissions` and exposed `ToolDefinition.required_permissions` become
+`frozenset[Permission]`. Registry construction rejects strings, unknown values, mutable sets, and
+empty requirements with a sanitized `ToolDefinitionError`.
+
+### PermissionRequest
+
+The request is strict and frozen and contains only authorization-relevant metadata:
+
+- agent slug, agent run UUID, project UUID, and task UUID;
+- registered tool name and risk level;
+- immutable required permission identifiers;
+- correlation UUID.
+
+It contains no tool arguments, paths, source content, prompts, response data, environment values,
+credentials, or database session. The engine accepts raw permission identifiers only at its outer
+boundary so it can fail closed and audit `UNKNOWN_PERMISSION`; validated policy adapters receive
+canonical enum values only.
+
+### PermissionDecision
+
+The immutable decision contains:
+
+- `outcome`: `ALLOW`, `DENY`, or `ASK`;
+- canonical required permissions when valid;
+- stable `reason_code`;
+- a bounded constant-safe message;
+- correlation and execution-scope identifiers;
+- evaluation timestamp.
+
+It does not expose all grants held by an agent, grantor identity, expiry values, internal SQL
+errors, or policy implementation details.
+
+## Policy semantics
+
+Evaluation is deterministic and deny-by-default. Rules are applied in this order:
+
+1. malformed request or unknown permission → `DENY / UNKNOWN_PERMISSION`;
+2. unknown tool, undeclared tool, or invalid execution scope remain executor-level denial reasons;
+3. agent/run/task/project mismatch or missing row → `DENY / INVALID_SCOPE`;
+4. no active matching grant for every requirement → `DENY / MISSING_PERMISSION`;
+5. any `deployment.production` requirement → `ASK / HUMAN_APPROVAL_REQUIRED`;
+6. insufficient autonomy for a granted permission → `ASK / AUTONOMY_APPROVAL_REQUIRED`;
+7. otherwise → `ALLOW / GRANTED`.
+
+Minimum autonomy levels follow specification §40:
+
+| Permission | Minimum autonomy |
+|---|---:|
+| `filesystem.read`, `git.read`, `database.read` | 0 |
+| `filesystem.write`, `tests.execute` | 1 |
+| `git.write` | 2 |
+| `network.access`, `shell.execute`, `database.write`, `deployment.staging` | 3 |
+| `deployment.production` | 4 plus mandatory human approval |
+
+The table is policy, not an implied permission grant. Both an active grant and sufficient autonomy
+are required. Phase 7 has no approval artifact, so `ASK` is terminal and non-executing. It is
+returned to callers as a denied tool result with safe code `APPROVAL_REQUIRED`.
+
+The policy performs no retry, fallback, network call, cache, implicit grant, wildcard match, or
+permission inference from role names.
+
+## Tool executor integration
+
+`ToolExecutionContext.permission_ids` is removed as execution authority. The executor creates a
+permission request only after successful registry lookup and declared-tool validation. It passes
+the registered definition’s immutable requirements to `PermissionEngine`.
+
+The order preserves Phase 6 guarantees:
+
+1. validate context and invocation shape;
+2. begin mandatory `ToolCall` audit before lookup;
+3. deny unknown or undeclared tools without policy access;
+4. evaluate and audit permission policy;
+5. execute only for `ALLOW`;
+6. map `DENY` to `PERMISSION_DENIED` and `ASK` to `APPROVAL_REQUIRED`;
+7. continue strict input validation, one attempt, timeout, cancellation, bounded output, and
+   terminal tool audit unchanged.
+
+A policy or permission-audit infrastructure failure fails closed with `PERMISSION_AUDIT_FAILED`;
+the tool never executes. The executor never substitutes stale profile permissions.
+
+## Permission audit
+
+Every completed policy evaluation appends one `AuditEvent` before tool execution:
+
+- actor type `AGENT` and the validated agent slug;
+- project, task, run, and correlation IDs;
+- event type `PERMISSION_EVALUATED`;
+- action `authorize_tool`;
+- resource type `TOOL` and registered tool name;
+- result `SUCCEEDED` for `ALLOW`, `DENIED` for `DENY` and `ASK`;
+- allowlisted data: decision, sorted required permission values, and stable reason code.
+
+Audit data excludes agent grant inventory, grantor identity, tool arguments, paths, source content,
+prompts, exception text, SQL values, environment values, credentials, and absolute host paths.
+
+The SQLAlchemy recorder flushes the append-only event before returning but never commits, rolls
+back, or closes the caller-owned session. Audit failure raises a sanitized error and prevents tool
+execution. Existing `ToolCall` terminal audit remains separate: permission audit explains why the
+decision was made; tool audit records the invocation lifecycle and result.
+
+## Error model
+
+Stable permission reason codes include:
+
+- `GRANTED`;
+- `UNKNOWN_PERMISSION`;
+- `INVALID_SCOPE`;
+- `MISSING_PERMISSION`;
+- `HUMAN_APPROVAL_REQUIRED`;
+- `AUTONOMY_APPROVAL_REQUIRED`.
+
+Sanitized boundary errors distinguish invalid request, unavailable policy persistence, and failed
+mandatory audit without containing rejected values or exception messages. Public tool errors add
+`APPROVAL_REQUIRED` and `PERMISSION_AUDIT_FAILED`; neither exposes which unrelated permissions the
+agent holds.
+
+## Resource and ownership guarantees
+
+- Permission evaluation is synchronous, local, and bounded to indexed PostgreSQL reads.
+- The evaluation timestamp is captured once in UTC and reused for expiry decisions.
+- No cache is introduced, preventing stale permission use and invalidation complexity.
+- Exactly one policy evaluation and one permission audit event occur per registered, declared tool
+  attempt.
+- Unknown and undeclared tool attempts retain their existing tool audit but do not query permission
+  grants, avoiding capability and grant enumeration.
+- Injected policies, recorders, sessions, registries, and tools remain caller-owned.
+- No component commits, rolls back, closes, retries, or launches background work implicitly.
+- Cancellation behavior after permission evaluation remains immediate and unchanged.
+
+## Database migration
+
+One reversible Alembic revision will:
+
+1. create the PostgreSQL `permission` enum;
+2. create `agent_permissions` with its foreign keys, constraints, and indexes;
+3. create global and project-scoped uniqueness indexes;
+4. downgrade by dropping indexes/table before the enum.
+
+Alembic imports model metadata directly. Tests create schemas only by applying Alembic migrations
+to real PostgreSQL; `metadata.create_all()` and SQLite remain forbidden.
+
+## Testing strategy
+
+Strict TDD covers:
+
+- exact enum values and rejection of unknown permissions;
+- frozen request, decision, and `ToolPermission` values;
+- all policy outcomes and rule precedence;
+- deny by default for missing, expired, revoked, cross-project, and partial grants;
+- global versus project-scoped grants;
+- run/agent/task/project mismatch and forged runtime permissions;
+- autonomy thresholds and mandatory production `ASK`;
+- proof that an `AGENT` grantor violates a database constraint;
+- proof that no engine/repository mutation or self-grant API exists;
+- one permission evaluation and audit per eligible invocation;
+- no tool execution for `DENY`, `ASK`, unknown permission, invalid scope, policy failure, or audit
+  failure;
+- successful execution only after `ALLOW`;
+- sanitized permission and tool audit rows with no raw content or host data;
+- caller-owned transaction rollback removes staged permission/tool audit records;
+- migration upgrade, downgrade, re-upgrade, and schema inspection;
+- regression coverage for all Phase 6 tools, cancellation, output bounds, and append-only history;
+- full pytest, Ruff, mypy, Alembic, Docker, API health, diff, and secret checks.
+
+## Acceptance criteria
+
+Phase 7 is complete only when:
+
+- all eleven permissions exist exactly once as canonical enum values;
+- all five Phase 6 tools use canonical permissions;
+- permission authority comes from verified active PostgreSQL grants, not runtime input;
+- policy returns deterministic, explainable `ALLOW`, `DENY`, or `ASK`;
+- only `ALLOW` can reach `Tool.execute()`;
+- missing, unknown, expired, revoked, partial, cross-project, and forged authority is denied;
+- agents cannot persist grants as their own actor type and no agent-facing grant API exists;
+- every policy decision is appended to audit with allowlisted metadata;
+- tests use real PostgreSQL schemas created by Alembic;
+- complete tests, Ruff, formatting, mypy, Alembic, Docker, and health checks pass;
+- only verified Phase 7 checklist boxes are updated;
+- Phase 8 remains unimplemented.

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -4,9 +4,9 @@ Phase 6 provides a small, deny-by-default execution boundary for five read-only 
 
 | Tool | Permission | Timeout | Main output limit |
 |---|---|---:|---:|
-| `read_file` | `workspace.read` | 5 s | 256 KiB |
-| `list_files` | `workspace.list` | 5 s | 512 KiB |
-| `search_text` | `workspace.search` | 10 s | 512 KiB |
+| `read_file` | `filesystem.read` | 5 s | 256 KiB |
+| `list_files` | `filesystem.read` | 5 s | 512 KiB |
+| `search_text` | `filesystem.read` | 10 s | 512 KiB |
 | `git_status` | `git.read` | 10 s | 256 KiB |
 | `git_diff` | `git.read` | 10 s | 512 KiB |
 
@@ -19,8 +19,15 @@ validation, and audit lifecycle and is not an approved application path.
 
 ```python
 registry = create_default_tool_registry()
-recorder = SQLAlchemyToolAuditRecorder(caller_owned_session)
-executor = ToolExecutor(registry, recorder)
+permission_engine = PermissionEngine(
+    SQLAlchemyPermissionPolicy(caller_owned_session),
+    SQLAlchemyPermissionAuditRecorder(caller_owned_session),
+)
+executor = ToolExecutor(
+    registry,
+    SQLAlchemyToolAuditRecorder(caller_owned_session),
+    permission_engine,
+)
 
 result = await executor.execute(
     "read_file",
@@ -29,9 +36,10 @@ result = await executor.execute(
 )
 ```
 
-The execution context identifies an existing agent run and contains a canonical workspace root,
-the agent's declared tool IDs, and its effective permission IDs. The executor performs exactly one
-attempt and never retries or falls back. Cancellation is audited and immediately re-raised.
+The execution context identifies an existing agent run and contains a canonical workspace root and
+the agent's declared tool IDs. It carries no permission authority. The executor resolves current
+PostgreSQL grants through the Phase 7 Permission Engine, performs exactly one attempt, and never
+retries or falls back. Cancellation is audited and immediately re-raised.
 
 The SQLAlchemy recorder flushes a new `ToolCall` to obtain its ID, appends one terminal
 `AuditEvent`, and flushes that terminal state before returning. It never commits, rolls back, or
@@ -83,9 +91,9 @@ Public results use stable statuses (`SUCCEEDED`, `FAILED`, `DENIED`, `TIMED_OUT`
 codes. Propagated cancellation is represented as `CANCELLED` in the append-only audit event and as
 a failed tool-call record with the safe `CANCELLED` code.
 
-## Deliberate boundary
+## Permission boundary
 
-Phase 6 checks only that the requested tool was declared and that every required permission ID is
-present. Policy evaluation, `ALLOW`/`DENY`/`ASK`, approval gates, risk-dependent autonomy, and
-permission provenance belong to the Phase 7 Permission Engine. This phase also excludes write
-tools, free-form shell execution, MCP, skill loading, agent loops, retries, and dynamic discovery.
+Phase 7 checks persisted grant scope, activity, and autonomy before execution. Only `ALLOW`
+executes; `DENY` and `ASK` return stable terminal errors. See [Permission engine](permissions.md)
+for the policy and audit contract. Write tools, free-form shell execution, MCP, skill loading,
+agent loops, retries, approval continuation, and dynamic discovery remain excluded.

--- a/infrastructure/database/models/__init__.py
+++ b/infrastructure/database/models/__init__.py
@@ -2,11 +2,12 @@
 
 from infrastructure.database.models.execution import AgentRun, Decision, ToolCall
 from infrastructure.database.models.history import AgentScore, AuditEvent
-from infrastructure.database.models.organization import Agent, Project
+from infrastructure.database.models.organization import Agent, AgentPermission, Project
 from infrastructure.database.models.work import Task, TaskDependency
 
 __all__ = [
     "Agent",
+    "AgentPermission",
     "AgentRun",
     "AgentScore",
     "AuditEvent",

--- a/infrastructure/database/models/organization.py
+++ b/infrastructure/database/models/organization.py
@@ -2,14 +2,22 @@
 
 from __future__ import annotations
 
+import uuid
+from datetime import datetime
 from decimal import Decimal
 from typing import TYPE_CHECKING
 
-from sqlalchemy import CheckConstraint, Enum, Index, Numeric, String, Text
+from sqlalchemy import CheckConstraint, DateTime, Enum, ForeignKey, Index, Numeric, String, Text
+from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
-from core.enums import AgentSeniority, AgentStatus, ProjectStatus
-from infrastructure.database.base import Base, TimestampMixin, UUIDPrimaryKeyMixin
+from core.enums import AgentSeniority, AgentStatus, AuditActorType, Permission, ProjectStatus
+from infrastructure.database.base import (
+    Base,
+    CreatedAtMixin,
+    TimestampMixin,
+    UUIDPrimaryKeyMixin,
+)
 
 if TYPE_CHECKING:
     from infrastructure.database.models.execution import AgentRun, Decision
@@ -49,6 +57,7 @@ class Agent(UUIDPrimaryKeyMixin, TimestampMixin, Base):
     runs: Mapped[list[AgentRun]] = relationship(back_populates="agent")
     decisions: Mapped[list[Decision]] = relationship(back_populates="agent")
     scores: Mapped[list[AgentScore]] = relationship(back_populates="agent")
+    permissions: Mapped[list[AgentPermission]] = relationship(back_populates="agent")
 
 
 class Project(UUIDPrimaryKeyMixin, TimestampMixin, Base):
@@ -67,3 +76,59 @@ class Project(UUIDPrimaryKeyMixin, TimestampMixin, Base):
     tasks: Mapped[list[Task]] = relationship(back_populates="project")
     scores: Mapped[list[AgentScore]] = relationship(back_populates="project")
     audit_events: Mapped[list[AuditEvent]] = relationship(back_populates="project")
+    agent_permissions: Mapped[list[AgentPermission]] = relationship(back_populates="project")
+
+
+class AgentPermission(UUIDPrimaryKeyMixin, CreatedAtMixin, Base):
+    """A scoped, expiring, and revocable source-of-authority grant."""
+
+    __tablename__ = "agent_permissions"
+    __table_args__ = (
+        CheckConstraint("granted_by_actor_type <> 'AGENT'", name="grantor_not_agent"),
+        CheckConstraint(
+            "expires_at IS NULL OR expires_at > created_at",
+            name="expiry_after_creation",
+        ),
+        CheckConstraint(
+            "revoked_at IS NULL OR revoked_at >= created_at",
+            name="revocation_not_before_creation",
+        ),
+        Index("ix_agent_permissions_lookup", "agent_id", "project_id", "permission"),
+        Index("ix_agent_permissions_expires_at", "expires_at"),
+        Index("ix_agent_permissions_revoked_at", "revoked_at"),
+        Index(
+            "uq_agent_permissions_global",
+            "agent_id",
+            "permission",
+            unique=True,
+            postgresql_where="project_id IS NULL",
+        ),
+        Index(
+            "uq_agent_permissions_project",
+            "agent_id",
+            "project_id",
+            "permission",
+            unique=True,
+            postgresql_where="project_id IS NOT NULL",
+        ),
+    )
+
+    agent_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("agents.id", ondelete="RESTRICT"), nullable=False
+    )
+    permission: Mapped[Permission] = mapped_column(
+        Enum(Permission, name="permission"), nullable=False
+    )
+    project_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("projects.id", ondelete="RESTRICT"), nullable=True
+    )
+    granted_by_actor_type: Mapped[AuditActorType] = mapped_column(
+        Enum(AuditActorType, name="audit_actor_type", create_type=False), nullable=False
+    )
+    granted_by_actor_id: Mapped[str] = mapped_column(String(255), nullable=False)
+    reason: Mapped[str] = mapped_column(String(1024), nullable=False)
+    expires_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    revoked_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+
+    agent: Mapped[Agent] = relationship(back_populates="permissions")
+    project: Mapped[Project | None] = relationship(back_populates="agent_permissions")

--- a/infrastructure/permissions/__init__.py
+++ b/infrastructure/permissions/__init__.py
@@ -1,0 +1,5 @@
+"""SQLAlchemy adapters for the Phase 7 Permission Engine."""
+
+from infrastructure.permissions.policy import SQLAlchemyPermissionPolicy
+
+__all__ = ["SQLAlchemyPermissionPolicy"]

--- a/infrastructure/permissions/__init__.py
+++ b/infrastructure/permissions/__init__.py
@@ -1,5 +1,6 @@
 """SQLAlchemy adapters for the Phase 7 Permission Engine."""
 
+from infrastructure.permissions.audit import SQLAlchemyPermissionAuditRecorder
 from infrastructure.permissions.policy import SQLAlchemyPermissionPolicy
 
-__all__ = ["SQLAlchemyPermissionPolicy"]
+__all__ = ["SQLAlchemyPermissionAuditRecorder", "SQLAlchemyPermissionPolicy"]

--- a/infrastructure/permissions/audit.py
+++ b/infrastructure/permissions/audit.py
@@ -1,0 +1,67 @@
+"""SQLAlchemy-backed sanitized permission decision auditing."""
+
+from __future__ import annotations
+
+from pydantic import ValidationError
+from sqlalchemy.orm import Session
+
+from core.enums import AuditActorType, AuditResult
+from core.permissions import (
+    PermissionAuditError,
+    PermissionDecision,
+    PermissionOutcome,
+)
+from infrastructure.database.models import AuditEvent
+
+
+class SQLAlchemyPermissionAuditRecorder:
+    """Append permission decisions without owning the caller's transaction."""
+
+    def __init__(self, session: Session) -> None:
+        self._session = session
+
+    def record(self, decision: PermissionDecision) -> None:
+        """Append one allowlisted permission decision and flush it before return."""
+        validated = self._validate(decision)
+        event = AuditEvent(
+            actor_type=AuditActorType.AGENT,
+            actor_id=validated.agent_id,
+            project_id=validated.project_id,
+            task_id=validated.task_id,
+            agent_run_id=validated.agent_run_id,
+            event_type="PERMISSION_EVALUATED",
+            action="authorize_tool",
+            resource_type="TOOL",
+            resource_id=validated.tool_name,
+            result=(
+                AuditResult.SUCCEEDED
+                if validated.outcome is PermissionOutcome.ALLOW
+                else AuditResult.DENIED
+            ),
+            data={
+                "decision": validated.outcome.value,
+                "required_permissions": [
+                    permission.value for permission in validated.required_permissions
+                ],
+                "reason_code": validated.reason_code.value,
+            },
+            correlation_id=validated.correlation_id,
+        )
+        try:
+            self._session.add(event)
+            self._session.flush()
+        except Exception as error:
+            error.__traceback__ = None
+            del error
+            raise PermissionAuditError("Permission audit is unavailable.") from None
+
+    @staticmethod
+    def _validate(decision: PermissionDecision) -> PermissionDecision:
+        try:
+            if type(decision) is not PermissionDecision:
+                raise ValueError
+            return PermissionDecision.model_validate(decision.__dict__, strict=True)
+        except (AttributeError, TypeError, ValueError, ValidationError) as error:
+            error.__traceback__ = None
+            del error
+            raise PermissionAuditError("Permission audit decision is invalid.") from None

--- a/infrastructure/permissions/policy.py
+++ b/infrastructure/permissions/policy.py
@@ -1,0 +1,164 @@
+"""Database-backed source of permission execution authority."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+from pydantic import ValidationError
+from sqlalchemy import or_, select
+from sqlalchemy.orm import Session
+
+from core.enums import Permission
+from core.permissions import (
+    PermissionDecision,
+    PermissionOutcome,
+    PermissionPolicyError,
+    PermissionReasonCode,
+    PolicyRequest,
+)
+from infrastructure.database.models import Agent, AgentPermission, AgentRun, Task
+
+_MINIMUM_AUTONOMY: dict[Permission, int] = {
+    Permission.FILESYSTEM_READ: 0,
+    Permission.FILESYSTEM_WRITE: 1,
+    Permission.GIT_READ: 0,
+    Permission.GIT_WRITE: 2,
+    Permission.SHELL_EXECUTE: 3,
+    Permission.TESTS_EXECUTE: 1,
+    Permission.NETWORK_ACCESS: 3,
+    Permission.DATABASE_READ: 0,
+    Permission.DATABASE_WRITE: 3,
+    Permission.DEPLOYMENT_STAGING: 3,
+    Permission.DEPLOYMENT_PRODUCTION: 4,
+}
+
+
+class SQLAlchemyPermissionPolicy:
+    """Resolve current grants from one caller-owned SQLAlchemy session."""
+
+    def __init__(self, session: Session) -> None:
+        self._session = session
+
+    def evaluate(
+        self,
+        request: PolicyRequest,
+        evaluated_at: datetime,
+    ) -> PermissionDecision:
+        """Evaluate coherent scope, active grants, autonomy, and approval gates."""
+        validated, timestamp = self._validate_inputs(request, evaluated_at)
+        try:
+            autonomy_level = self._session.scalar(
+                select(Agent.autonomy_level)
+                .join(AgentRun, AgentRun.agent_id == Agent.id)
+                .join(Task, Task.id == AgentRun.task_id)
+                .where(
+                    AgentRun.id == validated.agent_run_id,
+                    Agent.slug == validated.agent_id,
+                    AgentRun.task_id == validated.task_id,
+                    Task.id == validated.task_id,
+                    Task.project_id == validated.project_id,
+                    Task.assigned_agent_id == Agent.id,
+                )
+            )
+            if autonomy_level is None:
+                return self._decision(
+                    validated,
+                    timestamp,
+                    PermissionOutcome.DENY,
+                    PermissionReasonCode.INVALID_SCOPE,
+                    "Permission scope is invalid.",
+                )
+
+            granted = frozenset(
+                self._session.scalars(
+                    select(AgentPermission.permission).where(
+                        AgentPermission.agent_id
+                        == select(Agent.id)
+                        .where(Agent.slug == validated.agent_id)
+                        .scalar_subquery(),
+                        AgentPermission.permission.in_(validated.required_permissions),
+                        or_(
+                            AgentPermission.project_id.is_(None),
+                            AgentPermission.project_id == validated.project_id,
+                        ),
+                        AgentPermission.revoked_at.is_(None),
+                        or_(
+                            AgentPermission.expires_at.is_(None),
+                            AgentPermission.expires_at > timestamp,
+                        ),
+                    )
+                )
+            )
+        except Exception as error:
+            error.__traceback__ = None
+            del error
+            raise PermissionPolicyError("Permission policy is unavailable.") from None
+
+        if not validated.required_permissions.issubset(granted):
+            return self._decision(
+                validated,
+                timestamp,
+                PermissionOutcome.DENY,
+                PermissionReasonCode.MISSING_PERMISSION,
+                "A required permission is not granted.",
+            )
+        if Permission.DEPLOYMENT_PRODUCTION in validated.required_permissions:
+            return self._decision(
+                validated,
+                timestamp,
+                PermissionOutcome.ASK,
+                PermissionReasonCode.HUMAN_APPROVAL_REQUIRED,
+                "Human approval is required.",
+            )
+        if any(
+            autonomy_level < _MINIMUM_AUTONOMY[permission]
+            for permission in validated.required_permissions
+        ):
+            return self._decision(
+                validated,
+                timestamp,
+                PermissionOutcome.ASK,
+                PermissionReasonCode.AUTONOMY_APPROVAL_REQUIRED,
+                "Additional approval is required for this autonomy level.",
+            )
+        return self._decision(
+            validated,
+            timestamp,
+            PermissionOutcome.ALLOW,
+            PermissionReasonCode.GRANTED,
+            "Permission granted.",
+        )
+
+    @staticmethod
+    def _validate_inputs(
+        request: PolicyRequest,
+        evaluated_at: datetime,
+    ) -> tuple[PolicyRequest, datetime]:
+        try:
+            if type(request) is not PolicyRequest:
+                raise ValueError
+            validated = PolicyRequest.model_validate(request.__dict__, strict=True)
+            if evaluated_at.tzinfo is None or evaluated_at.utcoffset() is None:
+                raise ValueError
+            return validated, evaluated_at.astimezone(UTC)
+        except (AttributeError, TypeError, ValueError, ValidationError) as error:
+            error.__traceback__ = None
+            del error
+            raise PermissionPolicyError("Permission policy request is invalid.") from None
+
+    @staticmethod
+    def _decision(
+        request: PolicyRequest,
+        evaluated_at: datetime,
+        outcome: PermissionOutcome,
+        reason_code: PermissionReasonCode,
+        safe_message: str,
+    ) -> PermissionDecision:
+        return PermissionDecision.from_request(
+            request,
+            outcome=outcome,
+            required_permissions=request.required_permissions,
+            reason_code=reason_code,
+            safe_message=safe_message,
+            evaluated_at=evaluated_at,
+        )

--- a/infrastructure/tools/filesystem.py
+++ b/infrastructure/tools/filesystem.py
@@ -12,6 +12,7 @@ from typing import Annotated
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator
 
+from core.enums import Permission
 from core.tools import (
     JsonValue,
     Tool,
@@ -186,7 +187,7 @@ class ReadFileTool(Tool[ReadFileInput]):
     name = "read_file"
     description = "Read a bounded line range from one UTF-8 workspace file."
     input_type = ReadFileInput
-    required_permissions = frozenset({"workspace.read"})
+    required_permissions = frozenset({Permission.FILESYSTEM_READ})
     risk_level = ToolRiskLevel.LOW
     timeout_seconds = 5.0
 
@@ -228,7 +229,7 @@ class ListFilesTool(Tool[ListFilesInput]):
     name = "list_files"
     description = "List a bounded deterministic set of workspace entries."
     input_type = ListFilesInput
-    required_permissions = frozenset({"workspace.list"})
+    required_permissions = frozenset({Permission.FILESYSTEM_READ})
     risk_level = ToolRiskLevel.LOW
     timeout_seconds = 5.0
 
@@ -278,7 +279,7 @@ class SearchTextTool(Tool[SearchTextInput]):
     name = "search_text"
     description = "Search bounded UTF-8 workspace files for a literal string."
     input_type = SearchTextInput
-    required_permissions = frozenset({"workspace.search"})
+    required_permissions = frozenset({Permission.FILESYSTEM_READ})
     risk_level = ToolRiskLevel.LOW
     timeout_seconds = 10.0
 

--- a/infrastructure/tools/git.py
+++ b/infrastructure/tools/git.py
@@ -12,6 +12,7 @@ from typing import Annotated
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator
 
+from core.enums import Permission
 from core.tools import (
     JsonValue,
     Tool,
@@ -172,7 +173,7 @@ class GitStatusTool(Tool[GitStatusInput]):
     name = "git_status"
     description = "Read bounded Git branch and worktree status."
     input_type = GitStatusInput
-    required_permissions = frozenset({"git.read"})
+    required_permissions = frozenset({Permission.GIT_READ})
     risk_level = ToolRiskLevel.LOW
     timeout_seconds = 10.0
 
@@ -200,7 +201,7 @@ class GitDiffTool(Tool[GitDiffInput]):
     name = "git_diff"
     description = "Read one bounded Git worktree or staged diff."
     input_type = GitDiffInput
-    required_permissions = frozenset({"git.read"})
+    required_permissions = frozenset({Permission.GIT_READ})
     risk_level = ToolRiskLevel.LOW
     timeout_seconds = 10.0
 

--- a/tests/database/permission_fixtures.py
+++ b/tests/database/permission_fixtures.py
@@ -1,0 +1,118 @@
+"""Real-model setup helpers for Phase 7 permission policy tests."""
+
+from __future__ import annotations
+
+import uuid
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+from decimal import Decimal
+
+from sqlalchemy.orm import Session
+
+from core.enums import (
+    AgentRunStatus,
+    AgentSeniority,
+    AgentStatus,
+    AuditActorType,
+    Permission,
+    ProjectStatus,
+    TaskStatus,
+)
+from core.permissions import PolicyRequest
+from core.tools import ToolRiskLevel
+from infrastructure.database.models import Agent, AgentPermission, AgentRun, Project, Task
+
+
+@dataclass(frozen=True, slots=True)
+class PermissionScope:
+    """Coherent persisted execution scope with a deterministic evaluation time."""
+
+    agent: Agent
+    project: Project
+    task: Task
+    run: AgentRun
+    now: datetime
+
+    def request(
+        self,
+        permissions: frozenset[Permission],
+        **changes: object,
+    ) -> PolicyRequest:
+        values: dict[str, object] = {
+            "agent_id": self.agent.slug,
+            "agent_run_id": self.run.id,
+            "project_id": self.project.id,
+            "task_id": self.task.id,
+            "tool_name": "read_file",
+            "risk_level": ToolRiskLevel.LOW,
+            "required_permissions": permissions,
+            "correlation_id": uuid.uuid4(),
+        }
+        values.update(changes)
+        return PolicyRequest.model_validate(values, strict=True)
+
+
+def create_permission_scope(session: Session, *, autonomy_level: int = 2) -> PermissionScope:
+    """Persist one complete agent/project/task/run permission scope."""
+    agent = Agent(
+        name="Permission Policy Agent",
+        slug=f"permission-policy-agent-{uuid.uuid4().hex}",
+        role="Backend Engineer",
+        department="engineering",
+        seniority=AgentSeniority.SENIOR,
+        status=AgentStatus.WORKING,
+        autonomy_level=autonomy_level,
+        reputation_score=Decimal("0.9000"),
+        reliability_score=Decimal("0.9200"),
+    )
+    project = Project(name="Permission Policy Project", status=ProjectStatus.IN_PROGRESS)
+    session.add_all([agent, project])
+    session.flush()
+    task = Task(
+        project=project,
+        assigned_agent=agent,
+        title="Evaluate persisted permissions",
+        status=TaskStatus.IN_PROGRESS,
+    )
+    session.add(task)
+    session.flush()
+    run = AgentRun(agent=agent, task=task, status=AgentRunStatus.RUNNING, iteration=1)
+    session.add(run)
+    session.flush()
+    return PermissionScope(
+        agent=agent,
+        project=project,
+        task=task,
+        run=run,
+        now=datetime(2026, 8, 26, 14, 0, tzinfo=UTC),
+    )
+
+
+def add_permission(
+    session: Session,
+    scope: PermissionScope,
+    permission: Permission,
+    *,
+    project: Project | None = None,
+    expires_at: datetime | None = None,
+    revoked_at: datetime | None = None,
+) -> AgentPermission:
+    """Persist a trusted test grant without introducing a production grant API."""
+    grant = AgentPermission(
+        agent=scope.agent,
+        project=project,
+        permission=permission,
+        granted_by_actor_type=AuditActorType.HUMAN,
+        granted_by_actor_id="platform-admin",
+        reason="Approved test authority.",
+        expires_at=expires_at,
+        revoked_at=revoked_at,
+        created_at=(
+            scope.now - timedelta(days=1)
+            if expires_at is not None or revoked_at is not None
+            else scope.now
+        ),
+    )
+    session.add(grant)
+    session.flush()
+    return grant

--- a/tests/database/test_migrations.py
+++ b/tests/database/test_migrations.py
@@ -10,6 +10,7 @@ from sqlalchemy import create_engine, inspect, text
 from alembic import command
 
 EXPECTED_TABLES = {
+    "agent_permissions",
     "agent_runs",
     "agent_scores",
     "agents",
@@ -36,7 +37,7 @@ def test_migration_supports_upgrade_downgrade_and_second_upgrade(
     command.upgrade(config, "20260825_0001")
     engine = create_engine(migration_database_url)
     try:
-        assert set(inspect(engine).get_table_names()) >= EXPECTED_TABLES
+        assert set(inspect(engine).get_table_names()) >= EXPECTED_TABLES - {"agent_permissions"}
         project_id = uuid.uuid4()
         task_ids = [uuid.uuid4() for _ in range(4)]
         with engine.begin() as connection:
@@ -72,6 +73,7 @@ def test_migration_supports_upgrade_downgrade_and_second_upgrade(
     command.upgrade(config, "head")
     engine = create_engine(migration_database_url)
     try:
+        assert "agent_permissions" in inspect(engine).get_table_names()
         with engine.connect() as connection:
             assert connection.execute(text("SELECT version_num FROM alembic_version")).scalar_one()
             statuses = connection.execute(
@@ -105,6 +107,26 @@ def test_migration_supports_upgrade_downgrade_and_second_upgrade(
                 "FAILED",
                 "CANCELLED",
             ]
+            permission_values = connection.execute(
+                text(
+                    "SELECT enumlabel FROM pg_enum "
+                    "JOIN pg_type ON pg_type.oid = pg_enum.enumtypid "
+                    "WHERE pg_type.typname = 'permission' ORDER BY enumsortorder"
+                )
+            ).scalars()
+            assert list(permission_values) == [
+                "FILESYSTEM_READ",
+                "FILESYSTEM_WRITE",
+                "GIT_READ",
+                "GIT_WRITE",
+                "SHELL_EXECUTE",
+                "TESTS_EXECUTE",
+                "NETWORK_ACCESS",
+                "DATABASE_READ",
+                "DATABASE_WRITE",
+                "DEPLOYMENT_STAGING",
+                "DEPLOYMENT_PRODUCTION",
+            ]
         with engine.begin() as connection:
             for status in ("WAITING_QA", "WAITING_SECURITY", "FAILED"):
                 connection.execute(
@@ -122,6 +144,18 @@ def test_migration_supports_upgrade_downgrade_and_second_upgrade(
                         "status": status,
                     },
                 )
+    finally:
+        engine.dispose()
+
+    command.downgrade(config, "20260825_0002")
+    engine = create_engine(migration_database_url)
+    try:
+        assert "agent_permissions" not in inspect(engine).get_table_names()
+        with engine.connect() as connection:
+            permission_type_count = connection.execute(
+                text("SELECT count(*) FROM pg_type WHERE typname = 'permission'")
+            ).scalar_one()
+            assert permission_type_count == 0
     finally:
         engine.dispose()
 

--- a/tests/database/test_permission_audit.py
+++ b/tests/database/test_permission_audit.py
@@ -1,0 +1,127 @@
+"""Real-PostgreSQL tests for append-only permission decision audits."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from core.enums import AuditActorType, AuditResult, Permission
+from core.permissions import (
+    PermissionAuditError,
+    PermissionDecision,
+    PermissionOutcome,
+    PermissionReasonCode,
+)
+from infrastructure.database.models import AuditEvent
+from infrastructure.permissions import SQLAlchemyPermissionAuditRecorder
+from tests.database.permission_fixtures import PermissionScope, create_permission_scope
+
+
+def _decision(
+    scope: PermissionScope,
+    outcome: PermissionOutcome,
+    reason: PermissionReasonCode,
+) -> PermissionDecision:
+    request = scope.request(frozenset({Permission.FILESYSTEM_READ}))
+    return PermissionDecision.from_request(
+        request,
+        outcome=outcome,
+        required_permissions=request.required_permissions,
+        reason_code=reason,
+        safe_message="Permission decision completed.",
+        evaluated_at=scope.now,
+    )
+
+
+def test_allow_decision_appends_sanitized_event(db_session: Session) -> None:
+    scope = create_permission_scope(db_session)
+    decision = _decision(scope, PermissionOutcome.ALLOW, PermissionReasonCode.GRANTED)
+
+    SQLAlchemyPermissionAuditRecorder(db_session).record(decision)
+
+    event = db_session.scalar(
+        select(AuditEvent).where(AuditEvent.event_type == "PERMISSION_EVALUATED")
+    )
+    assert event is not None
+    assert event.actor_type is AuditActorType.AGENT
+    assert event.actor_id == scope.agent.slug
+    assert event.project_id == scope.project.id
+    assert event.task_id == scope.task.id
+    assert event.agent_run_id == scope.run.id
+    assert event.result is AuditResult.SUCCEEDED
+    assert event.data == {
+        "decision": "ALLOW",
+        "required_permissions": ["filesystem.read"],
+        "reason_code": "GRANTED",
+    }
+
+
+@pytest.mark.parametrize(
+    ("outcome", "reason"),
+    [
+        (PermissionOutcome.DENY, PermissionReasonCode.MISSING_PERMISSION),
+        (PermissionOutcome.ASK, PermissionReasonCode.AUTONOMY_APPROVAL_REQUIRED),
+    ],
+)
+def test_non_allow_decisions_are_audited_as_denied(
+    db_session: Session,
+    outcome: PermissionOutcome,
+    reason: PermissionReasonCode,
+) -> None:
+    scope = create_permission_scope(db_session)
+
+    SQLAlchemyPermissionAuditRecorder(db_session).record(_decision(scope, outcome, reason))
+
+    event = db_session.scalar(
+        select(AuditEvent).where(AuditEvent.event_type == "PERMISSION_EVALUATED")
+    )
+    assert event is not None
+    assert event.result is AuditResult.DENIED
+    assert event.data["decision"] == outcome.value
+
+
+def test_permission_audit_contains_no_unrelated_or_sensitive_data(db_session: Session) -> None:
+    scope = create_permission_scope(db_session)
+    secret = "secret-permission-audit-marker"
+    scope.project.description = secret
+    scope.task.description = secret
+
+    SQLAlchemyPermissionAuditRecorder(db_session).record(
+        _decision(scope, PermissionOutcome.ALLOW, PermissionReasonCode.GRANTED)
+    )
+
+    event = db_session.scalar(
+        select(AuditEvent).where(AuditEvent.event_type == "PERMISSION_EVALUATED")
+    )
+    assert event is not None
+    assert secret not in repr(event.data)
+    assert set(event.data) == {"decision", "required_permissions", "reason_code"}
+
+
+def test_permission_audit_never_owns_session_lifecycle(db_session: Session) -> None:
+    scope = create_permission_scope(db_session)
+    recorder = SQLAlchemyPermissionAuditRecorder(db_session)
+
+    with (
+        patch.object(db_session, "commit", side_effect=AssertionError("commit called")),
+        patch.object(db_session, "rollback", side_effect=AssertionError("rollback called")),
+        patch.object(db_session, "close", side_effect=AssertionError("close called")),
+    ):
+        recorder.record(_decision(scope, PermissionOutcome.ALLOW, PermissionReasonCode.GRANTED))
+
+
+def test_permission_audit_failure_is_sanitized(db_session: Session) -> None:
+    scope = create_permission_scope(db_session)
+    marker = "secret-permission-persistence-marker"
+
+    with (
+        patch.object(db_session, "flush", side_effect=RuntimeError(marker)),
+        pytest.raises(PermissionAuditError, match="Permission audit is unavailable") as error,
+    ):
+        SQLAlchemyPermissionAuditRecorder(db_session).record(
+            _decision(scope, PermissionOutcome.ALLOW, PermissionReasonCode.GRANTED)
+        )
+    assert marker not in str(error.value)

--- a/tests/database/test_permission_models.py
+++ b/tests/database/test_permission_models.py
@@ -1,0 +1,119 @@
+"""Real-PostgreSQL tests for scoped agent permission grants."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from typing import cast
+
+import pytest
+from sqlalchemy import Enum, Table
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm import Session
+
+from core.enums import AgentSeniority, AuditActorType, Permission
+from infrastructure.database.models import Agent, AgentPermission, Project
+
+
+def test_agent_permission_has_required_columns_and_indexes() -> None:
+    """Catch a schema that cannot represent scoped, expiring, revocable authority."""
+    table = cast(Table, AgentPermission.__table__)
+
+    assert set(table.columns.keys()) == {
+        "id",
+        "agent_id",
+        "permission",
+        "project_id",
+        "granted_by_actor_type",
+        "granted_by_actor_id",
+        "reason",
+        "expires_at",
+        "revoked_at",
+        "created_at",
+    }
+    assert cast(Enum, table.c.permission.type).name == "permission"
+    assert {
+        "ix_agent_permissions_lookup",
+        "ix_agent_permissions_expires_at",
+        "ix_agent_permissions_revoked_at",
+        "uq_agent_permissions_global",
+        "uq_agent_permissions_project",
+    }.issubset({index.name for index in table.indexes})
+
+
+def _scope(session: Session) -> tuple[Agent, Project]:
+    agent = Agent(
+        name="Permission Agent",
+        slug="permission-agent",
+        role="Developer",
+        department="engineering",
+        seniority=AgentSeniority.ENGINEER,
+    )
+    project = Project(name="Permission Project")
+    session.add_all([agent, project])
+    session.flush()
+    return agent, project
+
+
+def _grant(agent: Agent, **changes: object) -> AgentPermission:
+    values: dict[str, object] = {
+        "agent": agent,
+        "permission": Permission.FILESYSTEM_READ,
+        "granted_by_actor_type": AuditActorType.HUMAN,
+        "granted_by_actor_id": "platform-admin",
+        "reason": "Required for an approved repository task.",
+    }
+    values.update(changes)
+    return AgentPermission(**values)
+
+
+def test_agent_actor_cannot_persist_its_own_grant(db_session: Session) -> None:
+    agent, _ = _scope(db_session)
+    db_session.add(_grant(agent, granted_by_actor_type=AuditActorType.AGENT))
+
+    with pytest.raises(IntegrityError):
+        db_session.flush()
+
+
+@pytest.mark.parametrize("timestamp_field", ["expires_at", "revoked_at"])
+def test_permission_timestamps_cannot_precede_creation(
+    db_session: Session,
+    timestamp_field: str,
+) -> None:
+    agent, _ = _scope(db_session)
+    created_at = datetime(2026, 8, 26, 12, 0, tzinfo=UTC)
+    db_session.add(
+        _grant(
+            agent,
+            created_at=created_at,
+            **{timestamp_field: created_at - timedelta(seconds=1)},
+        )
+    )
+
+    with pytest.raises(IntegrityError):
+        db_session.flush()
+
+
+def test_duplicate_global_permission_is_rejected(db_session: Session) -> None:
+    agent, _ = _scope(db_session)
+    db_session.add_all([_grant(agent), _grant(agent)])
+
+    with pytest.raises(IntegrityError):
+        db_session.flush()
+
+
+def test_duplicate_project_permission_is_rejected(db_session: Session) -> None:
+    agent, project = _scope(db_session)
+    db_session.add_all([_grant(agent, project=project), _grant(agent, project=project)])
+
+    with pytest.raises(IntegrityError):
+        db_session.flush()
+
+
+def test_same_permission_can_be_scoped_to_different_projects(db_session: Session) -> None:
+    agent, project = _scope(db_session)
+    another_project = Project(name="Another Permission Project")
+    db_session.add(another_project)
+    db_session.flush()
+    db_session.add_all([_grant(agent, project=project), _grant(agent, project=another_project)])
+
+    db_session.flush()

--- a/tests/database/test_permission_policy.py
+++ b/tests/database/test_permission_policy.py
@@ -1,0 +1,177 @@
+"""Real-PostgreSQL tests for scoped permission policy evaluation."""
+
+from __future__ import annotations
+
+import uuid
+from datetime import timedelta
+from unittest.mock import patch
+
+import pytest
+from sqlalchemy.orm import Session
+
+from core.enums import Permission
+from core.permissions import PermissionOutcome, PermissionPolicyError, PermissionReasonCode
+from infrastructure.database.models import Project
+from infrastructure.permissions import SQLAlchemyPermissionPolicy
+from tests.database.permission_fixtures import add_permission, create_permission_scope
+
+
+def test_policy_allows_active_global_grant(db_session: Session) -> None:
+    scope = create_permission_scope(db_session)
+    add_permission(db_session, scope, Permission.FILESYSTEM_READ)
+
+    decision = SQLAlchemyPermissionPolicy(db_session).evaluate(
+        scope.request(frozenset({Permission.FILESYSTEM_READ})),
+        scope.now,
+    )
+
+    assert decision.outcome is PermissionOutcome.ALLOW
+    assert decision.reason_code is PermissionReasonCode.GRANTED
+
+
+def test_policy_allows_matching_project_grant(db_session: Session) -> None:
+    scope = create_permission_scope(db_session)
+    add_permission(
+        db_session,
+        scope,
+        Permission.FILESYSTEM_READ,
+        project=scope.project,
+    )
+
+    decision = SQLAlchemyPermissionPolicy(db_session).evaluate(
+        scope.request(frozenset({Permission.FILESYSTEM_READ})), scope.now
+    )
+
+    assert decision.outcome is PermissionOutcome.ALLOW
+
+
+@pytest.mark.parametrize("grant_state", ["missing", "expired", "revoked", "other-project"])
+def test_policy_denies_inactive_or_out_of_scope_grants(
+    db_session: Session,
+    grant_state: str,
+) -> None:
+    scope = create_permission_scope(db_session)
+    if grant_state == "expired":
+        add_permission(
+            db_session,
+            scope,
+            Permission.FILESYSTEM_READ,
+            expires_at=scope.now - timedelta(seconds=1),
+        )
+    elif grant_state == "revoked":
+        add_permission(
+            db_session,
+            scope,
+            Permission.FILESYSTEM_READ,
+            revoked_at=scope.now,
+        )
+    elif grant_state == "other-project":
+        other_project = Project(name="Other permission project")
+        db_session.add(other_project)
+        db_session.flush()
+        add_permission(
+            db_session,
+            scope,
+            Permission.FILESYSTEM_READ,
+            project=other_project,
+        )
+
+    decision = SQLAlchemyPermissionPolicy(db_session).evaluate(
+        scope.request(frozenset({Permission.FILESYSTEM_READ})), scope.now
+    )
+
+    assert decision.outcome is PermissionOutcome.DENY
+    assert decision.reason_code is PermissionReasonCode.MISSING_PERMISSION
+
+
+def test_policy_denies_when_one_required_permission_is_missing(db_session: Session) -> None:
+    scope = create_permission_scope(db_session, autonomy_level=3)
+    add_permission(db_session, scope, Permission.FILESYSTEM_READ)
+
+    decision = SQLAlchemyPermissionPolicy(db_session).evaluate(
+        scope.request(frozenset({Permission.FILESYSTEM_READ, Permission.NETWORK_ACCESS})),
+        scope.now,
+    )
+
+    assert decision.outcome is PermissionOutcome.DENY
+    assert decision.reason_code is PermissionReasonCode.MISSING_PERMISSION
+
+
+def test_policy_denies_forged_execution_scope(db_session: Session) -> None:
+    scope = create_permission_scope(db_session)
+    add_permission(db_session, scope, Permission.FILESYSTEM_READ)
+
+    decision = SQLAlchemyPermissionPolicy(db_session).evaluate(
+        scope.request(
+            frozenset({Permission.FILESYSTEM_READ}),
+            project_id=uuid.uuid4(),
+        ),
+        scope.now,
+    )
+
+    assert decision.outcome is PermissionOutcome.DENY
+    assert decision.reason_code is PermissionReasonCode.INVALID_SCOPE
+
+
+@pytest.mark.parametrize(
+    ("permission", "autonomy_level", "expected"),
+    [
+        (Permission.FILESYSTEM_READ, 0, PermissionOutcome.ALLOW),
+        (Permission.FILESYSTEM_WRITE, 0, PermissionOutcome.ASK),
+        (Permission.GIT_WRITE, 1, PermissionOutcome.ASK),
+        (Permission.NETWORK_ACCESS, 2, PermissionOutcome.ASK),
+        (Permission.DEPLOYMENT_STAGING, 3, PermissionOutcome.ALLOW),
+    ],
+)
+def test_policy_applies_minimum_autonomy_after_grant(
+    db_session: Session,
+    permission: Permission,
+    autonomy_level: int,
+    expected: PermissionOutcome,
+) -> None:
+    scope = create_permission_scope(db_session, autonomy_level=autonomy_level)
+    add_permission(db_session, scope, permission)
+
+    decision = SQLAlchemyPermissionPolicy(db_session).evaluate(
+        scope.request(frozenset({permission})), scope.now
+    )
+
+    assert decision.outcome is expected
+
+
+def test_production_permission_always_requires_human_approval(db_session: Session) -> None:
+    scope = create_permission_scope(db_session, autonomy_level=5)
+    add_permission(db_session, scope, Permission.DEPLOYMENT_PRODUCTION)
+
+    decision = SQLAlchemyPermissionPolicy(db_session).evaluate(
+        scope.request(frozenset({Permission.DEPLOYMENT_PRODUCTION})), scope.now
+    )
+
+    assert decision.outcome is PermissionOutcome.ASK
+    assert decision.reason_code is PermissionReasonCode.HUMAN_APPROVAL_REQUIRED
+
+
+def test_policy_never_owns_session_lifecycle(db_session: Session) -> None:
+    scope = create_permission_scope(db_session)
+    add_permission(db_session, scope, Permission.FILESYSTEM_READ)
+    policy = SQLAlchemyPermissionPolicy(db_session)
+
+    with (
+        patch.object(db_session, "commit", side_effect=AssertionError("commit called")),
+        patch.object(db_session, "rollback", side_effect=AssertionError("rollback called")),
+        patch.object(db_session, "close", side_effect=AssertionError("close called")),
+    ):
+        policy.evaluate(scope.request(frozenset({Permission.FILESYSTEM_READ})), scope.now)
+
+
+def test_database_failure_is_sanitized(db_session: Session) -> None:
+    scope = create_permission_scope(db_session)
+    marker = "secret-policy-database-marker"
+    with (
+        patch.object(db_session, "scalar", side_effect=RuntimeError(marker)),
+        pytest.raises(PermissionPolicyError, match="Permission policy is unavailable") as error,
+    ):
+        SQLAlchemyPermissionPolicy(db_session).evaluate(
+            scope.request(frozenset({Permission.FILESYSTEM_READ})), scope.now
+        )
+    assert marker not in str(error.value)

--- a/tests/database/test_permission_tool_execution.py
+++ b/tests/database/test_permission_tool_execution.py
@@ -1,0 +1,202 @@
+"""End-to-end PostgreSQL enforcement at the tool execution boundary."""
+
+from __future__ import annotations
+
+import asyncio
+import uuid
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any
+
+import pytest
+from pydantic import BaseModel, ConfigDict
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from core.enums import Permission
+from core.permissions import PermissionEngine
+from core.tools import (
+    JsonValue,
+    Tool,
+    ToolErrorCode,
+    ToolExecutionContext,
+    ToolExecutor,
+    ToolRegistry,
+    ToolResultStatus,
+    ToolRiskLevel,
+)
+from infrastructure.database.models import AuditEvent, Project
+from infrastructure.permissions import (
+    SQLAlchemyPermissionAuditRecorder,
+    SQLAlchemyPermissionPolicy,
+)
+from infrastructure.tools.audit import SQLAlchemyToolAuditRecorder
+from infrastructure.tools.filesystem import ReadFileTool
+from tests.database.permission_fixtures import (
+    PermissionScope,
+    add_permission,
+    create_permission_scope,
+)
+from tests.tools.fakes import FakeTool
+
+
+def _context(scope: PermissionScope, root: Path, tool_name: str) -> ToolExecutionContext:
+    return ToolExecutionContext(
+        workspace_root=root,
+        agent_id=scope.agent.slug,
+        agent_run_id=scope.run.id,
+        project_id=scope.project.id,
+        task_id=scope.task.id,
+        declared_tool_ids={tool_name},
+        correlation_id=uuid.uuid4(),
+    )
+
+
+def _executor(session: Session, scope: PermissionScope, tool: Tool[Any]) -> ToolExecutor:
+    return ToolExecutor(
+        ToolRegistry([tool]),
+        SQLAlchemyToolAuditRecorder(session),
+        PermissionEngine(
+            SQLAlchemyPermissionPolicy(session),
+            SQLAlchemyPermissionAuditRecorder(session),
+            clock=lambda: scope.now,
+        ),
+    )
+
+
+def test_persisted_grant_allows_audited_read(db_session: Session, tmp_path: Path) -> None:
+    marker = "secret-source-marker-41d2"
+    filename = "client-requirements.txt"
+    (tmp_path / filename).write_text(marker, encoding="utf-8")
+    scope = create_permission_scope(db_session)
+    add_permission(
+        db_session,
+        scope,
+        Permission.FILESYSTEM_READ,
+        project=scope.project,
+    )
+
+    result = asyncio.run(
+        _executor(db_session, scope, ReadFileTool()).execute(
+            "read_file",
+            {"path": filename},
+            _context(scope, tmp_path, "read_file"),
+        )
+    )
+
+    assert result.status is ToolResultStatus.SUCCEEDED
+    events = list(
+        db_session.scalars(
+            select(AuditEvent)
+            .where(AuditEvent.agent_run_id == scope.run.id)
+            .order_by(AuditEvent.created_at, AuditEvent.id)
+        )
+    )
+    assert [event.event_type for event in events] == [
+        "PERMISSION_EVALUATED",
+        "TOOL_EXECUTION",
+    ]
+    persisted = repr([(event.data, event.resource_id) for event in events])
+    assert marker not in persisted
+    assert filename not in persisted
+    assert str(tmp_path) not in persisted
+
+
+@pytest.mark.parametrize("grant_state", ["missing", "expired", "revoked", "cross-project"])
+def test_inactive_or_out_of_scope_grants_never_execute(
+    db_session: Session,
+    tmp_path: Path,
+    grant_state: str,
+) -> None:
+    scope = create_permission_scope(db_session)
+    if grant_state == "expired":
+        add_permission(
+            db_session,
+            scope,
+            Permission.FILESYSTEM_READ,
+            expires_at=scope.now,
+        )
+    elif grant_state == "revoked":
+        add_permission(
+            db_session,
+            scope,
+            Permission.FILESYSTEM_READ,
+            revoked_at=scope.now,
+        )
+    elif grant_state == "cross-project":
+        other_project = Project(name="Unrelated project")
+        db_session.add(other_project)
+        db_session.flush()
+        add_permission(
+            db_session,
+            scope,
+            Permission.FILESYSTEM_READ,
+            project=other_project,
+        )
+
+    result = asyncio.run(
+        _executor(db_session, scope, FakeTool()).execute(
+            "fake_read",
+            {"path": "README.md"},
+            _context(scope, tmp_path, "fake_read"),
+        )
+    )
+
+    assert result.status is ToolResultStatus.DENIED
+    assert result.error_code is ToolErrorCode.PERMISSION_DENIED
+    assert FakeTool.calls == 0
+
+
+class _NoInput(BaseModel):
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+
+class _ApprovalTool(Tool[_NoInput]):
+    name = "approval_tool"
+    description = "Require a permission that cannot execute without approval."
+    input_type = _NoInput
+    risk_level = ToolRiskLevel.CRITICAL
+    timeout_seconds = 1.0
+
+    def __init__(self, permission: Permission) -> None:
+        self.required_permissions = frozenset({permission})
+        self.calls = 0
+
+    async def execute(
+        self,
+        arguments: _NoInput,
+        context: ToolExecutionContext,
+    ) -> Mapping[str, JsonValue]:
+        del arguments, context
+        self.calls += 1
+        return {}
+
+
+@pytest.mark.parametrize(
+    ("permission", "autonomy_level"),
+    [
+        (Permission.TESTS_EXECUTE, 0),
+        (Permission.DEPLOYMENT_PRODUCTION, 5),
+    ],
+)
+def test_approval_decisions_never_execute(
+    db_session: Session,
+    tmp_path: Path,
+    permission: Permission,
+    autonomy_level: int,
+) -> None:
+    scope = create_permission_scope(db_session, autonomy_level=autonomy_level)
+    add_permission(db_session, scope, permission, project=scope.project)
+    tool = _ApprovalTool(permission)
+
+    result = asyncio.run(
+        _executor(db_session, scope, tool).execute(
+            tool.name,
+            {},
+            _context(scope, tmp_path, tool.name),
+        )
+    )
+
+    assert result.status is ToolResultStatus.DENIED
+    assert result.error_code is ToolErrorCode.APPROVAL_REQUIRED
+    assert tool.calls == 0

--- a/tests/database/test_tool_execution.py
+++ b/tests/database/test_tool_execution.py
@@ -13,7 +13,8 @@ from pydantic import BaseModel, ConfigDict
 from sqlalchemy import func, select
 from sqlalchemy.orm import Session
 
-from core.enums import AuditActorType, AuditResult, ToolCallStatus
+from core.enums import AuditActorType, AuditResult, Permission, ToolCallStatus
+from core.permissions import PermissionEngine
 from core.tools import (
     JsonValue,
     Tool,
@@ -24,7 +25,11 @@ from core.tools import (
     ToolRegistry,
     ToolRiskLevel,
 )
-from infrastructure.database.models import AuditEvent, ToolCall
+from infrastructure.database.models import AgentPermission, AuditEvent, ToolCall
+from infrastructure.permissions import (
+    SQLAlchemyPermissionAuditRecorder,
+    SQLAlchemyPermissionPolicy,
+)
 from infrastructure.tools.audit import SQLAlchemyToolAuditRecorder
 from infrastructure.tools.filesystem import ReadFileInput, ReadFileTool
 from tests.database.tool_fixtures import create_tool_run
@@ -36,9 +41,21 @@ def _context(
     workspace_root: Path,
     *,
     declared_tools: set[str] | None = None,
-    permissions: set[str] | None = None,
+    grant_permissions: frozenset[Permission] = frozenset({Permission.FILESYSTEM_READ}),
 ) -> ToolExecutionContext:
     project, agent, task, run = create_tool_run(session)
+    session.add_all(
+        AgentPermission(
+            agent_id=agent.id,
+            project_id=project.id,
+            permission=permission,
+            granted_by_actor_type=AuditActorType.HUMAN,
+            granted_by_actor_id="test-administrator",
+            reason="Test execution grant.",
+        )
+        for permission in grant_permissions
+    )
+    session.flush()
     return ToolExecutionContext(
         workspace_root=workspace_root,
         agent_id=agent.slug,
@@ -46,8 +63,14 @@ def _context(
         project_id=project.id,
         task_id=task.id,
         declared_tool_ids=declared_tools or {"fake_read"},
-        permission_ids=permissions or {"workspace.read"},
         correlation_id=uuid.uuid4(),
+    )
+
+
+def _permission_engine(session: Session) -> PermissionEngine:
+    return PermissionEngine(
+        SQLAlchemyPermissionPolicy(session),
+        SQLAlchemyPermissionAuditRecorder(session),
     )
 
 
@@ -56,7 +79,7 @@ def test_successful_tool_execution_is_audited(db_session: Session, tmp_path: Pat
     recorder = SQLAlchemyToolAuditRecorder(db_session)
 
     result = asyncio.run(
-        ToolExecutor(ToolRegistry([FakeTool()]), recorder).execute(
+        ToolExecutor(ToolRegistry([FakeTool()]), recorder, _permission_engine(db_session)).execute(
             "fake_read", {"path": "README.md"}, context
         )
     )
@@ -69,7 +92,10 @@ def test_successful_tool_execution_is_audited(db_session: Session, tmp_path: Pat
     assert call.output_data["output_field_count"] == 2
     assert call.output_data["truncated"] is False
     event = db_session.scalar(
-        select(AuditEvent).where(AuditEvent.agent_run_id == context.agent_run_id)
+        select(AuditEvent).where(
+            AuditEvent.agent_run_id == context.agent_run_id,
+            AuditEvent.event_type == "TOOL_EXECUTION",
+        )
     )
     assert event is not None
     assert event.actor_type is AuditActorType.AGENT
@@ -82,20 +108,26 @@ def test_successful_tool_execution_is_audited(db_session: Session, tmp_path: Pat
 
 
 @pytest.mark.parametrize(
-    ("tool_name", "declared_tools", "permissions", "expected_status", "expected_result"),
+    ("tool_name", "declared_tools", "grants", "expected_status", "expected_result"),
     [
-        ("unknown", {"unknown"}, {"workspace.read"}, ToolCallStatus.DENIED, AuditResult.DENIED),
+        (
+            "unknown",
+            {"unknown"},
+            frozenset({Permission.FILESYSTEM_READ}),
+            ToolCallStatus.DENIED,
+            AuditResult.DENIED,
+        ),
         (
             "fake_read",
             {"another_tool"},
-            {"workspace.read"},
+            frozenset({Permission.FILESYSTEM_READ}),
             ToolCallStatus.DENIED,
             AuditResult.DENIED,
         ),
         (
             "fake_read",
             {"fake_read"},
-            {"git.read"},
+            frozenset({Permission.GIT_READ}),
             ToolCallStatus.DENIED,
             AuditResult.DENIED,
         ),
@@ -106,7 +138,7 @@ def test_denied_attempts_are_persisted(
     tmp_path: Path,
     tool_name: str,
     declared_tools: set[str],
-    permissions: set[str],
+    grants: frozenset[Permission],
     expected_status: ToolCallStatus,
     expected_result: AuditResult,
 ) -> None:
@@ -114,12 +146,14 @@ def test_denied_attempts_are_persisted(
         db_session,
         tmp_path,
         declared_tools=declared_tools,
-        permissions=permissions,
+        grant_permissions=grants,
     )
     recorder = SQLAlchemyToolAuditRecorder(db_session)
 
     result = asyncio.run(
-        ToolExecutor(ToolRegistry([FakeTool()]), recorder).execute(tool_name, {}, context)
+        ToolExecutor(ToolRegistry([FakeTool()]), recorder, _permission_engine(db_session)).execute(
+            tool_name, {}, context
+        )
     )
     db_session.flush()
 
@@ -127,7 +161,10 @@ def test_denied_attempts_are_persisted(
     assert call is not None
     assert call.status is expected_status
     event = db_session.scalar(
-        select(AuditEvent).where(AuditEvent.agent_run_id == context.agent_run_id)
+        select(AuditEvent).where(
+            AuditEvent.agent_run_id == context.agent_run_id,
+            AuditEvent.event_type == "TOOL_EXECUTION",
+        )
     )
     assert event is not None
     assert event.result is expected_result
@@ -141,7 +178,7 @@ class _BlockingTool(Tool[_NoInput]):
     name = "blocking"
     description = "Wait until timed out or cancelled."
     input_type = _NoInput
-    required_permissions = frozenset({"workspace.read"})
+    required_permissions = frozenset({Permission.FILESYSTEM_READ})
     risk_level = ToolRiskLevel.LOW
     timeout_seconds = 0.01
 
@@ -171,9 +208,11 @@ def test_timeout_and_cancellation_have_terminal_audits(
     )
     timeout_recorder = SQLAlchemyToolAuditRecorder(db_session)
     timeout_result = asyncio.run(
-        ToolExecutor(ToolRegistry([_BlockingTool()]), timeout_recorder).execute(
-            "blocking", {}, timeout_context
-        )
+        ToolExecutor(
+            ToolRegistry([_BlockingTool()]),
+            timeout_recorder,
+            _permission_engine(db_session),
+        ).execute("blocking", {}, timeout_context)
     )
 
     cancellation_context = _context(
@@ -187,9 +226,11 @@ def test_timeout_and_cancellation_have_terminal_audits(
 
     async def cancel() -> None:
         operation = asyncio.create_task(
-            ToolExecutor(ToolRegistry([cancellation_tool]), cancellation_recorder).execute(
-                "blocking", {}, cancellation_context
-            )
+            ToolExecutor(
+                ToolRegistry([cancellation_tool]),
+                cancellation_recorder,
+                _permission_engine(db_session),
+            ).execute("blocking", {}, cancellation_context)
         )
         while cancellation_tool.started is None:
             await asyncio.sleep(0)
@@ -214,9 +255,10 @@ def test_timeout_and_cancellation_have_terminal_audits(
     results = set(
         db_session.scalars(
             select(AuditEvent.result).where(
+                AuditEvent.event_type == "TOOL_EXECUTION",
                 AuditEvent.agent_run_id.in_(
                     [timeout_context.agent_run_id, cancellation_context.agent_run_id]
-                )
+                ),
             )
         )
     )
@@ -233,20 +275,22 @@ def test_audit_persists_no_raw_file_or_host_content(
         db_session,
         tmp_path,
         declared_tools={"read_file"},
-        permissions={"workspace.read"},
     )
     recorder = SQLAlchemyToolAuditRecorder(db_session)
 
     result = asyncio.run(
-        ToolExecutor(ToolRegistry([ReadFileTool()]), recorder).execute(
-            "read_file", ReadFileInput(path="client.txt").model_dump(), context
-        )
+        ToolExecutor(
+            ToolRegistry([ReadFileTool()]), recorder, _permission_engine(db_session)
+        ).execute("read_file", ReadFileInput(path="client.txt").model_dump(), context)
     )
     db_session.flush()
 
     call = db_session.get(ToolCall, result.tool_call_id)
     event = db_session.scalar(
-        select(AuditEvent).where(AuditEvent.agent_run_id == context.agent_run_id)
+        select(AuditEvent).where(
+            AuditEvent.agent_run_id == context.agent_run_id,
+            AuditEvent.event_type == "TOOL_EXECUTION",
+        )
     )
     assert call is not None
     assert event is not None
@@ -269,9 +313,9 @@ def test_recorder_never_owns_session_transaction_or_lifecycle(
         patch.object(db_session, "close", side_effect=AssertionError("close called")),
     ):
         asyncio.run(
-            ToolExecutor(ToolRegistry([FakeTool()]), recorder).execute(
-                "fake_read", {"path": "README.md"}, context
-            )
+            ToolExecutor(
+                ToolRegistry([FakeTool()]), recorder, _permission_engine(db_session)
+            ).execute("fake_read", {"path": "README.md"}, context)
         )
         db_session.flush()
 
@@ -288,6 +332,7 @@ def test_recorder_rejects_forged_scope_before_tool_call(
             ToolExecutor(
                 ToolRegistry([FakeTool()]),
                 SQLAlchemyToolAuditRecorder(db_session),
+                _permission_engine(db_session),
             ).execute("fake_read", {"path": "README.md"}, forged)
         )
 

--- a/tests/permissions/__init__.py
+++ b/tests/permissions/__init__.py
@@ -1,0 +1,1 @@
+"""Phase 7 permission engine tests."""

--- a/tests/permissions/fakes.py
+++ b/tests/permissions/fakes.py
@@ -1,0 +1,52 @@
+"""Deterministic permission policy and audit test doubles."""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from core.permissions import (
+    PermissionDecision,
+    PermissionOutcome,
+    PermissionReasonCode,
+    PolicyRequest,
+)
+
+
+class RecordingPolicy:
+    """Return one deterministic decision while retaining bounded call metadata."""
+
+    def __init__(
+        self,
+        outcome: PermissionOutcome,
+        reason_code: PermissionReasonCode,
+    ) -> None:
+        self.outcome = outcome
+        self.reason_code = reason_code
+        self.requests: list[PolicyRequest] = []
+        self.evaluated_at: list[datetime] = []
+
+    def evaluate(
+        self,
+        request: PolicyRequest,
+        evaluated_at: datetime,
+    ) -> PermissionDecision:
+        self.requests.append(request)
+        self.evaluated_at.append(evaluated_at)
+        return PermissionDecision.from_request(
+            request,
+            outcome=self.outcome,
+            required_permissions=request.required_permissions,
+            reason_code=self.reason_code,
+            safe_message="Permission decision completed.",
+            evaluated_at=evaluated_at,
+        )
+
+
+class RecordingPermissionAudit:
+    """Retain decisions without persistence or external side effects."""
+
+    def __init__(self) -> None:
+        self.decisions: list[PermissionDecision] = []
+
+    def record(self, decision: PermissionDecision) -> None:
+        self.decisions.append(decision)

--- a/tests/permissions/test_engine.py
+++ b/tests/permissions/test_engine.py
@@ -1,0 +1,123 @@
+"""Tests for the central deny-by-default Permission Engine."""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime
+
+import pytest
+
+from core.permissions import (
+    PermissionAuditError,
+    PermissionDecision,
+    PermissionEngine,
+    PermissionOutcome,
+    PermissionPolicyError,
+    PermissionReasonCode,
+    PermissionRequest,
+    PolicyRequest,
+)
+from core.tools import ToolRiskLevel
+from tests.permissions.fakes import RecordingPermissionAudit, RecordingPolicy
+
+FIXED_NOW = datetime(2026, 8, 26, 13, 30, tzinfo=UTC)
+
+
+def _request(**changes: object) -> PermissionRequest:
+    values: dict[str, object] = {
+        "agent_id": "backend-agent-03",
+        "agent_run_id": uuid.uuid4(),
+        "project_id": uuid.uuid4(),
+        "task_id": uuid.uuid4(),
+        "tool_name": "read_file",
+        "risk_level": ToolRiskLevel.LOW,
+        "required_permission_ids": {"filesystem.read"},
+        "correlation_id": uuid.uuid4(),
+    }
+    values.update(changes)
+    return PermissionRequest.model_validate(values, strict=True)
+
+
+def test_engine_canonicalizes_evaluates_once_and_audits_allow() -> None:
+    policy = RecordingPolicy(PermissionOutcome.ALLOW, PermissionReasonCode.GRANTED)
+    audit = RecordingPermissionAudit()
+    engine = PermissionEngine(policy, audit, clock=lambda: FIXED_NOW)
+
+    decision = engine.evaluate(_request())
+
+    assert decision.outcome is PermissionOutcome.ALLOW
+    assert len(policy.requests) == 1
+    assert policy.evaluated_at == [FIXED_NOW]
+    assert audit.decisions == [decision]
+
+
+def test_unknown_permission_is_denied_and_audited_without_policy_call() -> None:
+    policy = RecordingPolicy(PermissionOutcome.ALLOW, PermissionReasonCode.GRANTED)
+    audit = RecordingPermissionAudit()
+    engine = PermissionEngine(policy, audit, clock=lambda: FIXED_NOW)
+
+    decision = engine.evaluate(_request(required_permission_ids={"unknown.permission"}))
+
+    assert decision.outcome is PermissionOutcome.DENY
+    assert decision.reason_code is PermissionReasonCode.UNKNOWN_PERMISSION
+    assert decision.required_permissions == ()
+    assert policy.requests == []
+    assert audit.decisions == [decision]
+    assert "unknown.permission" not in repr(decision)
+
+
+class _FailingPolicy:
+    def evaluate(
+        self,
+        request: PolicyRequest,
+        evaluated_at: datetime,
+    ) -> PermissionDecision:
+        del request, evaluated_at
+        raise RuntimeError("secret-policy-marker")
+
+
+class _FailingAudit:
+    def record(self, decision: object) -> None:
+        del decision
+        raise RuntimeError("secret-audit-marker")
+
+
+def test_policy_failure_is_sanitized_and_not_retried() -> None:
+    audit = RecordingPermissionAudit()
+    engine = PermissionEngine(_FailingPolicy(), audit, clock=lambda: FIXED_NOW)
+
+    with pytest.raises(PermissionPolicyError, match="Permission policy is unavailable") as captured:
+        engine.evaluate(_request())
+
+    assert "secret-policy-marker" not in str(captured.value)
+    assert audit.decisions == []
+
+
+def test_audit_failure_is_sanitized_and_fails_closed() -> None:
+    policy = RecordingPolicy(PermissionOutcome.ALLOW, PermissionReasonCode.GRANTED)
+    engine = PermissionEngine(policy, _FailingAudit(), clock=lambda: FIXED_NOW)
+
+    with pytest.raises(PermissionAuditError, match="Permission audit is unavailable") as captured:
+        engine.evaluate(_request())
+
+    assert "secret-audit-marker" not in str(captured.value)
+    assert len(policy.requests) == 1
+
+
+def test_engine_rejects_forged_policy_decision_scope() -> None:
+    class ForgedPolicy(RecordingPolicy):
+        def evaluate(
+            self,
+            request: PolicyRequest,
+            evaluated_at: datetime,
+        ) -> PermissionDecision:
+            decision = super().evaluate(request, evaluated_at)
+            return decision.model_copy(update={"project_id": uuid.uuid4()})
+
+    policy = ForgedPolicy(PermissionOutcome.ALLOW, PermissionReasonCode.GRANTED)
+    audit = RecordingPermissionAudit()
+
+    with pytest.raises(PermissionPolicyError, match="invalid decision"):
+        PermissionEngine(policy, audit, clock=lambda: FIXED_NOW).evaluate(_request())
+
+    assert audit.decisions == []

--- a/tests/permissions/test_types.py
+++ b/tests/permissions/test_types.py
@@ -1,0 +1,167 @@
+"""Tests for strict permission value objects."""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime
+
+import pytest
+from pydantic import ValidationError
+
+from core.enums import Permission
+from core.permissions import (
+    PermissionDecision,
+    PermissionOutcome,
+    PermissionReasonCode,
+    PermissionRequest,
+    PolicyRequest,
+    ToolPermission,
+)
+from core.tools import ToolRiskLevel
+
+
+def _request(**changes: object) -> PermissionRequest:
+    values: dict[str, object] = {
+        "agent_id": "backend-agent-03",
+        "agent_run_id": uuid.uuid4(),
+        "project_id": uuid.uuid4(),
+        "task_id": uuid.uuid4(),
+        "tool_name": "read_file",
+        "risk_level": ToolRiskLevel.LOW,
+        "required_permission_ids": {"filesystem.read"},
+        "correlation_id": uuid.uuid4(),
+    }
+    values.update(changes)
+    return PermissionRequest.model_validate(values, strict=True)
+
+
+def test_permission_enum_contains_exactly_v1_values() -> None:
+    """Catch missing, aliased, or unexpectedly expanded V1 authority."""
+    assert tuple(permission.value for permission in Permission) == (
+        "filesystem.read",
+        "filesystem.write",
+        "git.read",
+        "git.write",
+        "shell.execute",
+        "tests.execute",
+        "network.access",
+        "database.read",
+        "database.write",
+        "deployment.staging",
+        "deployment.production",
+    )
+
+
+def test_permission_request_is_strict_frozen_and_copies_identifiers() -> None:
+    supplied = {"filesystem.read"}
+    request = _request(required_permission_ids=supplied)
+    supplied.add("git.write")
+
+    assert request.required_permission_ids == frozenset({"filesystem.read"})
+    with pytest.raises(ValidationError):
+        request.tool_name = "changed"  # type: ignore[misc]
+    with pytest.raises(ValidationError):
+        _request(unexpected=True)
+
+
+@pytest.mark.parametrize(
+    ("field", "value", "marker"),
+    [
+        ("agent_id", "Backend-Agent-03", "Backend-Agent-03"),
+        ("tool_name", "../escape", "../escape"),
+        ("required_permission_ids", set(), "unused-marker"),
+        ("required_permission_ids", {"BAD.PERMISSION"}, "BAD.PERMISSION"),
+    ],
+)
+def test_permission_request_rejects_malformed_identifiers_without_echoing_values(
+    field: str,
+    value: object,
+    marker: str,
+) -> None:
+    with pytest.raises(ValidationError) as captured:
+        _request(**{field: value})
+    assert marker not in str(captured.value)
+
+
+def test_policy_request_and_tool_permission_require_canonical_permissions() -> None:
+    request = _request()
+    policy_request = PolicyRequest.from_request(
+        request,
+        frozenset({Permission.FILESYSTEM_READ}),
+    )
+    requirement = ToolPermission(
+        tool_name="read_file",
+        required_permissions=frozenset({Permission.FILESYSTEM_READ}),
+    )
+
+    assert policy_request.required_permissions == frozenset({Permission.FILESYSTEM_READ})
+    assert requirement.required_permissions == frozenset({Permission.FILESYSTEM_READ})
+    with pytest.raises(ValidationError):
+        ToolPermission.model_validate(
+            {"tool_name": "read_file", "required_permissions": {"unknown.permission"}},
+            strict=True,
+        )
+
+
+def test_permission_decision_sorts_requirements_and_normalizes_utc() -> None:
+    request = _request(required_permission_ids={"git.read", "filesystem.read"})
+    decision = PermissionDecision.from_request(
+        request,
+        outcome=PermissionOutcome.ALLOW,
+        required_permissions=frozenset({Permission.GIT_READ, Permission.FILESYSTEM_READ}),
+        reason_code=PermissionReasonCode.GRANTED,
+        safe_message="Permission granted.",
+        evaluated_at=datetime(2026, 8, 26, 10, 0, tzinfo=UTC),
+    )
+
+    assert decision.required_permissions == (
+        Permission.FILESYSTEM_READ,
+        Permission.GIT_READ,
+    )
+    assert decision.evaluated_at.tzinfo is UTC
+
+
+@pytest.mark.parametrize(
+    ("outcome", "reason"),
+    [
+        (PermissionOutcome.ALLOW, PermissionReasonCode.MISSING_PERMISSION),
+        (PermissionOutcome.DENY, PermissionReasonCode.GRANTED),
+        (PermissionOutcome.ASK, PermissionReasonCode.UNKNOWN_PERMISSION),
+    ],
+)
+def test_permission_decision_rejects_inconsistent_outcome_and_reason(
+    outcome: PermissionOutcome,
+    reason: PermissionReasonCode,
+) -> None:
+    request = _request()
+    with pytest.raises(ValidationError, match="outcome and reason"):
+        PermissionDecision.from_request(
+            request,
+            outcome=outcome,
+            required_permissions=frozenset({Permission.FILESYSTEM_READ}),
+            reason_code=reason,
+            safe_message="Safe decision message.",
+            evaluated_at=datetime.now(UTC),
+        )
+
+
+def test_permission_decision_rejects_naive_timestamp_and_secret_message() -> None:
+    request = _request()
+    with pytest.raises(ValidationError, match="timezone-aware"):
+        PermissionDecision.from_request(
+            request,
+            outcome=PermissionOutcome.DENY,
+            required_permissions=frozenset(),
+            reason_code=PermissionReasonCode.UNKNOWN_PERMISSION,
+            safe_message="Permission is unknown.",
+            evaluated_at=datetime(2026, 8, 26, 10, 0),
+        )
+    with pytest.raises(ValidationError):
+        PermissionDecision.from_request(
+            request,
+            outcome=PermissionOutcome.DENY,
+            required_permissions=frozenset(),
+            reason_code=PermissionReasonCode.UNKNOWN_PERMISSION,
+            safe_message="x" * 256,
+            evaluated_at=datetime.now(UTC),
+        )

--- a/tests/tools/fakes.py
+++ b/tests/tools/fakes.py
@@ -6,6 +6,7 @@ from typing import ClassVar
 
 from pydantic import BaseModel, ConfigDict
 
+from core.enums import Permission
 from core.tools import JsonValue, Tool, ToolExecutionContext, ToolRiskLevel
 
 
@@ -23,7 +24,7 @@ class FakeTool(Tool[FakeInput]):
     name = "fake_read"
     description = "Read one deterministic fake resource."
     input_type = FakeInput
-    required_permissions = frozenset({"workspace.read"})
+    required_permissions = frozenset({Permission.FILESYSTEM_READ})
     risk_level = ToolRiskLevel.LOW
     timeout_seconds = 1.0
     calls: ClassVar[int] = 0

--- a/tests/tools/test_default_registry.py
+++ b/tests/tools/test_default_registry.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from core.enums import Permission
 from infrastructure.tools import create_default_tool_registry
 
 
@@ -21,11 +22,13 @@ def test_default_registry_definitions_are_read_only_and_bounded() -> None:
     registry = create_default_tool_registry()
 
     definitions = {definition.name: definition for definition in registry.definitions}
-    assert definitions["read_file"].required_permissions == frozenset({"workspace.read"})
-    assert definitions["list_files"].required_permissions == frozenset({"workspace.list"})
-    assert definitions["search_text"].required_permissions == frozenset({"workspace.search"})
-    assert definitions["git_status"].required_permissions == frozenset({"git.read"})
-    assert definitions["git_diff"].required_permissions == frozenset({"git.read"})
+    assert definitions["read_file"].required_permissions == frozenset({Permission.FILESYSTEM_READ})
+    assert definitions["list_files"].required_permissions == frozenset({Permission.FILESYSTEM_READ})
+    assert definitions["search_text"].required_permissions == frozenset(
+        {Permission.FILESYSTEM_READ}
+    )
+    assert definitions["git_status"].required_permissions == frozenset({Permission.GIT_READ})
+    assert definitions["git_diff"].required_permissions == frozenset({Permission.GIT_READ})
     assert all(definition.risk_level.value == "LOW" for definition in definitions.values())
     assert all(0 < definition.timeout_seconds <= 30 for definition in definitions.values())
     assert all(

--- a/tests/tools/test_executor.py
+++ b/tests/tools/test_executor.py
@@ -11,6 +11,13 @@ from typing import cast
 import pytest
 from pydantic import BaseModel, ConfigDict
 
+from core.enums import Permission
+from core.permissions import (
+    PermissionDecision,
+    PermissionEngine,
+    PermissionOutcome,
+    PermissionReasonCode,
+)
 from core.tools import (
     JsonValue,
     Tool,
@@ -27,6 +34,7 @@ from core.tools import (
     ToolRiskLevel,
     ToolWorkspaceError,
 )
+from tests.permissions.fakes import RecordingPermissionAudit, RecordingPolicy
 from tests.tools.fakes import FakeTool
 
 
@@ -53,6 +61,12 @@ class RecordingAuditRecorder:
         self.finishes.append(finish)
 
 
+class _FailingPermissionAudit:
+    def record(self, decision: PermissionDecision) -> None:
+        del decision
+        raise RuntimeError("secret-permission-audit-marker")
+
+
 def _context(workspace_root: Path, **changes: object) -> ToolExecutionContext:
     values: dict[str, object] = {
         "workspace_root": workspace_root,
@@ -61,11 +75,21 @@ def _context(workspace_root: Path, **changes: object) -> ToolExecutionContext:
         "project_id": uuid.uuid4(),
         "task_id": uuid.uuid4(),
         "declared_tool_ids": {"fake_read"},
-        "permission_ids": {"workspace.read"},
         "correlation_id": uuid.uuid4(),
     }
     values.update(changes)
     return ToolExecutionContext.model_validate(values, strict=True)
+
+
+def _permission_engine(
+    outcome: PermissionOutcome = PermissionOutcome.ALLOW,
+) -> PermissionEngine:
+    reason = {
+        PermissionOutcome.ALLOW: PermissionReasonCode.GRANTED,
+        PermissionOutcome.DENY: PermissionReasonCode.MISSING_PERMISSION,
+        PermissionOutcome.ASK: PermissionReasonCode.HUMAN_APPROVAL_REQUIRED,
+    }[outcome]
+    return PermissionEngine(RecordingPolicy(outcome, reason), RecordingPermissionAudit())
 
 
 def test_executor_calls_registered_tool_once_and_audits_success(
@@ -73,12 +97,16 @@ def test_executor_calls_registered_tool_once_and_audits_success(
     fake_tool: FakeTool,
 ) -> None:
     recorder = RecordingAuditRecorder()
+    policy = RecordingPolicy(PermissionOutcome.ALLOW, PermissionReasonCode.GRANTED)
+    permission_audit = RecordingPermissionAudit()
+    permission_engine = PermissionEngine(policy, permission_audit)
+    context = _context(tmp_path)
 
     result = asyncio.run(
-        ToolExecutor(ToolRegistry([fake_tool]), recorder).execute(
+        ToolExecutor(ToolRegistry([fake_tool]), recorder, permission_engine).execute(
             "fake_read",
             {"path": "README.md"},
-            _context(tmp_path),
+            context,
         )
     )
 
@@ -89,18 +117,69 @@ def test_executor_calls_registered_tool_once_and_audits_success(
     assert len(recorder.starts) == 1
     assert recorder.starts[0].argument_count == 1
     assert recorder.finishes[0].outcome is ToolAuditOutcome.SUCCEEDED
+    assert len(policy.requests) == 1
+    assert policy.requests[0].required_permissions == frozenset({Permission.FILESYSTEM_READ})
+    assert policy.requests[0].agent_run_id == context.agent_run_id
+    assert permission_audit.decisions[0].outcome is PermissionOutcome.ALLOW
+
+
+def test_executor_does_not_evaluate_permissions_for_unknown_or_undeclared_tools(
+    tmp_path: Path,
+    fake_tool: FakeTool,
+) -> None:
+    policy = RecordingPolicy(PermissionOutcome.ALLOW, PermissionReasonCode.GRANTED)
+    engine = PermissionEngine(policy, RecordingPermissionAudit())
+
+    for tool_name, context in (
+        ("unknown", _context(tmp_path)),
+        ("fake_read", _context(tmp_path, declared_tool_ids={"another_tool"})),
+    ):
+        result = asyncio.run(
+            ToolExecutor(ToolRegistry([fake_tool]), RecordingAuditRecorder(), engine).execute(
+                tool_name, {}, context
+            )
+        )
+        assert result.status is ToolResultStatus.DENIED
+
+    assert policy.requests == []
+    assert FakeTool.calls == 0
+
+
+def test_executor_fails_closed_when_permission_audit_is_unavailable(
+    tmp_path: Path,
+    fake_tool: FakeTool,
+) -> None:
+    recorder = RecordingAuditRecorder()
+    engine = PermissionEngine(
+        RecordingPolicy(PermissionOutcome.ALLOW, PermissionReasonCode.GRANTED),
+        _FailingPermissionAudit(),
+    )
+
+    result = asyncio.run(
+        ToolExecutor(ToolRegistry([fake_tool]), recorder, engine).execute(
+            "fake_read", {"path": "README.md"}, _context(tmp_path)
+        )
+    )
+
+    assert result.status is ToolResultStatus.FAILED
+    assert result.error_code is ToolErrorCode.PERMISSION_AUDIT_FAILED
+    assert "secret-permission-audit-marker" not in repr(result)
+    assert recorder.finishes[0].outcome is ToolAuditOutcome.FAILED
+    assert FakeTool.calls == 0
 
 
 @pytest.mark.parametrize(
-    ("tool_name", "context_changes", "expected_code"),
+    ("tool_name", "context_changes", "outcome", "expected_code"),
     [
-        ("unknown", {}, ToolErrorCode.TOOL_NOT_FOUND),
+        ("unknown", {}, PermissionOutcome.ALLOW, ToolErrorCode.TOOL_NOT_FOUND),
         (
             "fake_read",
             {"declared_tool_ids": {"another_tool"}},
+            PermissionOutcome.ALLOW,
             ToolErrorCode.TOOL_NOT_DECLARED,
         ),
-        ("fake_read", {"permission_ids": {"git.read"}}, ToolErrorCode.PERMISSION_DENIED),
+        ("fake_read", {}, PermissionOutcome.DENY, ToolErrorCode.PERMISSION_DENIED),
+        ("fake_read", {}, PermissionOutcome.ASK, ToolErrorCode.APPROVAL_REQUIRED),
     ],
 )
 def test_executor_denies_before_tool_execution_and_audits_attempt(
@@ -108,12 +187,13 @@ def test_executor_denies_before_tool_execution_and_audits_attempt(
     fake_tool: FakeTool,
     tool_name: str,
     context_changes: dict[str, object],
+    outcome: PermissionOutcome,
     expected_code: ToolErrorCode,
 ) -> None:
     recorder = RecordingAuditRecorder()
 
     result = asyncio.run(
-        ToolExecutor(ToolRegistry([fake_tool]), recorder).execute(
+        ToolExecutor(ToolRegistry([fake_tool]), recorder, _permission_engine(outcome)).execute(
             tool_name,
             {"secret-field-marker": "secret-value-marker"},
             _context(tmp_path, **context_changes),
@@ -145,7 +225,7 @@ def test_executor_rejects_invalid_input_without_calling_tool(
     recorder = RecordingAuditRecorder()
 
     result = asyncio.run(
-        ToolExecutor(ToolRegistry([fake_tool]), recorder).execute(
+        ToolExecutor(ToolRegistry([fake_tool]), recorder, _permission_engine()).execute(
             "fake_read", arguments, _context(tmp_path)
         )
     )
@@ -165,7 +245,7 @@ class _BlockingTool(Tool[_NoInput]):
     name = "blocking"
     description = "Wait until cancelled or timed out."
     input_type = _NoInput
-    required_permissions = frozenset({"workspace.read"})
+    required_permissions = frozenset({Permission.FILESYSTEM_READ})
     risk_level = ToolRiskLevel.LOW
     timeout_seconds = 0.01
 
@@ -190,7 +270,7 @@ class _FailureTool(Tool[_NoInput]):
     name = "failure"
     description = "Produce one deterministic failure."
     input_type = _NoInput
-    required_permissions = frozenset({"workspace.read"})
+    required_permissions = frozenset({Permission.FILESYSTEM_READ})
     risk_level = ToolRiskLevel.LOW
     timeout_seconds = 1.0
 
@@ -232,7 +312,9 @@ def test_executor_sanitizes_tool_and_output_failures(
     context = _context(tmp_path, declared_tool_ids={"failure"})
 
     result = asyncio.run(
-        ToolExecutor(ToolRegistry([tool]), recorder).execute("failure", {}, context)
+        ToolExecutor(ToolRegistry([tool]), recorder, _permission_engine()).execute(
+            "failure", {}, context
+        )
     )
 
     assert result.status is ToolResultStatus.FAILED
@@ -248,11 +330,12 @@ def test_executor_times_out_once_without_retry(tmp_path: Path) -> None:
     context = _context(
         tmp_path,
         declared_tool_ids={"blocking"},
-        permission_ids={"workspace.read"},
     )
 
     result = asyncio.run(
-        ToolExecutor(ToolRegistry([tool]), recorder).execute("blocking", {}, context)
+        ToolExecutor(ToolRegistry([tool]), recorder, _permission_engine()).execute(
+            "blocking", {}, context
+        )
     )
 
     assert result.status is ToolResultStatus.TIMED_OUT
@@ -269,7 +352,9 @@ def test_executor_propagates_cancellation_after_audit(tmp_path: Path) -> None:
 
     async def cancel_operation() -> None:
         operation = asyncio.create_task(
-            ToolExecutor(ToolRegistry([tool]), recorder).execute("blocking", {}, context)
+            ToolExecutor(ToolRegistry([tool]), recorder, _permission_engine()).execute(
+                "blocking", {}, context
+            )
         )
         while tool.started is None:
             await asyncio.sleep(0)
@@ -291,7 +376,7 @@ def test_executor_fails_closed_when_audit_begin_fails(
 
     with pytest.raises(ToolAuditError, match="Tool audit is unavailable") as captured:
         asyncio.run(
-            ToolExecutor(ToolRegistry([fake_tool]), recorder).execute(
+            ToolExecutor(ToolRegistry([fake_tool]), recorder, _permission_engine()).execute(
                 "fake_read", {"path": "README.md"}, _context(tmp_path)
             )
         )
@@ -308,7 +393,7 @@ def test_executor_surfaces_sanitized_terminal_audit_failure(
 
     with pytest.raises(ToolAuditError, match="Tool audit could not be finalized") as captured:
         asyncio.run(
-            ToolExecutor(ToolRegistry([fake_tool]), recorder).execute(
+            ToolExecutor(ToolRegistry([fake_tool]), recorder, _permission_engine()).execute(
                 "fake_read", {"path": "README.md"}, _context(tmp_path)
             )
         )

--- a/tests/tools/test_filesystem_tools.py
+++ b/tests/tools/test_filesystem_tools.py
@@ -30,7 +30,6 @@ def _context(workspace_root: Path) -> ToolExecutionContext:
         project_id=uuid.uuid4(),
         task_id=uuid.uuid4(),
         declared_tool_ids={"read_file", "list_files", "search_text"},
-        permission_ids={"workspace.read", "workspace.list", "workspace.search"},
         correlation_id=uuid.uuid4(),
     )
 

--- a/tests/tools/test_git_tools.py
+++ b/tests/tools/test_git_tools.py
@@ -53,7 +53,6 @@ def _context(workspace_root: Path) -> ToolExecutionContext:
         project_id=uuid.uuid4(),
         task_id=uuid.uuid4(),
         declared_tool_ids={"git_status", "git_diff"},
-        permission_ids={"git.read"},
         correlation_id=uuid.uuid4(),
     )
 

--- a/tests/tools/test_registry.py
+++ b/tests/tools/test_registry.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import pytest
 from pydantic import BaseModel
 
+from core.enums import Permission
 from core.tools import (
     ToolDefinitionError,
     ToolErrorCode,
@@ -22,7 +23,7 @@ def test_registry_exposes_one_explicit_tool(fake_tool: FakeTool) -> None:
     definition = registry.definitions[0]
     assert definition.name == "fake_read"
     assert definition.input_schema == FakeTool.input_type.model_json_schema()
-    assert definition.required_permissions == frozenset({"workspace.read"})
+    assert definition.required_permissions == frozenset({Permission.FILESYSTEM_READ})
     assert definition.risk_level is ToolRiskLevel.LOW
     assert definition.timeout_seconds == 1.0
 
@@ -59,6 +60,7 @@ def test_registry_rejects_duplicate_names_without_exposing_name(fake_tool: FakeT
         ("name", "INVALID"),
         ("description", " "),
         ("required_permissions", frozenset()),
+        ("required_permissions", frozenset({"filesystem.read"})),
         ("required_permissions", frozenset({"../escape"})),
         ("risk_level", "LOW"),
         ("timeout_seconds", 0.0),

--- a/tests/tools/test_types.py
+++ b/tests/tools/test_types.py
@@ -24,7 +24,6 @@ def _context(workspace_root: Path, **changes: object) -> ToolExecutionContext:
         "project_id": uuid.uuid4(),
         "task_id": uuid.uuid4(),
         "declared_tool_ids": {"read_file"},
-        "permission_ids": {"workspace.read"},
         "correlation_id": uuid.uuid4(),
     }
     values.update(changes)
@@ -39,7 +38,6 @@ def test_execution_context_canonicalizes_root_and_freezes_capabilities(tmp_path:
 
     assert context.workspace_root == nested.resolve()
     assert context.declared_tool_ids == frozenset({"read_file"})
-    assert context.permission_ids == frozenset({"workspace.read"})
     with pytest.raises(ValidationError):
         context.agent_id = "changed"  # type: ignore[misc]
 
@@ -49,7 +47,6 @@ def test_execution_context_canonicalizes_root_and_freezes_capabilities(tmp_path:
     [
         ({"agent_id": "UPPERCASE"}, "UPPERCASE"),
         ({"declared_tool_ids": {"../escape"}}, "../escape"),
-        ({"permission_ids": set()}, "unused-marker"),
     ],
 )
 def test_execution_context_rejects_invalid_identifiers(


### PR DESCRIPTION
## Summary
- add the canonical eleven-permission model and scoped PostgreSQL grants
- enforce audited ALLOW, DENY, and ASK decisions before every declared tool execution
- document authority, transaction ownership, audit minimization, and Phase 7 boundaries

## Verification
- 573 tests passed against real PostgreSQL
- Ruff check and format check passed
- mypy strict passed
- Alembic current: 20260826_0003 (head)
- Alembic check: no new upgrade operations
- Docker API and PostgreSQL healthy; /health returned {"status":"ok"}

## Scope
Phase 7 only. No skills registry, approval workflow, permission administration API, write/shell/network tools, MCP, RLS, or PostgreSQL triggers.