### PR TITLE
feat(runtime): deliver bounded Loop Engineering and Developer Agent

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,7 +8,8 @@ The repository has completed **Phase 1 — repository initialization**, **Phase 
 model**, **Phase 3 — task state machine**, **Phase 4 — LLM provider boundary**, **Phase 5 — agent
 core**, **Phase 6 — tool registry**, **Phase 7 — permission engine**, **Phase 8 — Skills
 Registry**, **Phase 9 — workspace isolation**, **Phase 10 — transactional write tools**, and
-**Phase 11 — secure command profiles**, and **Phase 13 — Loop Engineering V1**. Phase 12 remains
+**Phase 11 — secure command profiles**, **Phase 13 — Loop Engineering V1**, and **Phase 14 —
+Developer Agent**. Phase 12 remains
 deliberately unimplemented. It
 contains a minimal FastAPI application, typed
 SQLAlchemy models, Alembic migrations, append-only history protection, an audited task workflow,
@@ -18,16 +19,18 @@ permission engine with audited `ALLOW`/`DENY`/`ASK` decisions, a PostgreSQL Dock
 Compose service, a bounded local registry of five versioned instructional skills, managed
 per-project workspaces with audited bounded Git import and cleanup, four permissioned
 compensatable UTF-8 file mutation tools, ten fixed test/lint/build/read-only-Git command profiles,
-a bounded provider-neutral single-agent loop with sanitized append-only step auditing, and
+a bounded provider-neutral single-agent loop with sanitized append-only step auditing, a bounded
+Developer role using deterministic skill context and real secure repository tools, and
 real-PostgreSQL integration tests.
 
 Phase 7 authorizes tools exclusively from active persisted `AgentPermission` grants. Phase 8 can
-load and rank local `SKILL.md` packages, but `skill_ids` remain inert declarations and skill content
-is never automatically executed or injected into prompts. Phase 9 provides local filesystem
+load and rank local `SKILL.md` packages. Phase 14 may inject only selected, complete, bounded skill
+instructions into ephemeral Developer context; skills remain subordinate data and never grant
+authority or execute directly. Phase 9 provides local filesystem
 isolation behind a backend-neutral contract; it is not an operating-system sandbox or execution
 container. Phase 11 command execution is an application-level fixed-profile boundary, not a
 hostile-code sandbox. The repository does not include a free-form shell, MCP access, provider
-routing, or multi-agent behavior. Phase 12 and Phase 14+ are not implemented.
+routing, or multi-agent behavior. Phase 12 and Phase 15+ are not implemented.
 In particular, there is no arbitrary terminal, approval workflow, MCP integration,
 QA/security engine, provider router, or frontend. Do not implement work from a later phase unless
 the user explicitly starts that phase.
@@ -50,6 +53,7 @@ Current source layout:
 - `infrastructure/tools/write.py` and `mutations.py` — bounded transactional file writes.
 - `core/commands/` and `infrastructure/commands/` — fixed command contracts, policy, and runner.
 - `core/runtime/` and `infrastructure/runtime/` — bounded one-agent loop and runtime-step audit.
+- `core/developer/` — Phase 14 role validation, skill context, evidence, reporting, and composition.
 - `skills/` — five repository-owned versioned V1 skill packages.
 - `alembic/` — PostgreSQL migrations.
 - `tests/` — unit and real-PostgreSQL integration tests.
@@ -80,6 +84,12 @@ For the focused Phase 13 runtime and PostgreSQL audit tests, run:
 
 ```bash
 TEST_POSTGRES_PORT=55432 .venv/bin/pytest tests/runtime tests/database/test_runtime_audit.py -q
+```
+
+For the focused Phase 14 Developer tests, run:
+
+```bash
+.venv/bin/pytest tests/developer -q
 ```
 
 Run a single test with:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,7 +8,8 @@ The repository has completed **Phase 1 — repository initialization**, **Phase 
 model**, **Phase 3 — task state machine**, **Phase 4 — LLM provider boundary**, **Phase 5 — agent
 core**, **Phase 6 — tool registry**, **Phase 7 — permission engine**, **Phase 8 — Skills
 Registry**, **Phase 9 — workspace isolation**, **Phase 10 — transactional write tools**, and
-**Phase 11 — secure command profiles**. It
+**Phase 11 — secure command profiles**, and **Phase 13 — Loop Engineering V1**. Phase 12 remains
+deliberately unimplemented. It
 contains a minimal FastAPI application, typed
 SQLAlchemy models, Alembic migrations, append-only history protection, an audited task workflow,
 bounded provider-neutral LLM contracts, an Ollama adapter, a bounded runtime agent with four
@@ -17,15 +18,16 @@ permission engine with audited `ALLOW`/`DENY`/`ASK` decisions, a PostgreSQL Dock
 Compose service, a bounded local registry of five versioned instructional skills, managed
 per-project workspaces with audited bounded Git import and cleanup, four permissioned
 compensatable UTF-8 file mutation tools, ten fixed test/lint/build/read-only-Git command profiles,
-and real-PostgreSQL integration tests.
+a bounded provider-neutral single-agent loop with sanitized append-only step auditing, and
+real-PostgreSQL integration tests.
 
 Phase 7 authorizes tools exclusively from active persisted `AgentPermission` grants. Phase 8 can
 load and rank local `SKILL.md` packages, but `skill_ids` remain inert declarations and skill content
 is never automatically executed or injected into prompts. Phase 9 provides local filesystem
 isolation behind a backend-neutral contract; it is not an operating-system sandbox or execution
 container. Phase 11 command execution is an application-level fixed-profile boundary, not a
-hostile-code sandbox. The repository does not include autonomous loops, a free-form shell, MCP
-access, provider routing, or multi-agent behavior. Phase 12 and later phases are not implemented.
+hostile-code sandbox. The repository does not include a free-form shell, MCP access, provider
+routing, or multi-agent behavior. Phase 12 and Phase 14+ are not implemented.
 In particular, there is no arbitrary terminal, approval workflow, MCP integration,
 QA/security engine, provider router, or frontend. Do not implement work from a later phase unless
 the user explicitly starts that phase.
@@ -47,6 +49,7 @@ Current source layout:
 - `infrastructure/workspaces/` — isolated local workspace, Git, and audit adapters.
 - `infrastructure/tools/write.py` and `mutations.py` — bounded transactional file writes.
 - `core/commands/` and `infrastructure/commands/` — fixed command contracts, policy, and runner.
+- `core/runtime/` and `infrastructure/runtime/` — bounded one-agent loop and runtime-step audit.
 - `skills/` — five repository-owned versioned V1 skill packages.
 - `alembic/` — PostgreSQL migrations.
 - `tests/` — unit and real-PostgreSQL integration tests.
@@ -73,10 +76,10 @@ For repository acceptance against the Docker PostgreSQL port, run:
 TEST_POSTGRES_PORT=55432 make test
 ```
 
-For the focused Phase 11 command, tool, and PostgreSQL tests, run:
+For the focused Phase 13 runtime and PostgreSQL audit tests, run:
 
 ```bash
-TEST_POSTGRES_PORT=55432 .venv/bin/pytest tests/commands tests/tools/test_command_tool.py tests/database/test_command_tool_execution.py -q
+TEST_POSTGRES_PORT=55432 .venv/bin/pytest tests/runtime tests/database/test_runtime_audit.py -q
 ```
 
 Run a single test with:

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 > The operating system for autonomous AI organizations.
 
-[![Status](https://img.shields.io/badge/status-Phase_11-orange)](SYNAPSEOS_DEVELOPMENT_CHECKLIST.md)
+[![Status](https://img.shields.io/badge/status-Phase_13-orange)](SYNAPSEOS_DEVELOPMENT_CHECKLIST.md)
 [![Python](https://img.shields.io/badge/python-3.12%2B-blue)](https://www.python.org/)
 [![Code style: Ruff](https://img.shields.io/badge/code_style-ruff-blueviolet)](https://docs.astral.sh/ruff/)
 [![Types: mypy](https://img.shields.io/badge/types-mypy-blue)](https://mypy-lang.org/)
@@ -48,12 +48,12 @@ See [`docs/cahier de charges.md`](docs/cahier%20de%20charges.md) for the full pr
 
 ## Status
 
-**Phase 11 — Secure command profiles completed.** The repository now provides the persistence foundation, an
+**Phase 13 — Loop Engineering V1 completed.** The repository now provides the persistence foundation, an
 audited task workflow, provider-neutral LLM contracts with an Ollama adapter, a bounded runtime
 agent, five read-only repository tools, deny-by-default PostgreSQL permission enforcement, a
 bounded deterministic registry of versioned skills, isolated audited project workspaces, and four
 compensatable UTF-8 write tools and fixed, bounded test/lint/build/read-only-Git profiles. A
-free-form shell, MCP, autonomous loops, multi-agent coordination, QA and security
+free-form shell, MCP, multi-agent coordination, QA and security
 engines, and the frontend remain intentionally unimplemented.
 
 What exists today:
@@ -87,6 +87,9 @@ What exists today:
 - Ten immutable command profiles with deterministic stack detection, exact managed cwd, sanitized
   environment, bounded concurrent output capture, timeout/cancellation cleanup, and audited
   `shell.execute` authorization. No arbitrary shell or model-controlled arguments are exposed.
+- A provider-neutral single-agent loop with finite iteration, timeout, failure, tool-call, token,
+  history, and stagnation limits, sanitized append-only runtime audit, immediate permission
+  escalation, and cancellation propagation.
 - A full tooling baseline: `pytest`, `Ruff`, `mypy` (strict), plus `Dockerfile` and
   `docker-compose.yml` for the API + PostgreSQL.
 
@@ -168,10 +171,10 @@ The complete suite uses the Docker PostgreSQL service when it is exposed on the 
 TEST_POSTGRES_PORT=55432 make test
 ```
 
-The focused Phase 11 suite covers command policy, process lifecycle, tools, and PostgreSQL audit:
+The focused Phase 13 suite covers bounded runtime behavior and PostgreSQL audit:
 
 ```bash
-TEST_POSTGRES_PORT=55432 .venv/bin/pytest tests/commands tests/tools/test_command_tool.py tests/database/test_command_tool_execution.py -q
+TEST_POSTGRES_PORT=55432 .venv/bin/pytest tests/runtime tests/database/test_runtime_audit.py -q
 ```
 
 Run `make help` to list every available target.
@@ -195,7 +198,9 @@ validated pull request. The near-term sequence is:
 9. **Workspace and isolation** — completed
 10. **Write tools** — completed
 11. **Secure command runner** — completed
-12. MCP client — not started
+12. MCP client — deliberately not started
+13. **Loop Engineering V1** — completed
+14. Developer Agent — not started
 
 The complete phased plan (up to a full engineering organisation) lives in
 [`SYNAPSEOS_DEVELOPMENT_CHECKLIST.md`](SYNAPSEOS_DEVELOPMENT_CHECKLIST.md).
@@ -212,6 +217,7 @@ The complete phased plan (up to a full engineering organisation) lives in
 - **Managed project workspaces:** [`docs/workspaces.md`](docs/workspaces.md)
 - **Transactional write tools:** [`docs/write-tools.md`](docs/write-tools.md)
 - **Secure command profiles:** [`docs/commands.md`](docs/commands.md)
+- **Loop Engineering V1:** [`docs/runtime.md`](docs/runtime.md)
 - **Architecture decisions (ADRs):** [`docs/adr/`](docs/adr/)
 - **Repository working agreement:** [`AGENTS.md`](AGENTS.md)
 

--- a/README.md
+++ b/README.md
@@ -53,8 +53,8 @@ audited task workflow, provider-neutral LLM contracts with an Ollama adapter, a 
 agent, five read-only repository tools, deny-by-default PostgreSQL permission enforcement, a
 bounded deterministic registry of versioned skills, isolated audited project workspaces, and four
 compensatable UTF-8 write tools and fixed, bounded test/lint/build/read-only-Git profiles. A
-free-form shell, MCP, multi-agent coordination, QA and security
-  engines, ReviewerAgent, and the frontend remain intentionally unimplemented.
+free-form shell, MCP, multi-agent coordination, QA and security engines, ReviewerAgent, and the
+frontend remain intentionally unimplemented.
 
 What exists today:
 
@@ -86,7 +86,8 @@ What exists today:
   backups, atomic replacement, bounded diffs, risk-aware authorization, audit, and rollback.
 - Ten immutable command profiles with deterministic stack detection, exact managed cwd, sanitized
   environment, bounded concurrent output capture, timeout/cancellation cleanup, and audited
-  `shell.execute` authorization. No arbitrary shell or model-controlled arguments are exposed.
+  persisted `shell.execute` plus `tests.execute` authorization. No arbitrary shell or
+  model-controlled arguments are exposed.
 - A provider-neutral single-agent loop with finite iteration, timeout, failure, tool-call, token,
   history, and stagnation limits, sanitized append-only runtime audit, immediate permission
   escalation, and cancellation propagation.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 > The operating system for autonomous AI organizations.
 
-[![Status](https://img.shields.io/badge/status-Phase_13-orange)](SYNAPSEOS_DEVELOPMENT_CHECKLIST.md)
+[![Status](https://img.shields.io/badge/status-Phase_14-orange)](SYNAPSEOS_DEVELOPMENT_CHECKLIST.md)
 [![Python](https://img.shields.io/badge/python-3.12%2B-blue)](https://www.python.org/)
 [![Code style: Ruff](https://img.shields.io/badge/code_style-ruff-blueviolet)](https://docs.astral.sh/ruff/)
 [![Types: mypy](https://img.shields.io/badge/types-mypy-blue)](https://mypy-lang.org/)
@@ -48,13 +48,13 @@ See [`docs/cahier de charges.md`](docs/cahier%20de%20charges.md) for the full pr
 
 ## Status
 
-**Phase 13 — Loop Engineering V1 completed.** The repository now provides the persistence foundation, an
+**Phase 14 — Developer Agent completed.** The repository now provides the persistence foundation, an
 audited task workflow, provider-neutral LLM contracts with an Ollama adapter, a bounded runtime
 agent, five read-only repository tools, deny-by-default PostgreSQL permission enforcement, a
 bounded deterministic registry of versioned skills, isolated audited project workspaces, and four
 compensatable UTF-8 write tools and fixed, bounded test/lint/build/read-only-Git profiles. A
 free-form shell, MCP, multi-agent coordination, QA and security
-engines, and the frontend remain intentionally unimplemented.
+  engines, ReviewerAgent, and the frontend remain intentionally unimplemented.
 
 What exists today:
 
@@ -90,6 +90,9 @@ What exists today:
 - A provider-neutral single-agent loop with finite iteration, timeout, failure, tool-call, token,
   history, and stagnation limits, sanitized append-only runtime audit, immediate permission
   escalation, and cancellation propagation.
+- A bounded Developer role that validates scope and authority before work, selects complete
+  subordinate skills, composes the single-agent loop, uses real repository tools and fixed checks,
+  and derives a metadata-only report that cannot hide missing or failed tests.
 - A full tooling baseline: `pytest`, `Ruff`, `mypy` (strict), plus `Dockerfile` and
   `docker-compose.yml` for the API + PostgreSQL.
 
@@ -135,8 +138,8 @@ make dev         # run the API with autoreload on http://localhost:8000
 
 ```text
 apps/api/                 # FastAPI application (Platform API)
-core/                     # Domain layer (placeholders filled in later phases)
-  agents/ commands/ tasks/ runtime/ memory/ skills/ tools/ scoring/ permissions/ workspaces/
+core/                     # Domain and application boundaries
+  agents/ commands/ developer/ tasks/ runtime/ memory/ skills/ tools/ scoring/ permissions/ workspaces/
   config.py               # Application settings (env-driven)
 infrastructure/           # Adapters to the outside world
   database/               # SQLAlchemy models, sessions, repositories, and append-only guard
@@ -177,6 +180,12 @@ The focused Phase 13 suite covers bounded runtime behavior and PostgreSQL audit:
 TEST_POSTGRES_PORT=55432 .venv/bin/pytest tests/runtime tests/database/test_runtime_audit.py -q
 ```
 
+The focused Phase 14 suite covers the Developer role and real repository-tool workflows:
+
+```bash
+.venv/bin/pytest tests/developer -q
+```
+
 Run `make help` to list every available target.
 
 **Working agreement:** changes are test-driven (write the failing test first), and `make check`
@@ -200,7 +209,8 @@ validated pull request. The near-term sequence is:
 11. **Secure command runner** — completed
 12. MCP client — deliberately not started
 13. **Loop Engineering V1** — completed
-14. Developer Agent — not started
+14. **Developer Agent** — completed
+15. Reviewer Agent — not started
 
 The complete phased plan (up to a full engineering organisation) lives in
 [`SYNAPSEOS_DEVELOPMENT_CHECKLIST.md`](SYNAPSEOS_DEVELOPMENT_CHECKLIST.md).
@@ -218,6 +228,7 @@ The complete phased plan (up to a full engineering organisation) lives in
 - **Transactional write tools:** [`docs/write-tools.md`](docs/write-tools.md)
 - **Secure command profiles:** [`docs/commands.md`](docs/commands.md)
 - **Loop Engineering V1:** [`docs/runtime.md`](docs/runtime.md)
+- **Developer Agent:** [`docs/developer-agent.md`](docs/developer-agent.md)
 - **Architecture decisions (ADRs):** [`docs/adr/`](docs/adr/)
 - **Repository working agreement:** [`AGENTS.md`](AGENTS.md)
 

--- a/SYNAPSEOS_DEVELOPMENT_CHECKLIST.md
+++ b/SYNAPSEOS_DEVELOPMENT_CHECKLIST.md
@@ -1065,15 +1065,15 @@ Créer le premier véritable rôle métier.
 
 Responsabilités :
 
-- [ ] comprendre une tâche
-- [ ] inspecter repository
-- [ ] sélectionner skills
-- [ ] planifier
-- [ ] modifier code
-- [ ] exécuter tests
-- [ ] analyser erreurs
-- [ ] corriger
-- [ ] produire rapport
+- [x] comprendre une tâche
+- [x] inspecter repository
+- [x] sélectionner skills
+- [x] planifier
+- [x] modifier code
+- [x] exécuter tests
+- [x] analyser erreurs
+- [x] corriger
+- [x] produire rapport
 
 ## Prompt Claude Code — Phase 14
 

--- a/SYNAPSEOS_DEVELOPMENT_CHECKLIST.md
+++ b/SYNAPSEOS_DEVELOPMENT_CHECKLIST.md
@@ -1006,13 +1006,13 @@ flowchart TD
 
 ## Garde-fous
 
-- [ ] `max_iterations`
-- [ ] timeout global
-- [ ] maximum failures
-- [ ] tool call budget
-- [ ] token budget
-- [ ] loop stagnation detection
-- [ ] human escalation
+- [x] `max_iterations`
+- [x] timeout global
+- [x] maximum failures
+- [x] tool call budget
+- [x] token budget
+- [x] loop stagnation detection
+- [x] human escalation
 
 ## Prompt Claude Code — Phase 13
 

--- a/core/developer/__init__.py
+++ b/core/developer/__init__.py
@@ -1,5 +1,6 @@
 """Bounded Developer Agent composition for Phase 14."""
 
+from core.developer.agent import DeveloperAgent
 from core.developer.errors import DeveloperError, DeveloperErrorCode
 from core.developer.evidence import (
     DeveloperEvidenceSnapshot,
@@ -17,6 +18,7 @@ from core.developer.validation import ValidatedDeveloperRequest, validate_develo
 
 __all__ = [
     "ChangedPath",
+    "DeveloperAgent",
     "DeveloperCheckResult",
     "DeveloperError",
     "DeveloperErrorCode",

--- a/core/developer/__init__.py
+++ b/core/developer/__init__.py
@@ -1,6 +1,11 @@
 """Bounded Developer Agent composition for Phase 14."""
 
 from core.developer.errors import DeveloperError, DeveloperErrorCode
+from core.developer.evidence import (
+    DeveloperEvidenceSnapshot,
+    EvidenceCollectingToolExecutor,
+)
+from core.developer.reporting import build_agent_report
 from core.developer.skills import DeveloperSkillContext, build_skill_context
 from core.developer.types import (
     ChangedPath,
@@ -15,10 +20,13 @@ __all__ = [
     "DeveloperCheckResult",
     "DeveloperError",
     "DeveloperErrorCode",
+    "DeveloperEvidenceSnapshot",
     "DeveloperRequest",
     "DeveloperResult",
     "DeveloperSkillContext",
+    "EvidenceCollectingToolExecutor",
     "ValidatedDeveloperRequest",
     "build_skill_context",
+    "build_agent_report",
     "validate_developer_request",
 ]

--- a/core/developer/__init__.py
+++ b/core/developer/__init__.py
@@ -1,0 +1,21 @@
+"""Bounded Developer Agent composition for Phase 14."""
+
+from core.developer.errors import DeveloperError, DeveloperErrorCode
+from core.developer.types import (
+    ChangedPath,
+    DeveloperCheckResult,
+    DeveloperRequest,
+    DeveloperResult,
+)
+from core.developer.validation import ValidatedDeveloperRequest, validate_developer_request
+
+__all__ = [
+    "ChangedPath",
+    "DeveloperCheckResult",
+    "DeveloperError",
+    "DeveloperErrorCode",
+    "DeveloperRequest",
+    "DeveloperResult",
+    "ValidatedDeveloperRequest",
+    "validate_developer_request",
+]

--- a/core/developer/__init__.py
+++ b/core/developer/__init__.py
@@ -1,6 +1,7 @@
 """Bounded Developer Agent composition for Phase 14."""
 
 from core.developer.errors import DeveloperError, DeveloperErrorCode
+from core.developer.skills import DeveloperSkillContext, build_skill_context
 from core.developer.types import (
     ChangedPath,
     DeveloperCheckResult,
@@ -16,6 +17,8 @@ __all__ = [
     "DeveloperErrorCode",
     "DeveloperRequest",
     "DeveloperResult",
+    "DeveloperSkillContext",
     "ValidatedDeveloperRequest",
+    "build_skill_context",
     "validate_developer_request",
 ]

--- a/core/developer/agent.py
+++ b/core/developer/agent.py
@@ -1,0 +1,69 @@
+"""Phase 14 Developer role composed over the bounded AgentRuntime."""
+
+from __future__ import annotations
+
+from core.developer.evidence import EvidenceCollectingToolExecutor
+from core.developer.reporting import build_agent_report
+from core.developer.skills import build_skill_context
+from core.developer.types import DeveloperRequest, DeveloperResult
+from core.developer.validation import validate_developer_request
+from core.llm import LLMProvider
+from core.runtime import (
+    AgentRuntime,
+    LLMLoopReasoner,
+    RuntimeAuditRecorder,
+    RuntimeLimits,
+    RuntimeToolExecutor,
+)
+from core.skills import SkillRegistry
+
+
+class DeveloperAgent:
+    """Execute one scoped Developer task without owning injected resources."""
+
+    def __init__(
+        self,
+        provider: LLMProvider,
+        tool_executor: RuntimeToolExecutor,
+        audit_recorder: RuntimeAuditRecorder,
+        skill_registry: SkillRegistry,
+        limits: RuntimeLimits,
+    ) -> None:
+        self._provider = provider
+        self._tool_executor = tool_executor
+        self._audit_recorder = audit_recorder
+        self._skill_registry = skill_registry
+        self._limits = limits
+
+    async def run(self, request: DeveloperRequest) -> DeveloperResult:
+        """Validate, execute one bounded runtime, and report deterministic evidence."""
+        validated = validate_developer_request(request)
+        skills = build_skill_context(validated, self._skill_registry)
+        evidence_executor = EvidenceCollectingToolExecutor(self._tool_executor)
+        reasoner = LLMLoopReasoner(
+            self._provider,
+            system_prompt=request.profile.system_prompt + skills.prompt_fragment,
+            max_step_tokens=self._limits.max_step_tokens,
+        )
+        runtime = AgentRuntime(
+            reasoner,
+            evidence_executor,
+            self._audit_recorder,
+            self._limits,
+        )
+        runtime_result = await runtime.run(request.task, request.execution_context)
+        evidence = evidence_executor.snapshot()
+        checks = evidence.check_results()
+        report = build_agent_report(
+            runtime_result,
+            request.required_check_profiles,
+            checks,
+        )
+        return DeveloperResult(
+            runtime=runtime_result,
+            report=report,
+            selected_skill_ids=skills.selected_ids,
+            omitted_skill_ids=skills.omitted_ids,
+            changed_paths=evidence.changed_paths,
+            checks=checks,
+        )

--- a/core/developer/errors.py
+++ b/core/developer/errors.py
@@ -1,0 +1,27 @@
+"""Stable sanitized failures for the Developer Agent boundary."""
+
+from __future__ import annotations
+
+from enum import StrEnum
+
+
+class DeveloperErrorCode(StrEnum):
+    """Closed public failure classifications for Phase 14."""
+
+    INVALID_INPUT = "INVALID_INPUT"
+    INVALID_ROLE = "INVALID_ROLE"
+    INACTIVE_AGENT = "INACTIVE_AGENT"
+    INVALID_SCOPE = "INVALID_SCOPE"
+    INVALID_PERMISSION = "INVALID_PERMISSION"
+    INVALID_TOOLS = "INVALID_TOOLS"
+    INVALID_CHECK_PROFILE = "INVALID_CHECK_PROFILE"
+    SKILL_CONTEXT_LIMIT = "SKILL_CONTEXT_LIMIT"
+
+
+class DeveloperError(Exception):
+    """A leak-resistant error carrying one stable classification."""
+
+    def __init__(self, code: DeveloperErrorCode, safe_message: str) -> None:
+        self.code = code
+        self.safe_message = safe_message
+        super().__init__(safe_message)

--- a/core/developer/evidence.py
+++ b/core/developer/evidence.py
@@ -44,10 +44,9 @@ class EvidenceCollectingToolExecutor:
     def __init__(self, delegate: RuntimeToolExecutor) -> None:
         self._delegate = delegate
         self._changed_paths: list[str] = []
-        self._checks: dict[
-            CommandProfileId,
+        self._checks: list[
             tuple[CommandProfileId, CommandCategory, CommandTerminalStatus, int, bool],
-        ] = {}
+        ] = []
         self._failures: list[tuple[str, ToolErrorCode]] = []
         self._record_count = 0
 
@@ -64,7 +63,7 @@ class EvidenceCollectingToolExecutor:
     def snapshot(self) -> DeveloperEvidenceSnapshot:
         return DeveloperEvidenceSnapshot(
             changed_paths=tuple(self._changed_paths),
-            checks=tuple(self._checks.values()),
+            checks=tuple(self._checks),
             failures=tuple(self._failures),
         )
 
@@ -120,5 +119,5 @@ class EvidenceCollectingToolExecutor:
             error.__traceback__ = None
             del error
             return
-        self._checks[profile_id] = (profile_id, category, status, exit_code, truncated)
+        self._checks.append((profile_id, category, status, exit_code, truncated))
         self._record_count += 1

--- a/core/developer/evidence.py
+++ b/core/developer/evidence.py
@@ -70,6 +70,8 @@ class EvidenceCollectingToolExecutor:
     def _observe(self, tool_name: str, arguments: Mapping[str, object], result: ToolResult) -> None:
         if self._record_count >= _MAX_EVIDENCE_RECORDS:
             return
+        if result.tool_name != tool_name:
+            return
         if result.status is not ToolResultStatus.SUCCEEDED:
             if result.error_code is not None:
                 self._failures.append((result.tool_name, result.error_code))
@@ -79,7 +81,7 @@ class EvidenceCollectingToolExecutor:
             self._observe_write(arguments)
             return
         if tool_name == "run_command_profile":
-            self._observe_command(result.output)
+            self._observe_command(arguments, result.output)
 
     def _observe_write(self, arguments: Mapping[str, object]) -> None:
         raw_path = arguments.get("path")
@@ -95,7 +97,9 @@ class EvidenceCollectingToolExecutor:
             self._changed_paths.append(path)
         self._record_count += 1
 
-    def _observe_command(self, output: Mapping[str, object]) -> None:
+    def _observe_command(
+        self, arguments: Mapping[str, object], output: Mapping[str, object]
+    ) -> None:
         try:
             raw_profile_id = output["profile_id"]
             raw_category = output["category"]
@@ -115,9 +119,21 @@ class EvidenceCollectingToolExecutor:
                 raise ValueError
             if type(truncated) is not bool:
                 raise ValueError
-        except (KeyError, TypeError, ValueError) as error:
+            requested_profile = arguments["profile_id"]
+            if not isinstance(requested_profile, str) or requested_profile != profile_id.value:
+                raise ValueError
+            check = DeveloperCheckResult(
+                profile_id=profile_id,
+                category=category,
+                status=status,
+                exit_code=exit_code,
+                truncated=truncated,
+            )
+        except (KeyError, TypeError, ValueError, ValidationError) as error:
             error.__traceback__ = None
             del error
             return
-        self._checks.append((profile_id, category, status, exit_code, truncated))
+        self._checks.append(
+            (check.profile_id, check.category, check.status, check.exit_code, check.truncated)
+        )
         self._record_count += 1

--- a/core/developer/evidence.py
+++ b/core/developer/evidence.py
@@ -1,0 +1,124 @@
+"""Metadata-only observation of Developer tool outcomes."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+
+from pydantic import TypeAdapter, ValidationError
+
+from core.commands import CommandCategory, CommandProfileId, CommandTerminalStatus
+from core.developer.types import ChangedPath, DeveloperCheckResult
+from core.runtime import RuntimeToolExecutor
+from core.tools import ToolErrorCode, ToolExecutionContext, ToolResult, ToolResultStatus
+
+_MAX_EVIDENCE_RECORDS = 128
+_WRITE_TOOLS = frozenset({"write_file", "create_file", "patch_file", "delete_file"})
+_PATH_ADAPTER = TypeAdapter(ChangedPath)
+
+
+@dataclass(frozen=True, slots=True)
+class DeveloperEvidenceSnapshot:
+    """Bounded copied metadata retained after tool execution."""
+
+    changed_paths: tuple[str, ...]
+    checks: tuple[tuple[CommandProfileId, CommandCategory, CommandTerminalStatus, int, bool], ...]
+    failures: tuple[tuple[str, ToolErrorCode], ...]
+
+    def check_results(self) -> tuple[DeveloperCheckResult, ...]:
+        return tuple(
+            DeveloperCheckResult(
+                profile_id=profile_id,
+                category=category,
+                status=status,
+                exit_code=exit_code,
+                truncated=truncated,
+            )
+            for profile_id, category, status, exit_code, truncated in self.checks
+        )
+
+
+class EvidenceCollectingToolExecutor:
+    """Delegate each call once and retain only allowlisted bounded metadata."""
+
+    def __init__(self, delegate: RuntimeToolExecutor) -> None:
+        self._delegate = delegate
+        self._changed_paths: list[str] = []
+        self._checks: dict[
+            CommandProfileId,
+            tuple[CommandProfileId, CommandCategory, CommandTerminalStatus, int, bool],
+        ] = {}
+        self._failures: list[tuple[str, ToolErrorCode]] = []
+        self._record_count = 0
+
+    async def execute(
+        self,
+        tool_name: str,
+        arguments: Mapping[str, object],
+        context: ToolExecutionContext,
+    ) -> ToolResult:
+        result = await self._delegate.execute(tool_name, arguments, context)
+        self._observe(tool_name, arguments, result)
+        return result
+
+    def snapshot(self) -> DeveloperEvidenceSnapshot:
+        return DeveloperEvidenceSnapshot(
+            changed_paths=tuple(self._changed_paths),
+            checks=tuple(self._checks.values()),
+            failures=tuple(self._failures),
+        )
+
+    def _observe(self, tool_name: str, arguments: Mapping[str, object], result: ToolResult) -> None:
+        if self._record_count >= _MAX_EVIDENCE_RECORDS:
+            return
+        if result.status is not ToolResultStatus.SUCCEEDED:
+            if result.error_code is not None:
+                self._failures.append((result.tool_name, result.error_code))
+                self._record_count += 1
+            return
+        if tool_name in _WRITE_TOOLS:
+            self._observe_write(arguments)
+            return
+        if tool_name == "run_command_profile":
+            self._observe_command(result.output)
+
+    def _observe_write(self, arguments: Mapping[str, object]) -> None:
+        raw_path = arguments.get("path")
+        if not isinstance(raw_path, str):
+            return
+        try:
+            path = _PATH_ADAPTER.validate_python(raw_path)
+        except ValidationError as error:
+            error.__traceback__ = None
+            del error
+            return
+        if path not in self._changed_paths:
+            self._changed_paths.append(path)
+        self._record_count += 1
+
+    def _observe_command(self, output: Mapping[str, object]) -> None:
+        try:
+            raw_profile_id = output["profile_id"]
+            raw_category = output["category"]
+            raw_status = output["terminal_status"]
+            exit_code = output["exit_code"]
+            truncated = output["truncated"]
+            if (
+                not isinstance(raw_profile_id, str)
+                or not isinstance(raw_category, str)
+                or not isinstance(raw_status, str)
+            ):
+                raise ValueError
+            profile_id = CommandProfileId(raw_profile_id)
+            category = CommandCategory(raw_category)
+            status = CommandTerminalStatus(raw_status)
+            if type(exit_code) is not int or not -255 <= exit_code <= 255:
+                raise ValueError
+            if type(truncated) is not bool:
+                raise ValueError
+        except (KeyError, TypeError, ValueError) as error:
+            error.__traceback__ = None
+            del error
+            return
+        self._checks[profile_id] = (profile_id, category, status, exit_code, truncated)
+        self._record_count += 1

--- a/core/developer/reporting.py
+++ b/core/developer/reporting.py
@@ -1,0 +1,87 @@
+"""Truthful deterministic reporting for Developer Agent runs."""
+
+from __future__ import annotations
+
+from core.agents import AgentReport, AgentReportOutcome
+from core.commands import CommandProfileId, CommandTerminalStatus
+from core.developer.types import DeveloperCheckResult
+from core.runtime import RuntimeResult, RuntimeTerminalReason, RuntimeTerminalStatus
+
+_HUMAN_REASONS = frozenset(
+    {
+        RuntimeTerminalReason.AGENT_ESCALATED,
+        RuntimeTerminalReason.HUMAN_APPROVAL_REQUIRED,
+        RuntimeTerminalReason.PERMISSION_DENIED,
+    }
+)
+_BLOCKED_REASONS = frozenset(
+    {
+        RuntimeTerminalReason.STAGNATION_DETECTED,
+        RuntimeTerminalReason.MAX_ITERATIONS_REACHED,
+        RuntimeTerminalReason.MAX_TOOL_CALLS_REACHED,
+        RuntimeTerminalReason.TOKEN_BUDGET_REACHED,
+        RuntimeTerminalReason.GLOBAL_TIMEOUT,
+    }
+)
+
+
+def build_agent_report(
+    runtime: RuntimeResult,
+    required_profiles: tuple[CommandProfileId, ...],
+    checks: tuple[DeveloperCheckResult, ...],
+) -> AgentReport:
+    """Derive a report from runtime state and authoritative latest checks."""
+    if runtime.reason in _HUMAN_REASONS:
+        return _report(
+            AgentReportOutcome.NEEDS_HUMAN,
+            "Developer work requires human action.",
+            (f"Runtime stopped with {runtime.reason.value}.",),
+        )
+    if runtime.reason in _BLOCKED_REASONS:
+        return _report(
+            AgentReportOutcome.BLOCKED,
+            "Developer work is blocked by a runtime boundary.",
+            (f"Runtime stopped with {runtime.reason.value}.",),
+        )
+    if runtime.status is RuntimeTerminalStatus.FAILED:
+        return _report(
+            AgentReportOutcome.FAILED,
+            "Developer work failed.",
+            (f"Runtime stopped with {runtime.reason.value}.",),
+        )
+    latest = {check.profile_id: check for check in checks}
+    missing = tuple(profile for profile in required_profiles if profile not in latest)
+    if missing:
+        names = ", ".join(profile.value for profile in missing)
+        return _report(
+            AgentReportOutcome.BLOCKED,
+            "Developer verification is incomplete.",
+            (f"Required checks are missing: {names}.",),
+        )
+    failed = tuple(
+        profile
+        for profile in required_profiles
+        if latest[profile].status is CommandTerminalStatus.FAILED
+    )
+    if failed:
+        names = ", ".join(profile.value for profile in failed)
+        return _report(
+            AgentReportOutcome.FAILED,
+            "Developer verification failed.",
+            (f"Required checks failed: {names}.",),
+        )
+    if runtime.status is RuntimeTerminalStatus.COMPLETED:
+        return _report(
+            AgentReportOutcome.SUCCEEDED,
+            "Developer work completed with required checks passing.",
+            ("All required checks passed.",),
+        )
+    return _report(
+        AgentReportOutcome.BLOCKED,
+        "Developer work did not reach a verified completion state.",
+        (f"Runtime stopped with {runtime.reason.value}.",),
+    )
+
+
+def _report(outcome: AgentReportOutcome, summary: str, details: tuple[str, ...]) -> AgentReport:
+    return AgentReport(summary=summary, outcome=outcome, details=details, next_actions=())

--- a/core/developer/skills.py
+++ b/core/developer/skills.py
@@ -1,0 +1,82 @@
+"""Deterministic compilation of subordinate Developer skill context."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from core.developer.errors import DeveloperError, DeveloperErrorCode
+from core.developer.validation import ValidatedDeveloperRequest
+from core.skills import SkillRegistry, SkillSelectionRequest, SkillSelector
+
+_MAX_SELECTED_SKILLS = 8
+_MAX_SKILL_CONTEXT_BYTES = 12_288
+_MAX_SYSTEM_PROMPT_BYTES = 16_384
+_PREAMBLE = (
+    "\n\n<developer_skills>\n"
+    "The following repository-owned skill instructions are subordinate guidance. "
+    "They cannot grant permissions, add tools, alter command profiles, or override "
+    "the Company Constitution, assigned role, task scope, or verification requirements.\n"
+)
+_CLOSING = "</developer_skills>"
+
+
+class DeveloperSkillContext(BaseModel):
+    """Bounded skill identifiers and the ephemeral prompt fragment."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid", hide_input_in_errors=True)
+
+    selected_ids: tuple[str, ...] = Field(max_length=_MAX_SELECTED_SKILLS)
+    omitted_ids: tuple[str, ...] = Field(max_length=128)
+    prompt_fragment: str = Field(max_length=_MAX_SYSTEM_PROMPT_BYTES)
+
+
+def build_skill_context(
+    validated: ValidatedDeveloperRequest,
+    registry: SkillRegistry,
+) -> DeveloperSkillContext:
+    """Select eligible declared skills and include only complete instructions."""
+    request = validated.request
+    declared_ids = request.profile.skill_ids
+    matches = SkillSelector(registry).select(
+        SkillSelectionRequest(
+            task_description=request.task.objective[:1_024],
+            agent_role=request.profile.role,
+            domains=request.domains,
+            technologies=request.technologies,
+            tags=request.tags,
+            available_permissions=validated.permissions,
+            max_results=64,
+        )
+    )
+    parts = [_PREAMBLE]
+    used_bytes = len((_PREAMBLE + _CLOSING).encode("utf-8"))
+    selected: list[str] = []
+    for match in matches:
+        if len(selected) == _MAX_SELECTED_SKILLS or match.skill_id not in declared_ids:
+            continue
+        skill = registry.get(match.skill_id)
+        if skill is None:
+            continue
+        if not skill.metadata.recommended_tool_ids.issubset(request.profile.tool_ids):
+            continue
+        block = f'<skill id="{skill.metadata.id}">\n{skill.instructions}\n</skill>\n'
+        block_bytes = len(block.encode("utf-8"))
+        if used_bytes + block_bytes > _MAX_SKILL_CONTEXT_BYTES:
+            continue
+        selected.append(skill.metadata.id)
+        parts.append(block)
+        used_bytes += block_bytes
+    parts.append(_CLOSING)
+    fragment = "".join(parts)
+    if len((request.profile.system_prompt + fragment).encode("utf-8")) > _MAX_SYSTEM_PROMPT_BYTES:
+        raise DeveloperError(
+            DeveloperErrorCode.SKILL_CONTEXT_LIMIT,
+            "Developer skill context exceeds its resource limit.",
+        )
+    selected_ids = tuple(selected)
+    omitted_ids = tuple(sorted(declared_ids.difference(selected_ids)))
+    return DeveloperSkillContext(
+        selected_ids=selected_ids,
+        omitted_ids=omitted_ids,
+        prompt_fragment=fragment,
+    )

--- a/core/developer/types.py
+++ b/core/developer/types.py
@@ -1,0 +1,108 @@
+"""Strict immutable values for the Phase 14 Developer Agent."""
+
+from __future__ import annotations
+
+from pathlib import PurePosixPath
+from typing import Annotated
+
+from pydantic import AfterValidator, BaseModel, ConfigDict, Field, field_validator
+
+from core.agents import AgentProfile, AgentReport
+from core.commands import CommandCategory, CommandProfileId, CommandTerminalStatus
+from core.runtime import RuntimeResult, RuntimeTask
+from core.tools import ToolExecutionContext
+
+Identifier = Annotated[str, Field(pattern=r"^[a-z0-9][a-z0-9._:-]{0,127}$")]
+IdentifierSet = Annotated[frozenset[Identifier], Field(max_length=128)]
+
+
+def _require_scoped_relative_path(value: str) -> str:
+    path = PurePosixPath(value)
+    if not value or path.is_absolute() or ".." in path.parts or path.as_posix() != value:
+        raise ValueError("path must be a normalized relative path")
+    return value
+
+
+ChangedPath = Annotated[
+    str,
+    Field(min_length=1, max_length=1_024),
+    AfterValidator(_require_scoped_relative_path),
+]
+
+
+class _ImmutableDeveloperModel(BaseModel):
+    model_config = ConfigDict(frozen=True, extra="forbid", hide_input_in_errors=True)
+
+
+class DeveloperRequest(_ImmutableDeveloperModel):
+    """One fully scoped invocation of a Developer Agent."""
+
+    task: RuntimeTask
+    profile: AgentProfile
+    execution_context: ToolExecutionContext
+    domains: IdentifierSet = frozenset()
+    technologies: IdentifierSet = frozenset()
+    tags: IdentifierSet = frozenset()
+    required_check_profiles: Annotated[
+        tuple[CommandProfileId, ...], Field(min_length=1, max_length=4)
+    ]
+
+    @field_validator("domains", "technologies", "tags", mode="before")
+    @classmethod
+    def copy_identifier_sets(cls, value: object) -> object:
+        if isinstance(value, (set, frozenset, tuple, list)):
+            return frozenset(value)
+        return value
+
+    @field_validator("required_check_profiles", mode="before")
+    @classmethod
+    def copy_check_profiles(cls, value: object) -> object:
+        if isinstance(value, (list, tuple)):
+            return tuple(value)
+        return value
+
+    @field_validator("required_check_profiles")
+    @classmethod
+    def require_unique_check_profiles(
+        cls, value: tuple[CommandProfileId, ...]
+    ) -> tuple[CommandProfileId, ...]:
+        if len(set(value)) != len(value):
+            raise ValueError("required check profiles must be unique")
+        return value
+
+
+class DeveloperCheckResult(_ImmutableDeveloperModel):
+    """Allowlisted deterministic metadata for one command profile result."""
+
+    profile_id: CommandProfileId
+    category: CommandCategory
+    status: CommandTerminalStatus
+    exit_code: Annotated[int, Field(ge=-255, le=255)]
+    truncated: bool
+
+
+class DeveloperResult(_ImmutableDeveloperModel):
+    """Bounded result of one Developer Agent invocation."""
+
+    runtime: RuntimeResult
+    report: AgentReport
+    selected_skill_ids: Annotated[tuple[Identifier, ...], Field(max_length=8)] = ()
+    omitted_skill_ids: Annotated[tuple[Identifier, ...], Field(max_length=128)] = ()
+    changed_paths: Annotated[tuple[ChangedPath, ...], Field(max_length=128)] = ()
+    checks: Annotated[tuple[DeveloperCheckResult, ...], Field(max_length=128)] = ()
+
+    @field_validator(
+        "selected_skill_ids", "omitted_skill_ids", "changed_paths", "checks", mode="before"
+    )
+    @classmethod
+    def copy_sequences(cls, value: object) -> object:
+        if isinstance(value, (list, tuple)):
+            return tuple(value)
+        return value
+
+    @field_validator("changed_paths")
+    @classmethod
+    def require_unique_changed_paths(cls, value: tuple[str, ...]) -> tuple[str, ...]:
+        if len(set(value)) != len(value):
+            raise ValueError("changed paths must be unique")
+        return value

--- a/core/developer/types.py
+++ b/core/developer/types.py
@@ -3,9 +3,9 @@
 from __future__ import annotations
 
 from pathlib import PurePosixPath
-from typing import Annotated
+from typing import Annotated, Self
 
-from pydantic import AfterValidator, BaseModel, ConfigDict, Field, field_validator
+from pydantic import AfterValidator, BaseModel, ConfigDict, Field, field_validator, model_validator
 
 from core.agents import AgentProfile, AgentReport
 from core.commands import CommandCategory, CommandProfileId, CommandTerminalStatus
@@ -79,6 +79,27 @@ class DeveloperCheckResult(_ImmutableDeveloperModel):
     status: CommandTerminalStatus
     exit_code: Annotated[int, Field(ge=-255, le=255)]
     truncated: bool
+
+    @model_validator(mode="after")
+    def require_truthful_canonical_metadata(self) -> Self:
+        categories = {
+            CommandProfileId.PYTEST: CommandCategory.TEST,
+            CommandProfileId.NPM_TEST: CommandCategory.TEST,
+            CommandProfileId.PHP_ARTISAN_TEST: CommandCategory.TEST,
+            CommandProfileId.RUFF: CommandCategory.LINT,
+            CommandProfileId.MYPY: CommandCategory.LINT,
+            CommandProfileId.NPM_BUILD: CommandCategory.BUILD,
+            CommandProfileId.GIT_STATUS: CommandCategory.GIT_READ,
+            CommandProfileId.GIT_DIFF: CommandCategory.GIT_READ,
+            CommandProfileId.GIT_DIFF_STAGED: CommandCategory.GIT_READ,
+            CommandProfileId.GIT_LOG: CommandCategory.GIT_READ,
+        }
+        expected_status = (
+            CommandTerminalStatus.SUCCEEDED if self.exit_code == 0 else CommandTerminalStatus.FAILED
+        )
+        if self.category is not categories[self.profile_id] or self.status is not expected_status:
+            raise ValueError("command check metadata is inconsistent")
+        return self
 
 
 class DeveloperResult(_ImmutableDeveloperModel):

--- a/core/developer/validation.py
+++ b/core/developer/validation.py
@@ -13,7 +13,7 @@ DEVELOPER_TOOL_IDS = frozenset(
     {
         "read_file",
         "list_files",
-        "search_literal",
+        "search_text",
         "git_status",
         "git_diff",
         "write_file",
@@ -23,7 +23,7 @@ DEVELOPER_TOOL_IDS = frozenset(
         "run_command_profile",
     }
 )
-_READ_TOOLS = frozenset({"read_file", "list_files", "search_literal"})
+_READ_TOOLS = frozenset({"read_file", "list_files", "search_text"})
 _WRITE_TOOLS = frozenset({"write_file", "create_file", "patch_file", "delete_file"})
 _CHECK_PROFILES = frozenset(
     {
@@ -36,6 +36,14 @@ _CHECK_PROFILES = frozenset(
     }
 )
 _ACTIVE_STATUSES = frozenset({AgentStatus.ASSIGNED, AgentStatus.WORKING})
+_REQUIRED_PERMISSIONS = frozenset(
+    {
+        Permission.FILESYSTEM_READ,
+        Permission.FILESYSTEM_WRITE,
+        Permission.SHELL_EXECUTE,
+        Permission.TESTS_EXECUTE,
+    }
+)
 
 
 @dataclass(frozen=True, slots=True)
@@ -63,6 +71,11 @@ def validate_developer_request(request: DeveloperRequest) -> ValidatedDeveloperR
     ):
         raise DeveloperError(DeveloperErrorCode.INVALID_SCOPE, "Developer scope is inconsistent.")
     permissions = _canonical_permissions(profile.permission_ids)
+    if not _REQUIRED_PERMISSIONS.issubset(permissions):
+        raise DeveloperError(
+            DeveloperErrorCode.INVALID_PERMISSION,
+            "Developer permissions are incomplete.",
+        )
     if (
         not profile.tool_ids.issubset(DEVELOPER_TOOL_IDS)
         or not profile.tool_ids.intersection(_READ_TOOLS)

--- a/core/developer/validation.py
+++ b/core/developer/validation.py
@@ -1,0 +1,90 @@
+"""Fail-closed preflight validation for one Developer Agent run."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from core.commands import CommandProfileId
+from core.developer.errors import DeveloperError, DeveloperErrorCode
+from core.developer.types import DeveloperRequest
+from core.enums import AgentStatus, Permission
+
+DEVELOPER_TOOL_IDS = frozenset(
+    {
+        "read_file",
+        "list_files",
+        "search_literal",
+        "git_status",
+        "git_diff",
+        "write_file",
+        "create_file",
+        "patch_file",
+        "delete_file",
+        "run_command_profile",
+    }
+)
+_READ_TOOLS = frozenset({"read_file", "list_files", "search_literal"})
+_WRITE_TOOLS = frozenset({"write_file", "create_file", "patch_file", "delete_file"})
+_CHECK_PROFILES = frozenset(
+    {
+        CommandProfileId.PYTEST,
+        CommandProfileId.RUFF,
+        CommandProfileId.MYPY,
+        CommandProfileId.NPM_TEST,
+        CommandProfileId.NPM_BUILD,
+        CommandProfileId.PHP_ARTISAN_TEST,
+    }
+)
+_ACTIVE_STATUSES = frozenset({AgentStatus.ASSIGNED, AgentStatus.WORKING})
+
+
+@dataclass(frozen=True, slots=True)
+class ValidatedDeveloperRequest:
+    """Canonical capabilities derived before any external work."""
+
+    request: DeveloperRequest
+    permissions: frozenset[Permission]
+
+
+def validate_developer_request(request: DeveloperRequest) -> ValidatedDeveloperRequest:
+    """Reject invalid role authority and scope before collaborators are invoked."""
+    if type(request) is not DeveloperRequest:
+        raise DeveloperError(DeveloperErrorCode.INVALID_INPUT, "Developer request is invalid.")
+    profile = request.profile
+    context = request.execution_context
+    if profile.role != "Developer":
+        raise DeveloperError(DeveloperErrorCode.INVALID_ROLE, "Agent role is not authorized.")
+    if profile.status not in _ACTIVE_STATUSES:
+        raise DeveloperError(DeveloperErrorCode.INACTIVE_AGENT, "Agent is not active.")
+    if (
+        profile.id != context.agent_id
+        or request.task.task_id != context.task_id
+        or profile.tool_ids != context.declared_tool_ids
+    ):
+        raise DeveloperError(DeveloperErrorCode.INVALID_SCOPE, "Developer scope is inconsistent.")
+    permissions = _canonical_permissions(profile.permission_ids)
+    if (
+        not profile.tool_ids.issubset(DEVELOPER_TOOL_IDS)
+        or not profile.tool_ids.intersection(_READ_TOOLS)
+        or not profile.tool_ids.intersection(_WRITE_TOOLS)
+        or "run_command_profile" not in profile.tool_ids
+    ):
+        raise DeveloperError(DeveloperErrorCode.INVALID_TOOLS, "Developer tools are invalid.")
+    if any(profile_id not in _CHECK_PROFILES for profile_id in request.required_check_profiles):
+        raise DeveloperError(
+            DeveloperErrorCode.INVALID_CHECK_PROFILE,
+            "Required check profile is invalid.",
+        )
+    return ValidatedDeveloperRequest(request=request, permissions=permissions)
+
+
+def _canonical_permissions(permission_ids: frozenset[str]) -> frozenset[Permission]:
+    try:
+        return frozenset(Permission(permission_id) for permission_id in permission_ids)
+    except ValueError as error:
+        error.__traceback__ = None
+        del error
+        raise DeveloperError(
+            DeveloperErrorCode.INVALID_PERMISSION,
+            "Developer permissions are invalid.",
+        ) from None

--- a/core/runtime/__init__.py
+++ b/core/runtime/__init__.py
@@ -1,6 +1,7 @@
 """Bounded single-agent runtime contracts."""
 
 from core.runtime.errors import RuntimeError, RuntimeErrorCode
+from core.runtime.reasoner import LLMLoopReasoner, LoopReasoner
 from core.runtime.types import (
     ReasonerOutput,
     RuntimeAction,
@@ -21,6 +22,8 @@ from core.runtime.types import (
 
 __all__ = [
     "ReasonerOutput",
+    "LLMLoopReasoner",
+    "LoopReasoner",
     "RuntimeAction",
     "RuntimeDecision",
     "RuntimeError",

--- a/core/runtime/__init__.py
+++ b/core/runtime/__init__.py
@@ -1,5 +1,6 @@
 """Bounded single-agent runtime contracts."""
 
+from core.runtime.audit import RuntimeAuditOutcome, RuntimeAuditRecord, RuntimeAuditRecorder
 from core.runtime.errors import RuntimeError, RuntimeErrorCode
 from core.runtime.reasoner import LLMLoopReasoner, LoopReasoner
 from core.runtime.types import (
@@ -24,6 +25,9 @@ __all__ = [
     "ReasonerOutput",
     "LLMLoopReasoner",
     "LoopReasoner",
+    "RuntimeAuditOutcome",
+    "RuntimeAuditRecord",
+    "RuntimeAuditRecorder",
     "RuntimeAction",
     "RuntimeDecision",
     "RuntimeError",

--- a/core/runtime/__init__.py
+++ b/core/runtime/__init__.py
@@ -3,6 +3,7 @@
 from core.runtime.audit import RuntimeAuditOutcome, RuntimeAuditRecord, RuntimeAuditRecorder
 from core.runtime.errors import RuntimeError, RuntimeErrorCode
 from core.runtime.reasoner import LLMLoopReasoner, LoopReasoner
+from core.runtime.stagnation import StagnationDetector
 from core.runtime.types import (
     ReasonerOutput,
     RuntimeAction,
@@ -44,4 +45,5 @@ __all__ = [
     "RuntimeTerminalStatus",
     "RuntimeVerification",
     "RuntimeVerificationOutcome",
+    "StagnationDetector",
 ]

--- a/core/runtime/__init__.py
+++ b/core/runtime/__init__.py
@@ -3,6 +3,7 @@
 from core.runtime.audit import RuntimeAuditOutcome, RuntimeAuditRecord, RuntimeAuditRecorder
 from core.runtime.errors import RuntimeError, RuntimeErrorCode
 from core.runtime.reasoner import LLMLoopReasoner, LoopReasoner
+from core.runtime.runtime import AgentRuntime, RuntimeToolExecutor
 from core.runtime.stagnation import StagnationDetector
 from core.runtime.types import (
     ReasonerOutput,
@@ -24,6 +25,7 @@ from core.runtime.types import (
 
 __all__ = [
     "ReasonerOutput",
+    "AgentRuntime",
     "LLMLoopReasoner",
     "LoopReasoner",
     "RuntimeAuditOutcome",
@@ -43,6 +45,7 @@ __all__ = [
     "RuntimeTask",
     "RuntimeTerminalReason",
     "RuntimeTerminalStatus",
+    "RuntimeToolExecutor",
     "RuntimeVerification",
     "RuntimeVerificationOutcome",
     "StagnationDetector",

--- a/core/runtime/__init__.py
+++ b/core/runtime/__init__.py
@@ -1,1 +1,40 @@
-"""Agent runtime / loop engineering (placeholder — implemented in Phase 13)."""
+"""Bounded single-agent runtime contracts."""
+
+from core.runtime.errors import RuntimeError, RuntimeErrorCode
+from core.runtime.types import (
+    ReasonerOutput,
+    RuntimeAction,
+    RuntimeDecision,
+    RuntimeHistoryEntry,
+    RuntimeLimits,
+    RuntimeObservation,
+    RuntimePlan,
+    RuntimeReport,
+    RuntimeResult,
+    RuntimeStep,
+    RuntimeTask,
+    RuntimeTerminalReason,
+    RuntimeTerminalStatus,
+    RuntimeVerification,
+    RuntimeVerificationOutcome,
+)
+
+__all__ = [
+    "ReasonerOutput",
+    "RuntimeAction",
+    "RuntimeDecision",
+    "RuntimeError",
+    "RuntimeErrorCode",
+    "RuntimeHistoryEntry",
+    "RuntimeLimits",
+    "RuntimeObservation",
+    "RuntimePlan",
+    "RuntimeReport",
+    "RuntimeResult",
+    "RuntimeStep",
+    "RuntimeTask",
+    "RuntimeTerminalReason",
+    "RuntimeTerminalStatus",
+    "RuntimeVerification",
+    "RuntimeVerificationOutcome",
+]

--- a/core/runtime/audit.py
+++ b/core/runtime/audit.py
@@ -10,6 +10,7 @@ from pydantic import BaseModel, ConfigDict, Field
 
 from core.runtime.errors import RuntimeErrorCode
 from core.runtime.types import Identifier, RuntimeAction, RuntimeStep, RuntimeTerminalReason
+from core.tools import ToolErrorCode
 
 
 class RuntimeAuditOutcome(StrEnum):
@@ -45,7 +46,7 @@ class RuntimeAuditRecord(BaseModel):
     reason: RuntimeTerminalReason | None = None
     action: RuntimeAction | None = None
     tool_name: Identifier | None = None
-    error_code: RuntimeErrorCode | None = None
+    error_code: RuntimeErrorCode | ToolErrorCode | None = None
 
 
 class RuntimeAuditRecorder(Protocol):
@@ -53,4 +54,8 @@ class RuntimeAuditRecorder(Protocol):
 
     def record(self, record: RuntimeAuditRecord) -> None:
         """Persist one sanitized audit record or fail closed."""
+        ...
+
+    def record_cancellation(self, record: RuntimeAuditRecord) -> None:
+        """Stage one cancellation record without blocking I/O."""
         ...

--- a/core/runtime/audit.py
+++ b/core/runtime/audit.py
@@ -1,0 +1,56 @@
+"""Sanitized append-only audit contract for bounded agent loops."""
+
+from __future__ import annotations
+
+from enum import StrEnum
+from typing import Annotated, Protocol
+from uuid import UUID
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from core.runtime.errors import RuntimeErrorCode
+from core.runtime.types import Identifier, RuntimeAction, RuntimeStep, RuntimeTerminalReason
+
+
+class RuntimeAuditOutcome(StrEnum):
+    """Stable outcomes safe to persist for one runtime step."""
+
+    STARTED = "STARTED"
+    SUCCEEDED = "SUCCEEDED"
+    FAILED = "FAILED"
+    DENIED = "DENIED"
+    TIMED_OUT = "TIMED_OUT"
+    CANCELLED = "CANCELLED"
+    ESCALATED = "ESCALATED"
+    LIMIT_REACHED = "LIMIT_REACHED"
+
+
+class RuntimeAuditRecord(BaseModel):
+    """Allowlisted metadata for one runtime-step audit event."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid", hide_input_in_errors=True)
+
+    agent_id: Identifier
+    agent_run_id: UUID
+    project_id: UUID
+    task_id: UUID
+    correlation_id: UUID
+    iteration: Annotated[int, Field(ge=0, le=100)]
+    step: RuntimeStep
+    outcome: RuntimeAuditOutcome
+    duration_ms: Annotated[int, Field(ge=0, le=3_600_000)]
+    tool_calls: Annotated[int, Field(ge=0, le=1_000)]
+    failures: Annotated[int, Field(ge=0, le=100)]
+    reported_tokens: Annotated[int, Field(ge=0, le=10_000_000)]
+    reason: RuntimeTerminalReason | None = None
+    action: RuntimeAction | None = None
+    tool_name: Identifier | None = None
+    error_code: RuntimeErrorCode | None = None
+
+
+class RuntimeAuditRecorder(Protocol):
+    """Append-only persistence boundary for runtime-step metadata."""
+
+    def record(self, record: RuntimeAuditRecord) -> None:
+        """Persist one sanitized audit record or fail closed."""
+        ...

--- a/core/runtime/errors.py
+++ b/core/runtime/errors.py
@@ -1,0 +1,24 @@
+"""Sanitized failures for the bounded agent runtime."""
+
+from __future__ import annotations
+
+from enum import StrEnum
+
+
+class RuntimeErrorCode(StrEnum):
+    """Stable non-sensitive runtime failure classifications."""
+
+    INVALID_REQUEST = "INVALID_REQUEST"
+    LLM_FAILED = "LLM_FAILED"
+    LLM_OUTPUT_INVALID = "LLM_OUTPUT_INVALID"
+    AUDIT_FAILED = "AUDIT_FAILED"
+    TOOL_FAILED = "TOOL_FAILED"
+    BUDGET_EXCEEDED = "BUDGET_EXCEEDED"
+
+
+class RuntimeError(Exception):
+    """Runtime exception containing only a stable code and safe message."""
+
+    def __init__(self, code: RuntimeErrorCode, message: str) -> None:
+        super().__init__(message)
+        self.code = code

--- a/core/runtime/reasoner.py
+++ b/core/runtime/reasoner.py
@@ -50,6 +50,9 @@ _REPORT = (
 class LoopReasoner(Protocol):
     """Provider-neutral structured reasoning operations consumed by AgentRuntime."""
 
+    @property
+    def max_step_tokens(self) -> int: ...
+
     async def observe(
         self,
         task: RuntimeTask,
@@ -99,6 +102,11 @@ class LLMLoopReasoner:
         self._provider = provider
         self._system_prompt = system_prompt
         self._max_step_tokens = max_step_tokens
+
+    @property
+    def max_step_tokens(self) -> int:
+        """Return the authoritative per-call generation ceiling."""
+        return self._max_step_tokens
 
     async def observe(
         self,

--- a/core/runtime/reasoner.py
+++ b/core/runtime/reasoner.py
@@ -1,0 +1,235 @@
+"""Strict one-shot language-model reasoning for bounded loops."""
+
+from __future__ import annotations
+
+import json
+from enum import StrEnum
+from typing import Protocol
+
+from pydantic import BaseModel, ValidationError
+
+from core.agents import AgentOutputValidationError
+from core.agents.structured_output import decode_structured_output
+from core.llm import LLMMessage, LLMProvider, LLMProviderError, LLMRequest, LLMResponse, LLMRole
+from core.runtime.errors import RuntimeError, RuntimeErrorCode
+from core.runtime.types import (
+    ReasonerOutput,
+    RuntimeDecision,
+    RuntimeHistoryEntry,
+    RuntimeObservation,
+    RuntimePlan,
+    RuntimeReport,
+    RuntimeTask,
+    RuntimeTerminalReason,
+    RuntimeTerminalStatus,
+    RuntimeVerification,
+)
+from core.tools import ToolResult
+
+_OBSERVE = (
+    "Observe the task. Return exactly one JSON object with only: summary, facts, uncertainties."
+)
+_PLAN = (
+    "Plan one bounded iteration. Return exactly one JSON object with only: objective, steps, "
+    "success_criteria."
+)
+_DECIDE = (
+    "Choose one action. Return exactly one JSON object with only: action, tool_name, arguments, "
+    "rationale, confidence. action must be TOOL_CALL, COMPLETE, or ESCALATE."
+)
+_VERIFY = (
+    "Verify the tool observation. Return exactly one JSON object with only: outcome, summary, "
+    "progress_made. outcome must be CONTINUE, COMPLETE, or ESCALATE."
+)
+_REPORT = (
+    "Report the terminal run. Return exactly one JSON object with only: summary, details, "
+    "next_actions."
+)
+
+
+class LoopReasoner(Protocol):
+    """Provider-neutral structured reasoning operations consumed by AgentRuntime."""
+
+    async def observe(
+        self,
+        task: RuntimeTask,
+        history: tuple[RuntimeHistoryEntry, ...],
+    ) -> ReasonerOutput[RuntimeObservation]: ...
+
+    async def plan(
+        self,
+        task: RuntimeTask,
+        observation: RuntimeObservation,
+        history: tuple[RuntimeHistoryEntry, ...],
+    ) -> ReasonerOutput[RuntimePlan]: ...
+
+    async def decide(
+        self,
+        task: RuntimeTask,
+        observation: RuntimeObservation,
+        plan: RuntimePlan,
+        history: tuple[RuntimeHistoryEntry, ...],
+    ) -> ReasonerOutput[RuntimeDecision]: ...
+
+    async def verify(
+        self,
+        task: RuntimeTask,
+        decision: RuntimeDecision,
+        tool_result: ToolResult,
+        history: tuple[RuntimeHistoryEntry, ...],
+    ) -> ReasonerOutput[RuntimeVerification]: ...
+
+    async def report(
+        self,
+        task: RuntimeTask,
+        status: RuntimeTerminalStatus,
+        reason: RuntimeTerminalReason,
+        history: tuple[RuntimeHistoryEntry, ...],
+    ) -> ReasonerOutput[RuntimeReport]: ...
+
+
+class LLMLoopReasoner:
+    """Decode one strict typed response per provider request without retries."""
+
+    def __init__(self, provider: LLMProvider, *, system_prompt: str, max_step_tokens: int) -> None:
+        if not system_prompt.strip() or len(system_prompt) > 16_384:
+            raise ValueError("runtime system prompt is invalid")
+        if not 1 <= max_step_tokens <= 131_072:
+            raise ValueError("runtime step token limit is invalid")
+        self._provider = provider
+        self._system_prompt = system_prompt
+        self._max_step_tokens = max_step_tokens
+
+    async def observe(
+        self,
+        task: RuntimeTask,
+        history: tuple[RuntimeHistoryEntry, ...],
+    ) -> ReasonerOutput[RuntimeObservation]:
+        return await self._generate(_OBSERVE, RuntimeObservation, task=task, history=history)
+
+    async def plan(
+        self,
+        task: RuntimeTask,
+        observation: RuntimeObservation,
+        history: tuple[RuntimeHistoryEntry, ...],
+    ) -> ReasonerOutput[RuntimePlan]:
+        return await self._generate(
+            _PLAN,
+            RuntimePlan,
+            task=task,
+            observation=observation,
+            history=history,
+        )
+
+    async def decide(
+        self,
+        task: RuntimeTask,
+        observation: RuntimeObservation,
+        plan: RuntimePlan,
+        history: tuple[RuntimeHistoryEntry, ...],
+    ) -> ReasonerOutput[RuntimeDecision]:
+        return await self._generate(
+            _DECIDE,
+            RuntimeDecision,
+            task=task,
+            observation=observation,
+            plan=plan,
+            history=history,
+        )
+
+    async def verify(
+        self,
+        task: RuntimeTask,
+        decision: RuntimeDecision,
+        tool_result: ToolResult,
+        history: tuple[RuntimeHistoryEntry, ...],
+    ) -> ReasonerOutput[RuntimeVerification]:
+        return await self._generate(
+            _VERIFY,
+            RuntimeVerification,
+            task=task,
+            decision=decision,
+            tool_result=tool_result,
+            history=history,
+        )
+
+    async def report(
+        self,
+        task: RuntimeTask,
+        status: RuntimeTerminalStatus,
+        reason: RuntimeTerminalReason,
+        history: tuple[RuntimeHistoryEntry, ...],
+    ) -> ReasonerOutput[RuntimeReport]:
+        return await self._generate(
+            _REPORT,
+            RuntimeReport,
+            task=task,
+            status=status,
+            reason=reason,
+            history=history,
+        )
+
+    async def _generate[ValueT: BaseModel](
+        self,
+        instruction: str,
+        model_type: type[ValueT],
+        **values: object,
+    ) -> ReasonerOutput[ValueT]:
+        request = LLMRequest(
+            system_prompt=self._system_prompt,
+            messages=(
+                LLMMessage(
+                    role=LLMRole.USER,
+                    content=f"{instruction}\nInput:\n{_safe_json(values)}",
+                ),
+            ),
+            max_tokens=self._max_step_tokens,
+        )
+        try:
+            response = await self._provider.generate(request)
+        except LLMProviderError as error:
+            error.__traceback__ = None
+            del error
+            raise RuntimeError(RuntimeErrorCode.LLM_FAILED, "Runtime reasoning failed.") from None
+        try:
+            value = decode_structured_output(response.content, model_type)
+            tokens, available = _reported_usage(response)
+            return ReasonerOutput(
+                value=value,
+                reported_tokens=tokens,
+                usage_available=available,
+            )
+        except (AgentOutputValidationError, TypeError, ValueError, ValidationError) as error:
+            error.__traceback__ = None
+            del error, response
+            raise RuntimeError(
+                RuntimeErrorCode.LLM_OUTPUT_INVALID,
+                "Runtime reasoning output is invalid.",
+            ) from None
+
+
+def _safe_json(values: dict[str, object]) -> str:
+    serializable: dict[str, object] = {}
+    for key, value in values.items():
+        if isinstance(value, BaseModel):
+            serializable[key] = value.model_dump(mode="json")
+        elif isinstance(value, tuple) and all(isinstance(item, BaseModel) for item in value):
+            serializable[key] = [item.model_dump(mode="json") for item in value]
+        elif isinstance(value, StrEnum):
+            serializable[key] = value.value
+        else:
+            serializable[key] = value
+    return json.dumps(serializable, allow_nan=False, separators=(",", ":"), sort_keys=True)
+
+
+def _reported_usage(response: LLMResponse) -> tuple[int, bool]:
+    usage = response.usage
+    if usage is None:
+        return 0, False
+    if usage.total_tokens is not None:
+        return usage.total_tokens, True
+    components = (usage.prompt_tokens, usage.completion_tokens)
+    reported = [item for item in components if item is not None]
+    if not reported:
+        return 0, False
+    return sum(reported), True

--- a/core/runtime/runtime.py
+++ b/core/runtime/runtime.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import logging
 from collections.abc import Awaitable, Callable, Mapping
 from functools import partial
 from time import perf_counter
@@ -27,7 +28,15 @@ from core.runtime.types import (
     RuntimeTerminalStatus,
     RuntimeVerificationOutcome,
 )
-from core.tools import ToolErrorCode, ToolExecutionContext, ToolResult, ToolResultStatus
+from core.tools import (
+    ToolAuditError,
+    ToolErrorCode,
+    ToolExecutionContext,
+    ToolResult,
+    ToolResultStatus,
+)
+
+_LOGGER = logging.getLogger(__name__)
 
 
 class RuntimeToolExecutor(Protocol):
@@ -53,15 +62,16 @@ class AgentRuntime:
         self._tool_executor = tool_executor
         self._audit = audit_recorder
         self._limits = limits
+        if reasoner.max_step_tokens > limits.max_step_tokens:
+            raise ValueError("reasoner step token limit exceeds runtime limit")
 
     async def run(self, task: RuntimeTask, context: ToolExecutionContext) -> RuntimeResult:
         """Run one bounded task; injected collaborators remain caller-owned."""
         started = perf_counter()
         if task.task_id != context.task_id:
-            return self._result(
-                RuntimeTerminalStatus.FAILED,
-                RuntimeTerminalReason.INVALID_LLM_OUTPUT,
-                started,
+            raise RuntimeError(
+                RuntimeErrorCode.INVALID_REQUEST,
+                "Runtime task scope is invalid.",
             )
         state = _RunState(self._limits)
         try:
@@ -170,9 +180,37 @@ class AgentRuntime:
 
             self._audit_step(context, state, RuntimeStep.ACT, RuntimeAuditOutcome.STARTED, decision)
             state.tool_calls += 1
-            tool_result = await self._tool_executor.execute(
-                decision.tool_name or "invalid", decision.arguments, context
-            )
+            try:
+                tool_result = await self._tool_executor.execute(
+                    decision.tool_name or "invalid", decision.arguments, context
+                )
+            except ToolAuditError as error:
+                error.__traceback__ = None
+                del error
+                self._audit_step(
+                    context,
+                    state,
+                    RuntimeStep.ACT,
+                    RuntimeAuditOutcome.FAILED,
+                    decision,
+                    ToolErrorCode.AUDIT_FAILED,
+                )
+                self._audit_step(
+                    context,
+                    state,
+                    RuntimeStep.OBSERVE_RESULT,
+                    RuntimeAuditOutcome.STARTED,
+                    decision,
+                )
+                self._audit_step(
+                    context,
+                    state,
+                    RuntimeStep.OBSERVE_RESULT,
+                    RuntimeAuditOutcome.FAILED,
+                    decision,
+                    ToolErrorCode.AUDIT_FAILED,
+                )
+                return self._terminal_failure(context, state, RuntimeTerminalReason.AUDIT_FAILED)
             tool_outcome = (
                 RuntimeAuditOutcome.SUCCEEDED
                 if tool_result.status is ToolResultStatus.SUCCEEDED
@@ -184,6 +222,21 @@ class AgentRuntime:
                 context,
                 state,
                 RuntimeStep.ACT,
+                tool_outcome,
+                decision,
+                tool_result.error_code,
+            )
+            self._audit_step(
+                context,
+                state,
+                RuntimeStep.OBSERVE_RESULT,
+                RuntimeAuditOutcome.STARTED,
+                decision,
+            )
+            self._audit_step(
+                context,
+                state,
+                RuntimeStep.OBSERVE_RESULT,
                 tool_outcome,
                 decision,
                 tool_result.error_code,
@@ -211,14 +264,28 @@ class AgentRuntime:
                         RuntimeTerminalReason.MAX_FAILURES_REACHED,
                     )
 
-            verification = await self._reason(
-                RuntimeStep.VERIFY,
-                iteration,
-                context,
-                state,
-                partial(self._reasoner.verify, task, decision, tool_result, state.history),
-                decision,
-            )
+            try:
+                verification = await self._reason(
+                    RuntimeStep.VERIFY,
+                    iteration,
+                    context,
+                    state,
+                    partial(self._reasoner.verify, task, decision, tool_result, state.history),
+                    decision,
+                )
+            except RuntimeError as error:
+                if error.code is RuntimeErrorCode.AUDIT_FAILED:
+                    raise
+                state.failures += 1
+                if state.failures >= self._limits.max_failures:
+                    return await self._finish(
+                        task,
+                        context,
+                        state,
+                        RuntimeTerminalStatus.FAILED,
+                        RuntimeTerminalReason.MAX_FAILURES_REACHED,
+                    )
+                continue
             if self._token_budget_reached(state):
                 return self._token_terminal(context, state)
             state.append(
@@ -309,35 +376,39 @@ class AgentRuntime:
                 RuntimeTerminalStatus.LIMIT_REACHED,
                 RuntimeTerminalReason.TOKEN_BUDGET_REACHED,
             )
-        await self._reason(
-            RuntimeStep.REPORT,
-            state.iterations,
-            context,
-            state,
-            partial(self._reasoner.report, task, status, reason, state.history),
-        )
+        try:
+            await self._reason(
+                RuntimeStep.REPORT,
+                state.iterations,
+                context,
+                state,
+                partial(self._reasoner.report, task, status, reason, state.history),
+            )
+        except RuntimeError as error:
+            if error.code is RuntimeErrorCode.AUDIT_FAILED:
+                raise
+            state.failures += 1
+            failed_reason = RuntimeTerminalReason.INVALID_LLM_OUTPUT
+            self._terminal_audit(context, state, RuntimeAuditOutcome.FAILED, failed_reason)
+            return RuntimeTerminalStatus.FAILED, failed_reason, None
+        if self._token_budget_reached(state):
+            return self._token_terminal(context, state)
         self._terminal_audit(context, state, RuntimeAuditOutcome.SUCCEEDED, reason)
         return status, reason, None
 
-    async def _audit_cancellation(
-        self, context: ToolExecutionContext, state: _RunState
-    ) -> None:
-        async def cleanup() -> None:
-            await asyncio.sleep(0)
-            self._terminal_audit(
-                context,
-                state,
-                RuntimeAuditOutcome.CANCELLED,
-                RuntimeTerminalReason.CANCELLED,
+    async def _audit_cancellation(self, context: ToolExecutionContext, state: _RunState) -> None:
+        try:
+            self._audit.record_cancellation(
+                self._build_terminal_audit_record(
+                    context,
+                    state,
+                    RuntimeAuditOutcome.CANCELLED,
+                    RuntimeTerminalReason.CANCELLED,
+                )
             )
-
-        cleanup_task = asyncio.create_task(cleanup())
-        while not cleanup_task.done():
-            try:
-                await asyncio.shield(cleanup_task)
-            except asyncio.CancelledError:
-                continue
-        cleanup_task.result()
+        except RuntimeError:
+            _LOGGER.warning("Runtime cancellation audit failed.")
+        await asyncio.sleep(0)
 
     def _terminal(
         self,
@@ -354,6 +425,15 @@ class AgentRuntime:
         self._terminal_audit(context, state, outcome, reason)
         return status, reason, None
 
+    def _terminal_failure(
+        self,
+        context: ToolExecutionContext,
+        state: _RunState,
+        reason: RuntimeTerminalReason,
+    ) -> tuple[RuntimeTerminalStatus, RuntimeTerminalReason, None]:
+        self._terminal_audit(context, state, RuntimeAuditOutcome.FAILED, reason)
+        return RuntimeTerminalStatus.FAILED, reason, None
+
     def _audit_step(
         self,
         context: ToolExecutionContext,
@@ -363,6 +443,16 @@ class AgentRuntime:
         decision: object | None = None,
         error_code: ToolErrorCode | None = None,
     ) -> None:
+        if outcome is RuntimeAuditOutcome.STARTED:
+            state.step_started[step] = perf_counter()
+            duration_ms = 0
+        else:
+            step_started = state.step_started.pop(step, None)
+            duration_ms = (
+                min(round((perf_counter() - step_started) * 1000), 3_600_000)
+                if step_started is not None
+                else 0
+            )
         action = decision.action if hasattr(decision, "action") else None
         tool_name = decision.tool_name if hasattr(decision, "tool_name") else None
         self._audit.record(
@@ -375,15 +465,13 @@ class AgentRuntime:
                 iteration=state.iterations,
                 step=step,
                 outcome=outcome,
-                duration_ms=0,
+                duration_ms=duration_ms,
                 tool_calls=state.tool_calls,
                 failures=state.failures,
                 reported_tokens=state.reported_tokens,
                 action=action,
                 tool_name=tool_name,
-                error_code=(
-                    RuntimeErrorCode.TOOL_FAILED if error_code is not None else None
-                ),
+                error_code=error_code,
             )
         )
 
@@ -394,22 +482,29 @@ class AgentRuntime:
         outcome: RuntimeAuditOutcome,
         reason: RuntimeTerminalReason,
     ) -> None:
-        self._audit.record(
-            RuntimeAuditRecord(
-                agent_id=context.agent_id,
-                agent_run_id=context.agent_run_id,
-                project_id=context.project_id,
-                task_id=context.task_id,
-                correlation_id=context.correlation_id,
-                iteration=state.iterations,
-                step=RuntimeStep.REPORT,
-                outcome=outcome,
-                duration_ms=0,
-                tool_calls=state.tool_calls,
-                failures=state.failures,
-                reported_tokens=state.reported_tokens,
-                reason=reason,
-            )
+        self._audit.record(self._build_terminal_audit_record(context, state, outcome, reason))
+
+    @staticmethod
+    def _build_terminal_audit_record(
+        context: ToolExecutionContext,
+        state: _RunState,
+        outcome: RuntimeAuditOutcome,
+        reason: RuntimeTerminalReason,
+    ) -> RuntimeAuditRecord:
+        return RuntimeAuditRecord(
+            agent_id=context.agent_id,
+            agent_run_id=context.agent_run_id,
+            project_id=context.project_id,
+            task_id=context.task_id,
+            correlation_id=context.correlation_id,
+            iteration=state.iterations,
+            step=RuntimeStep.REPORT,
+            outcome=outcome,
+            duration_ms=min(round((perf_counter() - state.started) * 1000), 3_600_000),
+            tool_calls=state.tool_calls,
+            failures=state.failures,
+            reported_tokens=state.reported_tokens,
+            reason=reason,
         )
 
     def _result(
@@ -438,6 +533,7 @@ class AgentRuntime:
 
 class _RunState:
     def __init__(self, limits: RuntimeLimits) -> None:
+        self.started = perf_counter()
         self._max_history = limits.max_history_entries
         self.iterations = 0
         self.tool_calls = 0
@@ -445,6 +541,7 @@ class _RunState:
         self.reported_tokens = 0
         self.usage_available = True
         self.history: tuple[RuntimeHistoryEntry, ...] = ()
+        self.step_started: dict[RuntimeStep, float] = {}
 
     def append(self, entry: RuntimeHistoryEntry) -> None:
         self.history = (*self.history, entry)[-self._max_history :]

--- a/core/runtime/runtime.py
+++ b/core/runtime/runtime.py
@@ -1,0 +1,426 @@
+"""Bounded single-agent Understand-Plan-Act-Verify runtime."""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Awaitable, Mapping
+from time import perf_counter
+from typing import Protocol
+
+from pydantic import BaseModel
+
+from core.runtime.audit import RuntimeAuditOutcome, RuntimeAuditRecord, RuntimeAuditRecorder
+from core.runtime.errors import RuntimeError, RuntimeErrorCode
+from core.runtime.reasoner import LoopReasoner
+from core.runtime.stagnation import StagnationDetector
+from core.runtime.types import (
+    ReasonerOutput,
+    RuntimeAction,
+    RuntimeHistoryEntry,
+    RuntimeLimits,
+    RuntimeReport,
+    RuntimeResult,
+    RuntimeStep,
+    RuntimeTask,
+    RuntimeTerminalReason,
+    RuntimeTerminalStatus,
+    RuntimeVerificationOutcome,
+)
+from core.tools import ToolErrorCode, ToolExecutionContext, ToolResult, ToolResultStatus
+
+
+class RuntimeToolExecutor(Protocol):
+    async def execute(
+        self,
+        tool_name: str,
+        arguments: Mapping[str, object],
+        context: ToolExecutionContext,
+    ) -> ToolResult: ...
+
+
+class AgentRuntime:
+    """Execute one agent loop with finite budgets and fail-closed auditing."""
+
+    def __init__(
+        self,
+        reasoner: LoopReasoner,
+        tool_executor: RuntimeToolExecutor,
+        audit_recorder: RuntimeAuditRecorder,
+        limits: RuntimeLimits,
+    ) -> None:
+        self._reasoner = reasoner
+        self._tool_executor = tool_executor
+        self._audit = audit_recorder
+        self._limits = limits
+
+    async def run(self, task: RuntimeTask, context: ToolExecutionContext) -> RuntimeResult:
+        """Run one bounded task; injected collaborators remain caller-owned."""
+        started = perf_counter()
+        if task.task_id != context.task_id:
+            return self._result(
+                RuntimeTerminalStatus.FAILED,
+                RuntimeTerminalReason.INVALID_LLM_OUTPUT,
+                started,
+            )
+        state = _RunState(self._limits)
+        try:
+            async with asyncio.timeout(self._limits.timeout_seconds):
+                status, reason, report = await self._execute(task, context, state)
+        except TimeoutError:
+            status = RuntimeTerminalStatus.TIMED_OUT
+            reason = RuntimeTerminalReason.GLOBAL_TIMEOUT
+            report = None
+            self._terminal_audit(context, state, RuntimeAuditOutcome.TIMED_OUT, reason)
+        except RuntimeError as error:
+            if error.code is not RuntimeErrorCode.AUDIT_FAILED:
+                raise
+            status = RuntimeTerminalStatus.FAILED
+            reason = RuntimeTerminalReason.AUDIT_FAILED
+            report = None
+        return self._result(status, reason, started, state, report)
+
+    async def _execute(
+        self,
+        task: RuntimeTask,
+        context: ToolExecutionContext,
+        state: _RunState,
+    ) -> tuple[RuntimeTerminalStatus, RuntimeTerminalReason, RuntimeReport | None]:
+        detector = StagnationDetector(self._limits.stagnation_window)
+        for iteration in range(1, self._limits.max_iterations + 1):
+            state.iterations = iteration
+            try:
+                observation = await self._reason(
+                    RuntimeStep.OBSERVE,
+                    iteration,
+                    context,
+                    state,
+                    self._reasoner.observe(task, state.history),
+                )
+                if self._token_budget_reached(state):
+                    return self._token_terminal(context, state)
+                plan = await self._reason(
+                    RuntimeStep.PLAN,
+                    iteration,
+                    context,
+                    state,
+                    self._reasoner.plan(task, observation, state.history),
+                )
+                if self._token_budget_reached(state):
+                    return self._token_terminal(context, state)
+                decision = await self._reason(
+                    RuntimeStep.DECIDE,
+                    iteration,
+                    context,
+                    state,
+                    self._reasoner.decide(task, observation, plan, state.history),
+                )
+                if self._token_budget_reached(state):
+                    return self._token_terminal(context, state)
+            except RuntimeError as error:
+                if error.code is RuntimeErrorCode.AUDIT_FAILED:
+                    raise
+                state.failures += 1
+                state.append(RuntimeHistoryEntry(iteration=iteration, step=RuntimeStep.DECIDE))
+                if state.failures >= self._limits.max_failures:
+                    return await self._finish(
+                        task,
+                        context,
+                        state,
+                        RuntimeTerminalStatus.FAILED,
+                        RuntimeTerminalReason.MAX_FAILURES_REACHED,
+                    )
+                continue
+
+            state.append(
+                RuntimeHistoryEntry(
+                    iteration=iteration,
+                    step=RuntimeStep.DECIDE,
+                    action=decision.action,
+                    tool_name=decision.tool_name,
+                    reported_tokens=0,
+                )
+            )
+            if decision.action is RuntimeAction.COMPLETE:
+                return await self._finish(
+                    task,
+                    context,
+                    state,
+                    RuntimeTerminalStatus.COMPLETED,
+                    RuntimeTerminalReason.TASK_COMPLETED,
+                )
+            if decision.action is RuntimeAction.ESCALATE:
+                return await self._finish(
+                    task,
+                    context,
+                    state,
+                    RuntimeTerminalStatus.ESCALATED,
+                    RuntimeTerminalReason.AGENT_ESCALATED,
+                )
+            if state.tool_calls >= self._limits.max_tool_calls:
+                return self._terminal(
+                    context,
+                    state,
+                    RuntimeTerminalStatus.LIMIT_REACHED,
+                    RuntimeTerminalReason.MAX_TOOL_CALLS_REACHED,
+                )
+
+            self._audit_step(context, state, RuntimeStep.ACT, RuntimeAuditOutcome.STARTED, decision)
+            state.tool_calls += 1
+            tool_result = await self._tool_executor.execute(
+                decision.tool_name or "invalid", decision.arguments, context
+            )
+            tool_outcome = (
+                RuntimeAuditOutcome.SUCCEEDED
+                if tool_result.status is ToolResultStatus.SUCCEEDED
+                else RuntimeAuditOutcome.DENIED
+                if tool_result.status is ToolResultStatus.DENIED
+                else RuntimeAuditOutcome.FAILED
+            )
+            self._audit_step(
+                context,
+                state,
+                RuntimeStep.ACT,
+                tool_outcome,
+                decision,
+                tool_result.error_code,
+            )
+            if tool_result.status is not ToolResultStatus.SUCCEEDED:
+                if tool_result.error_code in {
+                    ToolErrorCode.PERMISSION_DENIED,
+                    ToolErrorCode.APPROVAL_REQUIRED,
+                }:
+                    reason = (
+                        RuntimeTerminalReason.HUMAN_APPROVAL_REQUIRED
+                        if tool_result.error_code is ToolErrorCode.APPROVAL_REQUIRED
+                        else RuntimeTerminalReason.PERMISSION_DENIED
+                    )
+                    return await self._finish(
+                        task, context, state, RuntimeTerminalStatus.ESCALATED, reason
+                    )
+                state.failures += 1
+                if state.failures >= self._limits.max_failures:
+                    return await self._finish(
+                        task,
+                        context,
+                        state,
+                        RuntimeTerminalStatus.FAILED,
+                        RuntimeTerminalReason.MAX_FAILURES_REACHED,
+                    )
+
+            verification = await self._reason(
+                RuntimeStep.VERIFY,
+                iteration,
+                context,
+                state,
+                self._reasoner.verify(task, decision, tool_result, state.history),
+                decision,
+            )
+            if self._token_budget_reached(state):
+                return self._token_terminal(context, state)
+            state.append(
+                RuntimeHistoryEntry(
+                    iteration=iteration,
+                    step=RuntimeStep.VERIFY,
+                    action=decision.action,
+                    tool_name=decision.tool_name,
+                    tool_error_code=tool_result.error_code,
+                )
+            )
+            if verification.outcome is RuntimeVerificationOutcome.COMPLETE:
+                return await self._finish(
+                    task,
+                    context,
+                    state,
+                    RuntimeTerminalStatus.COMPLETED,
+                    RuntimeTerminalReason.TASK_COMPLETED,
+                )
+            if verification.outcome is RuntimeVerificationOutcome.ESCALATE:
+                return await self._finish(
+                    task,
+                    context,
+                    state,
+                    RuntimeTerminalStatus.ESCALATED,
+                    RuntimeTerminalReason.AGENT_ESCALATED,
+                )
+            if detector.observe(decision, verification, tool_result.error_code):
+                return await self._finish(
+                    task,
+                    context,
+                    state,
+                    RuntimeTerminalStatus.ESCALATED,
+                    RuntimeTerminalReason.STAGNATION_DETECTED,
+                )
+        return self._terminal(
+            context,
+            state,
+            RuntimeTerminalStatus.LIMIT_REACHED,
+            RuntimeTerminalReason.MAX_ITERATIONS_REACHED,
+        )
+
+    async def _reason[ValueT: BaseModel](
+        self,
+        step: RuntimeStep,
+        iteration: int,
+        context: ToolExecutionContext,
+        state: _RunState,
+        operation: Awaitable[ReasonerOutput[ValueT]],
+        decision: object | None = None,
+    ) -> ValueT:
+        self._audit_step(context, state, step, RuntimeAuditOutcome.STARTED, decision)
+        try:
+            output = await operation
+        except RuntimeError:
+            self._audit_step(context, state, step, RuntimeAuditOutcome.FAILED, decision)
+            raise
+        state.reported_tokens += output.reported_tokens
+        state.usage_available = state.usage_available and output.usage_available
+        self._audit_step(context, state, step, RuntimeAuditOutcome.SUCCEEDED, decision)
+        return output.value
+
+    def _token_budget_reached(self, state: _RunState) -> bool:
+        return state.reported_tokens >= self._limits.max_tokens
+
+    def _token_terminal(
+        self, context: ToolExecutionContext, state: _RunState
+    ) -> tuple[RuntimeTerminalStatus, RuntimeTerminalReason, None]:
+        return self._terminal(
+            context,
+            state,
+            RuntimeTerminalStatus.LIMIT_REACHED,
+            RuntimeTerminalReason.TOKEN_BUDGET_REACHED,
+        )
+
+    async def _finish(
+        self,
+        task: RuntimeTask,
+        context: ToolExecutionContext,
+        state: _RunState,
+        status: RuntimeTerminalStatus,
+        reason: RuntimeTerminalReason,
+    ) -> tuple[RuntimeTerminalStatus, RuntimeTerminalReason, RuntimeReport | None]:
+        if state.reported_tokens >= self._limits.max_tokens:
+            return self._terminal(
+                context,
+                state,
+                RuntimeTerminalStatus.LIMIT_REACHED,
+                RuntimeTerminalReason.TOKEN_BUDGET_REACHED,
+            )
+        report = await self._reason(
+            RuntimeStep.REPORT,
+            state.iterations,
+            context,
+            state,
+            self._reasoner.report(task, status, reason, state.history),
+        )
+        self._terminal_audit(context, state, RuntimeAuditOutcome.SUCCEEDED, reason)
+        return status, reason, report
+
+    def _terminal(
+        self,
+        context: ToolExecutionContext,
+        state: _RunState,
+        status: RuntimeTerminalStatus,
+        reason: RuntimeTerminalReason,
+    ) -> tuple[RuntimeTerminalStatus, RuntimeTerminalReason, None]:
+        outcome = (
+            RuntimeAuditOutcome.LIMIT_REACHED
+            if status is RuntimeTerminalStatus.LIMIT_REACHED
+            else RuntimeAuditOutcome.ESCALATED
+        )
+        self._terminal_audit(context, state, outcome, reason)
+        return status, reason, None
+
+    def _audit_step(
+        self,
+        context: ToolExecutionContext,
+        state: _RunState,
+        step: RuntimeStep,
+        outcome: RuntimeAuditOutcome,
+        decision: object | None = None,
+        error_code: ToolErrorCode | None = None,
+    ) -> None:
+        action = decision.action if hasattr(decision, "action") else None
+        tool_name = decision.tool_name if hasattr(decision, "tool_name") else None
+        self._audit.record(
+            RuntimeAuditRecord(
+                agent_id=context.agent_id,
+                agent_run_id=context.agent_run_id,
+                project_id=context.project_id,
+                task_id=context.task_id,
+                correlation_id=context.correlation_id,
+                iteration=state.iterations,
+                step=step,
+                outcome=outcome,
+                duration_ms=0,
+                tool_calls=state.tool_calls,
+                failures=state.failures,
+                reported_tokens=state.reported_tokens,
+                action=action,
+                tool_name=tool_name,
+                error_code=(
+                    RuntimeErrorCode.TOOL_FAILED if error_code is not None else None
+                ),
+            )
+        )
+
+    def _terminal_audit(
+        self,
+        context: ToolExecutionContext,
+        state: _RunState,
+        outcome: RuntimeAuditOutcome,
+        reason: RuntimeTerminalReason,
+    ) -> None:
+        self._audit.record(
+            RuntimeAuditRecord(
+                agent_id=context.agent_id,
+                agent_run_id=context.agent_run_id,
+                project_id=context.project_id,
+                task_id=context.task_id,
+                correlation_id=context.correlation_id,
+                iteration=state.iterations,
+                step=RuntimeStep.REPORT,
+                outcome=outcome,
+                duration_ms=0,
+                tool_calls=state.tool_calls,
+                failures=state.failures,
+                reported_tokens=state.reported_tokens,
+                reason=reason,
+            )
+        )
+
+    def _result(
+        self,
+        status: RuntimeTerminalStatus,
+        reason: RuntimeTerminalReason,
+        started: float,
+        state: _RunState | None = None,
+        report: RuntimeReport | None = None,
+    ) -> RuntimeResult:
+        state = state or _RunState(self._limits)
+        return RuntimeResult(
+            status=status,
+            reason=reason,
+            summary="Agent runtime terminated.",
+            iterations=state.iterations,
+            tool_calls=state.tool_calls,
+            failures=state.failures,
+            reported_tokens=state.reported_tokens,
+            usage_available=state.usage_available,
+            duration_ms=(perf_counter() - started) * 1000,
+            history=state.history,
+            report=report,
+        )
+
+
+class _RunState:
+    def __init__(self, limits: RuntimeLimits) -> None:
+        self._max_history = limits.max_history_entries
+        self.iterations = 0
+        self.tool_calls = 0
+        self.failures = 0
+        self.reported_tokens = 0
+        self.usage_available = True
+        self.history: tuple[RuntimeHistoryEntry, ...] = ()
+
+    def append(self, entry: RuntimeHistoryEntry) -> None:
+        self.history = (*self.history, entry)[-self._max_history :]

--- a/core/runtime/runtime.py
+++ b/core/runtime/runtime.py
@@ -3,7 +3,8 @@
 from __future__ import annotations
 
 import asyncio
-from collections.abc import Awaitable, Mapping
+from collections.abc import Awaitable, Callable, Mapping
+from functools import partial
 from time import perf_counter
 from typing import Protocol
 
@@ -66,6 +67,9 @@ class AgentRuntime:
         try:
             async with asyncio.timeout(self._limits.timeout_seconds):
                 status, reason, report = await self._execute(task, context, state)
+        except asyncio.CancelledError:
+            await self._audit_cancellation(context, state)
+            raise
         except TimeoutError:
             status = RuntimeTerminalStatus.TIMED_OUT
             reason = RuntimeTerminalReason.GLOBAL_TIMEOUT
@@ -94,7 +98,7 @@ class AgentRuntime:
                     iteration,
                     context,
                     state,
-                    self._reasoner.observe(task, state.history),
+                    partial(self._reasoner.observe, task, state.history),
                 )
                 if self._token_budget_reached(state):
                     return self._token_terminal(context, state)
@@ -103,7 +107,7 @@ class AgentRuntime:
                     iteration,
                     context,
                     state,
-                    self._reasoner.plan(task, observation, state.history),
+                    partial(self._reasoner.plan, task, observation, state.history),
                 )
                 if self._token_budget_reached(state):
                     return self._token_terminal(context, state)
@@ -112,7 +116,7 @@ class AgentRuntime:
                     iteration,
                     context,
                     state,
-                    self._reasoner.decide(task, observation, plan, state.history),
+                    partial(self._reasoner.decide, task, observation, plan, state.history),
                 )
                 if self._token_budget_reached(state):
                     return self._token_terminal(context, state)
@@ -212,7 +216,7 @@ class AgentRuntime:
                 iteration,
                 context,
                 state,
-                self._reasoner.verify(task, decision, tool_result, state.history),
+                partial(self._reasoner.verify, task, decision, tool_result, state.history),
                 decision,
             )
             if self._token_budget_reached(state):
@@ -263,12 +267,12 @@ class AgentRuntime:
         iteration: int,
         context: ToolExecutionContext,
         state: _RunState,
-        operation: Awaitable[ReasonerOutput[ValueT]],
+        operation: Callable[[], Awaitable[ReasonerOutput[ValueT]]],
         decision: object | None = None,
     ) -> ValueT:
         self._audit_step(context, state, step, RuntimeAuditOutcome.STARTED, decision)
         try:
-            output = await operation
+            output = await operation()
         except RuntimeError:
             self._audit_step(context, state, step, RuntimeAuditOutcome.FAILED, decision)
             raise
@@ -305,15 +309,35 @@ class AgentRuntime:
                 RuntimeTerminalStatus.LIMIT_REACHED,
                 RuntimeTerminalReason.TOKEN_BUDGET_REACHED,
             )
-        report = await self._reason(
+        await self._reason(
             RuntimeStep.REPORT,
             state.iterations,
             context,
             state,
-            self._reasoner.report(task, status, reason, state.history),
+            partial(self._reasoner.report, task, status, reason, state.history),
         )
         self._terminal_audit(context, state, RuntimeAuditOutcome.SUCCEEDED, reason)
-        return status, reason, report
+        return status, reason, None
+
+    async def _audit_cancellation(
+        self, context: ToolExecutionContext, state: _RunState
+    ) -> None:
+        async def cleanup() -> None:
+            await asyncio.sleep(0)
+            self._terminal_audit(
+                context,
+                state,
+                RuntimeAuditOutcome.CANCELLED,
+                RuntimeTerminalReason.CANCELLED,
+            )
+
+        cleanup_task = asyncio.create_task(cleanup())
+        while not cleanup_task.done():
+            try:
+                await asyncio.shield(cleanup_task)
+            except asyncio.CancelledError:
+                continue
+        cleanup_task.result()
 
     def _terminal(
         self,

--- a/core/runtime/stagnation.py
+++ b/core/runtime/stagnation.py
@@ -1,0 +1,67 @@
+"""Deterministic, bounded stagnation detection for agent loops."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from collections import deque
+
+from core.runtime.types import RuntimeDecision, RuntimeVerification
+from core.tools import JsonValue, ToolErrorCode
+
+type _Shape = str | list[_Shape] | dict[str, _Shape]
+
+
+class StagnationDetector:
+    """Retain only consecutive SHA-256 progress fingerprints."""
+
+    def __init__(self, window: int) -> None:
+        if isinstance(window, bool) or not 2 <= window <= 20:
+            raise ValueError("stagnation window must be between 2 and 20")
+        self._window = window
+        self._digests: deque[str] = deque(maxlen=window)
+
+    @property
+    def size(self) -> int:
+        """Return the number of bounded fingerprints currently retained."""
+        return len(self._digests)
+
+    def observe(
+        self,
+        decision: RuntimeDecision,
+        verification: RuntimeVerification | None,
+        tool_error_code: ToolErrorCode | None = None,
+    ) -> bool:
+        """Record one allowlisted progress shape and report repeated stagnation."""
+        canonical = {
+            "action": decision.action.value,
+            "tool_name": decision.tool_name,
+            "argument_shape": _shape(decision.arguments),
+            "verification_outcome": verification.outcome.value if verification else None,
+            "tool_error_code": tool_error_code.value if tool_error_code else None,
+        }
+        encoded = json.dumps(canonical, sort_keys=True, separators=(",", ":")).encode()
+        digest = hashlib.sha256(encoded).hexdigest()
+        if self._digests and self._digests[-1] != digest:
+            self._digests.clear()
+        self._digests.append(digest)
+        return len(self._digests) == self._window
+
+    def __repr__(self) -> str:
+        return f"StagnationDetector(window={self._window}, digests={tuple(self._digests)!r})"
+
+
+def _shape(value: JsonValue) -> _Shape:
+    if value is None:
+        return "null"
+    if isinstance(value, bool):
+        return "boolean"
+    if isinstance(value, str):
+        return "string"
+    if isinstance(value, int):
+        return "integer"
+    if isinstance(value, float):
+        return "number"
+    if isinstance(value, list):
+        return [_shape(item) for item in value]
+    return {key: _shape(value[key]) for key in sorted(value)}

--- a/core/runtime/types.py
+++ b/core/runtime/types.py
@@ -1,0 +1,247 @@
+"""Immutable values for one bounded autonomous agent loop."""
+
+from __future__ import annotations
+
+from copy import deepcopy
+from enum import StrEnum
+from typing import Annotated, Self
+from uuid import UUID
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+
+from core.tools import JsonValue, ToolErrorCode
+
+Identifier = Annotated[str, Field(pattern=r"^[a-z0-9][a-z0-9._:-]{0,127}$")]
+Text1024 = Annotated[str, Field(min_length=1, max_length=1_024)]
+Text4096 = Annotated[str, Field(min_length=1, max_length=4_096)]
+
+
+class _ImmutableRuntimeModel(BaseModel):
+    model_config = ConfigDict(frozen=True, extra="forbid", hide_input_in_errors=True)
+
+
+class RuntimeStep(StrEnum):
+    """Closed steps emitted by the V1 loop."""
+
+    OBSERVE = "OBSERVE"
+    PLAN = "PLAN"
+    DECIDE = "DECIDE"
+    ACT = "ACT"
+    OBSERVE_RESULT = "OBSERVE_RESULT"
+    VERIFY = "VERIFY"
+    REPORT = "REPORT"
+
+
+class RuntimeAction(StrEnum):
+    """Closed action categories returned by the reasoner."""
+
+    TOOL_CALL = "TOOL_CALL"
+    COMPLETE = "COMPLETE"
+    ESCALATE = "ESCALATE"
+
+
+class RuntimeVerificationOutcome(StrEnum):
+    """Closed verification outcomes after a tool observation."""
+
+    CONTINUE = "CONTINUE"
+    COMPLETE = "COMPLETE"
+    ESCALATE = "ESCALATE"
+
+
+class RuntimeTerminalStatus(StrEnum):
+    """Public terminal classifications for one run."""
+
+    COMPLETED = "COMPLETED"
+    ESCALATED = "ESCALATED"
+    LIMIT_REACHED = "LIMIT_REACHED"
+    TIMED_OUT = "TIMED_OUT"
+    FAILED = "FAILED"
+
+    def accepts(self, reason: RuntimeTerminalReason) -> bool:
+        """Return whether a reason truthfully belongs to this terminal status."""
+        return reason in _STATUS_REASONS[self]
+
+
+class RuntimeTerminalReason(StrEnum):
+    """Stable non-sensitive reasons for stopping a loop."""
+
+    TASK_COMPLETED = "TASK_COMPLETED"
+    AGENT_ESCALATED = "AGENT_ESCALATED"
+    HUMAN_APPROVAL_REQUIRED = "HUMAN_APPROVAL_REQUIRED"
+    PERMISSION_DENIED = "PERMISSION_DENIED"
+    STAGNATION_DETECTED = "STAGNATION_DETECTED"
+    MAX_ITERATIONS_REACHED = "MAX_ITERATIONS_REACHED"
+    MAX_TOOL_CALLS_REACHED = "MAX_TOOL_CALLS_REACHED"
+    TOKEN_BUDGET_REACHED = "TOKEN_BUDGET_REACHED"
+    GLOBAL_TIMEOUT = "GLOBAL_TIMEOUT"
+    MAX_FAILURES_REACHED = "MAX_FAILURES_REACHED"
+    AUDIT_FAILED = "AUDIT_FAILED"
+    INVALID_LLM_OUTPUT = "INVALID_LLM_OUTPUT"
+    CANCELLED = "CANCELLED"
+
+
+_STATUS_REASONS: dict[RuntimeTerminalStatus, frozenset[RuntimeTerminalReason]] = {
+    RuntimeTerminalStatus.COMPLETED: frozenset({RuntimeTerminalReason.TASK_COMPLETED}),
+    RuntimeTerminalStatus.ESCALATED: frozenset(
+        {
+            RuntimeTerminalReason.AGENT_ESCALATED,
+            RuntimeTerminalReason.HUMAN_APPROVAL_REQUIRED,
+            RuntimeTerminalReason.PERMISSION_DENIED,
+            RuntimeTerminalReason.STAGNATION_DETECTED,
+        }
+    ),
+    RuntimeTerminalStatus.LIMIT_REACHED: frozenset(
+        {
+            RuntimeTerminalReason.MAX_ITERATIONS_REACHED,
+            RuntimeTerminalReason.MAX_TOOL_CALLS_REACHED,
+            RuntimeTerminalReason.TOKEN_BUDGET_REACHED,
+        }
+    ),
+    RuntimeTerminalStatus.TIMED_OUT: frozenset({RuntimeTerminalReason.GLOBAL_TIMEOUT}),
+    RuntimeTerminalStatus.FAILED: frozenset(
+        {
+            RuntimeTerminalReason.MAX_FAILURES_REACHED,
+            RuntimeTerminalReason.AUDIT_FAILED,
+            RuntimeTerminalReason.INVALID_LLM_OUTPUT,
+        }
+    ),
+}
+
+
+class RuntimeLimits(_ImmutableRuntimeModel):
+    """Finite limits governing one complete autonomous run."""
+
+    max_iterations: Annotated[int, Field(ge=1, le=100)]
+    timeout_seconds: Annotated[float, Field(gt=0.0, le=3_600.0, allow_inf_nan=False)]
+    max_tool_calls: Annotated[int, Field(ge=0, le=1_000)]
+    max_failures: Annotated[int, Field(ge=0, le=100)]
+    max_tokens: Annotated[int, Field(ge=1, le=10_000_000)]
+    max_history_entries: Annotated[int, Field(ge=1, le=1_000)]
+    stagnation_window: Annotated[int, Field(ge=2, le=20)]
+    max_step_tokens: Annotated[int, Field(ge=1, le=131_072)]
+
+    @model_validator(mode="after")
+    def require_history_for_stagnation_window(self) -> Self:
+        if self.stagnation_window > self.max_history_entries:
+            raise ValueError("stagnation window exceeds retained history")
+        return self
+
+
+class RuntimeTask(_ImmutableRuntimeModel):
+    """Bounded task supplied to one runtime invocation."""
+
+    task_id: UUID
+    objective: Annotated[str, Field(min_length=1, max_length=8_192)]
+    acceptance_criteria: Annotated[tuple[Text1024, ...], Field(min_length=1, max_length=32)]
+
+    @field_validator("objective")
+    @classmethod
+    def reject_blank_objective(cls, value: str) -> str:
+        if not value.strip():
+            raise ValueError("objective must not be blank")
+        return value
+
+    @field_validator("acceptance_criteria", mode="before")
+    @classmethod
+    def copy_criteria(cls, value: object) -> object:
+        if isinstance(value, (list, tuple)):
+            return tuple(value)
+        return value
+
+    @field_validator("acceptance_criteria")
+    @classmethod
+    def reject_blank_criteria(cls, value: tuple[str, ...]) -> tuple[str, ...]:
+        if any(not item.strip() for item in value):
+            raise ValueError("acceptance criteria must not be blank")
+        return value
+
+
+class RuntimeObservation(_ImmutableRuntimeModel):
+    summary: Text4096
+    facts: Annotated[tuple[Text1024, ...], Field(max_length=32)] = ()
+    uncertainties: Annotated[tuple[Text1024, ...], Field(max_length=16)] = ()
+
+
+class RuntimePlan(_ImmutableRuntimeModel):
+    objective: Text4096
+    steps: Annotated[tuple[Text1024, ...], Field(min_length=1, max_length=32)]
+    success_criteria: Annotated[tuple[Text1024, ...], Field(min_length=1, max_length=16)]
+
+
+class RuntimeDecision(_ImmutableRuntimeModel):
+    """One closed action chosen by the reasoner."""
+
+    action: RuntimeAction
+    tool_name: Identifier | None
+    arguments: Annotated[dict[str, JsonValue], Field(max_length=128)]
+    rationale: Text4096
+    confidence: Annotated[float, Field(ge=0.0, le=1.0, allow_inf_nan=False)]
+
+    @field_validator("arguments", mode="before")
+    @classmethod
+    def copy_arguments(cls, value: object) -> object:
+        return deepcopy(value)
+
+    @model_validator(mode="after")
+    def require_action_fields(self) -> Self:
+        if self.action is RuntimeAction.TOOL_CALL:
+            if self.tool_name is None:
+                raise ValueError("tool action requires a tool name")
+        elif self.tool_name is not None or self.arguments:
+            raise ValueError("terminal action cannot contain tool controls")
+        return self
+
+
+class RuntimeVerification(_ImmutableRuntimeModel):
+    outcome: RuntimeVerificationOutcome
+    summary: Text4096
+    progress_made: bool
+
+
+class RuntimeReport(_ImmutableRuntimeModel):
+    summary: Text4096
+    details: Annotated[tuple[Text1024, ...], Field(max_length=32)] = ()
+    next_actions: Annotated[tuple[Text1024, ...], Field(max_length=16)] = ()
+
+
+class ReasonerOutput[ValueT: BaseModel](_ImmutableRuntimeModel):
+    """Typed structured value plus authoritative provider token metadata."""
+
+    value: ValueT
+    reported_tokens: Annotated[int, Field(ge=0)]
+    usage_available: bool
+
+    @model_validator(mode="after")
+    def require_consistent_usage(self) -> Self:
+        if not self.usage_available and self.reported_tokens != 0:
+            raise ValueError("unavailable usage cannot report tokens")
+        return self
+
+
+class RuntimeHistoryEntry(_ImmutableRuntimeModel):
+    iteration: Annotated[int, Field(ge=1, le=100)]
+    step: RuntimeStep
+    action: RuntimeAction | None = None
+    tool_name: Identifier | None = None
+    tool_error_code: ToolErrorCode | None = None
+    reported_tokens: Annotated[int, Field(ge=0)] = 0
+
+
+class RuntimeResult(_ImmutableRuntimeModel):
+    status: RuntimeTerminalStatus
+    reason: RuntimeTerminalReason
+    summary: Text4096
+    iterations: Annotated[int, Field(ge=0, le=100)]
+    tool_calls: Annotated[int, Field(ge=0, le=1_000)]
+    failures: Annotated[int, Field(ge=0, le=100)]
+    reported_tokens: Annotated[int, Field(ge=0, le=10_000_000)]
+    usage_available: bool
+    duration_ms: Annotated[float, Field(ge=0.0, allow_inf_nan=False)]
+    history: Annotated[tuple[RuntimeHistoryEntry, ...], Field(max_length=1_000)]
+    report: RuntimeReport | None = None
+
+    @model_validator(mode="after")
+    def require_truthful_terminal_pair(self) -> Self:
+        if not self.status.accepts(self.reason):
+            raise ValueError("runtime terminal status and reason do not match")
+        return self

--- a/core/runtime/types.py
+++ b/core/runtime/types.py
@@ -208,7 +208,7 @@ class ReasonerOutput[ValueT: BaseModel](_ImmutableRuntimeModel):
     """Typed structured value plus authoritative provider token metadata."""
 
     value: ValueT
-    reported_tokens: Annotated[int, Field(ge=0)]
+    reported_tokens: Annotated[int, Field(ge=0, le=10_000_000)]
     usage_available: bool
 
     @model_validator(mode="after")

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -31,8 +31,10 @@ different repository. Explicit workspace cleanup removes both the worktree and s
 
 ## Authorization
 
-The tool requires an active persisted `shell.execute` grant in the exact project scope. It is
-`HIGH` risk and requires autonomy level 3. Existing cumulative permission rules may impose a
+The tool requires active persisted `shell.execute` and `tests.execute` grants in the exact project
+scope. Requiring both closes the execution boundary for test, lint, and build profiles; read-only
+Git remains available through the dedicated `git_status` and `git_diff` tools with `git.read`.
+The command tool is `HIGH` risk and requires autonomy level 3. Existing cumulative rules may impose a
 stronger decision. `DENY` and `ASK` stop before profile detection or process creation.
 
 ## Process boundary

--- a/docs/developer-agent.md
+++ b/docs/developer-agent.md
@@ -42,7 +42,8 @@ A request is rejected before any model, tool, audit, or filesystem work unless:
 The allowlist contains `read_file`, `list_files`, `search_text`, `git_status`, `git_diff`,
 `write_file`, `create_file`, `patch_file`, `delete_file`, and `run_command_profile`. The allowlist
 does not grant authority: tools must still be registered, declared for the run, and allowed by the
-existing permission engine.
+existing permission engine from active persisted grants. Test, lint, and build execution requires
+both persisted `shell.execute` and `tests.execute` grants.
 
 ## Skill context
 
@@ -63,7 +64,9 @@ transaction, audit, and compensation behavior. Tests, linting, and builds run on
 Phase 11 fixed command profiles; the model cannot choose an executable, arguments, working
 directory, environment, timeout, or output limits.
 
-The command runner is an application-level safety boundary, not a hostile-code sandbox. Test and
+Command evidence is bound to the requested profile and validated for canonical profile/category,
+exit-code/status, and returned-tool consistency before it can affect the report. The command runner
+is an application-level safety boundary, not a hostile-code sandbox. Test and
 build profiles execute code from the managed repository. Production use with untrusted source
 still requires a stronger isolated execution backend in its designated future phase.
 

--- a/docs/developer-agent.md
+++ b/docs/developer-agent.md
@@ -1,0 +1,111 @@
+# Developer Agent
+
+Phase 14 introduces the first bounded business role in SynapseOS. `DeveloperAgent` understands one
+assigned task, selects relevant repository-owned skills, inspects one managed workspace, changes
+files through existing transactional tools, runs fixed verification profiles, reacts to failures
+inside the Phase 13 loop, and returns a deterministic report.
+
+## Architecture
+
+`DeveloperAgent` is a composition service in `core/developer/`. It does not subclass or duplicate
+`AgentRuntime`:
+
+```text
+DeveloperRequest
+  -> fail-closed role and scope validation
+  -> deterministic bounded skill selection
+  -> LLMLoopReasoner
+  -> AgentRuntime
+  -> ToolExecutor
+  -> managed read/write/fixed-command adapters
+  -> metadata-only evidence gate
+  -> DeveloperResult + AgentReport
+```
+
+The role delegates exactly one run to `AgentRuntime`. Runtime iteration, timeout, token, tool-call,
+failure, history, and stagnation limits therefore remain authoritative. One structured model
+decision causes at most one tool call; there are no implicit retries.
+
+## Request boundary
+
+A request is rejected before any model, tool, audit, or filesystem work unless:
+
+- the profile role is exactly `Developer` and its status is `ASSIGNED` or `WORKING`;
+- profile, task, and execution-context identifiers agree;
+- profile and execution-context tool declarations are identical;
+- every permission identifier is canonical;
+- filesystem read/write, shell execution, and test execution permissions are declared;
+- at least one read tool, one write tool, and `run_command_profile` are declared;
+- every declared tool belongs to the closed Developer allowlist;
+- one through four unique required checks use test, lint, or build profiles rather than Git profiles.
+
+The allowlist contains `read_file`, `list_files`, `search_text`, `git_status`, `git_diff`,
+`write_file`, `create_file`, `patch_file`, `delete_file`, and `run_command_profile`. The allowlist
+does not grant authority: tools must still be registered, declared for the run, and allowed by the
+existing permission engine.
+
+## Skill context
+
+The existing deterministic `SkillSelector` ranks only skills declared by the agent. A selected
+skill must exist in the injected immutable registry, have a positive match, fit the agent's
+canonical permissions, and recommend only declared tools.
+
+At most eight complete skills enter an ephemeral 12 KiB UTF-8 context. Instructions are never
+truncated: a skill that does not fit is omitted by stable identifier. The complete system prompt
+must remain within 16 KiB. Skill instructions are subordinate guidance and cannot grant
+permissions, add tools, change command profiles, override the task, or bypass the Company
+Constitution. Skill instructions and prompts are not persisted in results or audit metadata.
+
+## Repository changes and verification
+
+All repository access crosses the existing `ToolExecutor`. File mutations retain the Phase 10
+transaction, audit, and compensation behavior. Tests, linting, and builds run only through the
+Phase 11 fixed command profiles; the model cannot choose an executable, arguments, working
+directory, environment, timeout, or output limits.
+
+The command runner is an application-level safety boundary, not a hostile-code sandbox. Test and
+build profiles execute code from the managed repository. Production use with untrusted source
+still requires a stronger isolated execution backend in its designated future phase.
+
+## Evidence and report truthfulness
+
+The evidence wrapper delegates each call once and retains at most 128 records. It keeps only:
+
+- the validated relative path of a successful write;
+- command profile, category, exit code, terminal status, and truncation flag;
+- tool name and stable error code for failed or denied calls.
+
+It discards file content, patches, command stdout/stderr, prompts, responses, rationale, absolute
+paths, environment values, and raw exceptions. For repeated command profiles, the latest result is
+authoritative.
+
+The final `AgentReport` is application-generated, not model-generated:
+
+- `SUCCEEDED`: runtime completed and every required latest check succeeded;
+- `NEEDS_HUMAN`: permission, approval, or explicit agent escalation;
+- `BLOCKED`: runtime limits, timeout, stagnation, or missing required checks;
+- `FAILED`: runtime/audit failure or a failed latest required check.
+
+A model completion claim never overrides missing or failed deterministic checks. The Developer
+does not approve, merge, push, deploy, or review its own work.
+
+## Cancellation and resource ownership
+
+Cancellation propagates through `AgentRuntime` immediately after a sanitized cancellation audit.
+`DeveloperAgent` never closes the injected model provider, tool executor, audit recorder, skill
+registry, command runner, HTTP client, or database session.
+
+## Verification
+
+Run the focused Phase 14 tests:
+
+```bash
+.venv/bin/pytest tests/developer -q
+```
+
+The integration fixture uses `FakeLLMProvider` only for deterministic model output. It uses the
+real `ToolExecutor`, permission engine, managed workspace filesystem, transactional patch tool,
+fixed command policy, local process runner, and a real pytest subprocess. It covers both a direct
+fix and a failed-test/corrective-iteration/success path.
+
+Phase 15 `ReviewerAgent` and multi-agent coordination remain unimplemented.

--- a/docs/developer-agent.md
+++ b/docs/developer-agent.md
@@ -76,8 +76,8 @@ The evidence wrapper delegates each call once and retains at most 128 records. I
 - tool name and stable error code for failed or denied calls.
 
 It discards file content, patches, command stdout/stderr, prompts, responses, rationale, absolute
-paths, environment values, and raw exceptions. For repeated command profiles, the latest result is
-authoritative.
+paths, environment values, and raw exceptions. Repeated command profiles retain a bounded sequence
+so failures are not hidden; the latest result is authoritative for the final outcome.
 
 The final `AgentReport` is application-generated, not model-generated:
 

--- a/docs/runtime.md
+++ b/docs/runtime.md
@@ -1,0 +1,84 @@
+# Loop Engineering V1
+
+Phase 13 introduces the first controlled autonomous loop for one agent. It is provider-neutral and
+does not create a DeveloperAgent, coordinate multiple agents, or implement MCP.
+
+## State machine
+
+```text
+OBSERVE -> PLAN -> DECIDE
+  COMPLETE -> REPORT -> COMPLETED
+  ESCALATE -> REPORT -> ESCALATED
+  TOOL_CALL -> ACT -> VERIFY
+    CONTINUE -> next iteration
+    COMPLETE -> REPORT -> COMPLETED
+    ESCALATE -> REPORT -> ESCALATED
+```
+
+`AgentRuntime.run()` accepts an immutable `RuntimeTask` and an existing `ToolExecutionContext`.
+Every action goes exactly once through the central `ToolExecutor`; registry validation, declared
+capabilities, persisted permissions, approval gates, timeouts, output limits, and tool auditing
+therefore remain mandatory. The runtime exposes no direct shell, filesystem, Git, or network path.
+
+## Mandatory limits
+
+| Limit | Accepted range | Meaning |
+| --- | ---: | --- |
+| `max_iterations` | 1–100 | Iterations that may start |
+| `timeout_seconds` | >0–3,600 | Monotonic deadline for the whole run |
+| `max_tool_calls` | 0–1,000 | Calls handed to `ToolExecutor`, including failures |
+| `max_failures` | 0–100 | Malformed reasoning and unsuccessful tools |
+| `max_tokens` | 1–10,000,000 | Cumulative provider-reported tokens |
+| `max_history_entries` | 1–1,000 | Metadata-only entries retained in memory |
+| `stagnation_window` | 2–20 | Equal consecutive progress fingerprints |
+| `max_step_tokens` | 1–131,072 | Maximum generation configured per LLM request |
+
+Token usage is never estimated. The runtime uses the provider's authoritative total, or its
+reported prompt-plus-completion total. Missing usage remains zero and makes `usage_available`
+false. An exhausted known budget prevents the next external call. Phase 13 does not estimate cost.
+
+## Termination and failure behavior
+
+- `COMPLETED`: acceptance was reported complete.
+- `ESCALATED`: the agent escalated, permission was denied, approval is required, or the loop
+  stagnated.
+- `LIMIT_REACHED`: an iteration, tool-call, or token budget was exhausted.
+- `TIMED_OUT`: the global deadline expired.
+- `FAILED`: the failure limit, audit boundary, or structured-output boundary failed closed.
+
+There are no retries inside reasoning or tool operations. A malformed response or failed tool can
+only lead to another attempt through a new bounded iteration. Permission denial and approval
+requirements escalate immediately.
+
+The public result retains only counters, stable classifications, duration, and bounded
+metadata-only history. Prompts, responses, rationale, arguments, tool output, paths, and raw errors
+are excluded. A report is generated for ordinary terminal states but its text is deliberately not
+persisted in `RuntimeResult` during Phase 13.
+
+## Stagnation, audit, and lifecycle
+
+The stagnation detector keeps at most `stagnation_window` SHA-256 digests. A digest covers only the
+action category, tool name, recursive argument key/type shape, verification outcome, and stable
+tool error code. It never hashes or stores argument values or content.
+
+Each step emits started and terminal `RuntimeAuditRecord` values. The PostgreSQL adapter validates
+the persisted agent/run/task/project scope and appends an `AGENT_RUNTIME_STEP` `AuditEvent` with
+allowlisted identifiers, counters, outcomes, actions, reasons, tool names, and error
+classifications. It never commits, rolls back, or closes the caller's session. This guarantee is
+application-level; database-level hardening is deferred.
+
+The global timeout cancels active inner work. External cancellation is propagated after staging a
+prevalidated cancellation event through a dedicated non-blocking recorder method. The production
+adapter performs no query, flush, network I/O, or thread handoff on this path. The runtime never
+closes injected providers, executors, sessions, or network clients.
+
+## Deliberate exclusions
+
+Phase 12 MCP remains unimplemented. Phase 13 adds no multi-agent coordination, DeveloperAgent,
+memory, reputation, cost estimation, provider routing, recursive loop, or frontend.
+
+## Focused verification
+
+```bash
+TEST_POSTGRES_PORT=55432 .venv/bin/pytest tests/runtime tests/database/test_runtime_audit.py -q
+```

--- a/docs/superpowers/plans/2026-08-28-phase-13-loop-engineering-v1.md
+++ b/docs/superpowers/plans/2026-08-28-phase-13-loop-engineering-v1.md
@@ -1,0 +1,406 @@
+# Phase 13 Loop Engineering V1 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build one bounded, audited, provider-neutral autonomous agent loop that can select and execute existing secured tools without implementing multi-agent behavior.
+
+**Architecture:** Immutable contracts and ports live in `core/runtime`; `LLMLoopReasoner` performs strict one-shot structured generations; `AgentRuntime` owns the non-recursive state machine and budgets; SQLAlchemy only implements the audit port. Existing `ToolExecutor` remains the exclusive action boundary.
+
+**Tech Stack:** Python 3.12, asyncio, Pydantic v2, existing LLM/tool/permission contracts, SQLAlchemy 2, PostgreSQL 16, pytest, Ruff, mypy strict.
+
+**Spec:** `docs/superpowers/specs/2026-08-28-phase-13-loop-engineering-v1-design.md`
+
+## Global Constraints
+
+- Implement Phase 13 only; leave all Phase 12 and Phase 14+ checkboxes unchanged.
+- One agent only; no orchestration, delegation, scheduler, event bus, role-specific agent, or multi-agent state.
+- No free-form command, permission bypass, implicit retry, recursion, fallback provider, or duplicate tool call.
+- Every external call is bounded; the run has one monotonic global timeout.
+- Cancellation propagates after cancellation-resistant terminal audit cleanup.
+- Never persist prompts, LLM responses, reasoning, tool arguments/output, paths, environment values, or provider/database errors.
+- Injected providers, executors, sessions, and network clients are never closed by the runtime.
+- Tests use `FakeLLMProvider`; database tests use real PostgreSQL migrated by Alembic.
+- Apply strict RED → GREEN → REFACTOR TDD and commit each independently reviewable task.
+
+---
+
+## File structure
+
+- `core/runtime/types.py` — immutable limits, task, step, decision, verification, audit, and result values.
+- `core/runtime/errors.py` — stable sanitized runtime error codes and exceptions.
+- `core/runtime/audit.py` — persistence-neutral runtime audit recorder protocol.
+- `core/runtime/reasoner.py` — reasoner protocol and strict LLM-backed implementation.
+- `core/runtime/stagnation.py` — bounded allowlisted progress fingerprint window.
+- `core/runtime/runtime.py` — iterative one-agent state machine and budget enforcement.
+- `core/runtime/__init__.py` — explicit public Phase 13 API.
+- `infrastructure/runtime/audit.py` — SQLAlchemy append-only audit adapter.
+- `infrastructure/runtime/__init__.py` — infrastructure exports.
+- `tests/runtime/` — contracts, reasoner, loop, security, and cancellation tests.
+- `tests/database/test_runtime_audit.py` — migrated PostgreSQL audit integration.
+- `docs/runtime.md` — operator/developer contract and exclusions.
+
+### Task 1: Immutable runtime contracts
+
+**Files:**
+- Create: `core/runtime/types.py`
+- Create: `core/runtime/errors.py`
+- Modify: `core/runtime/__init__.py`
+- Create: `tests/runtime/__init__.py`
+- Create: `tests/runtime/test_types.py`
+
+**Interfaces:**
+- Produces: `RuntimeLimits`, `RuntimeTask`, `RuntimeStep`, `RuntimeAction`, `RuntimeObservation`, `RuntimePlan`, `RuntimeDecision`, `RuntimeVerification`, `RuntimeTerminalStatus`, `RuntimeTerminalReason`, `RuntimeHistoryEntry`, `RuntimeReport`, `RuntimeResult`, `ReasonerOutput[T]`, `RuntimeErrorCode`, `RuntimeError`.
+- Consumes: existing `JsonValue`, `ToolErrorCode`, and UUID/Pydantic primitives.
+
+- [ ] **Step 1: Write strict failing contract tests**
+
+Assert exact enum values, frozen models, forbidden extras, copied JSON arguments, finite numeric
+limits, bounded criteria/history, cross-field decision rules, truthful terminal status/reason pairs,
+and combined constraints such as `stagnation_window <= max_history_entries`.
+
+```python
+def test_tool_decision_requires_name_and_arguments() -> None:
+    decision = RuntimeDecision(
+        action=RuntimeAction.TOOL_CALL,
+        tool_name="fake_read",
+        arguments={"path": "README.md"},
+        rationale="Inspect the bounded target.",
+        confidence=0.8,
+    )
+    assert decision.tool_name == "fake_read"
+    with pytest.raises(ValidationError):
+        RuntimeDecision(
+            action=RuntimeAction.COMPLETE,
+            tool_name="fake_read",
+            arguments={},
+            rationale="Invalid terminal decision.",
+            confidence=0.8,
+        )
+```
+
+- [ ] **Step 2: Run RED**
+
+Run: `.venv/bin/pytest tests/runtime/test_types.py -q`
+Expected: collection fails because Phase 13 runtime contracts do not exist.
+
+- [ ] **Step 3: Implement minimal immutable models and safe errors**
+
+Use `ConfigDict(frozen=True, extra="forbid", hide_input_in_errors=True)`, strict validators, bounded
+collections, finite fields, and recursive JSON copying. Define the exact terminal statuses and
+reasons from the approved spec; do not add future phases.
+
+- [ ] **Step 4: Verify GREEN and static quality**
+
+Run: `.venv/bin/pytest tests/runtime/test_types.py -q`
+Run: `.venv/bin/ruff check core/runtime tests/runtime`
+Run: `.venv/bin/mypy core/runtime tests/runtime`
+Expected: all pass without warnings.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add core/runtime tests/runtime
+git commit -m "feat(runtime): define bounded loop contracts"
+```
+
+### Task 2: Strict one-shot LLM reasoner
+
+**Files:**
+- Create: `core/runtime/reasoner.py`
+- Modify: `core/runtime/__init__.py`
+- Create: `tests/runtime/conftest.py`
+- Create: `tests/runtime/test_reasoner.py`
+
+**Interfaces:**
+- Produces: `LoopReasoner` protocol and `LLMLoopReasoner(provider, *, system_prompt, max_step_tokens)`.
+- Produces async methods `observe`, `plan`, `decide`, `verify`, and `report`, each accepting the exact immutable runtime values from Task 1 and returning `ReasonerOutput[the_expected_type]`.
+- Consumes: `LLMProvider`, `LLMRequest`, `LLMResponse`, `decode_structured_output`.
+
+- [ ] **Step 1: Write RED tests with `FakeLLMProvider`**
+
+Queue exact `LLMResponse` objects and assert each operation sends one request, uses the configured
+`max_tokens`, validates one exact JSON object, returns its typed model, and records only returned
+usage metadata. Assert malformed JSON, duplicate keys, extras, invalid tool arguments, and provider
+failure produce sanitized `RuntimeError` values without a second provider call.
+
+```python
+async def test_decide_decodes_one_closed_tool_action(fake_response: LLMResponse) -> None:
+    provider = FakeLLMProvider(responses=[fake_response])
+    reasoner = LLMLoopReasoner(provider, system_prompt="Bounded runtime.", max_step_tokens=512)
+    decision = await reasoner.decide(task, observation, plan, ())
+    assert decision.action is RuntimeAction.TOOL_CALL
+    assert len(provider.requests) == 1
+    assert provider.requests[0].max_tokens == 512
+```
+
+- [ ] **Step 2: Run RED**
+
+Run: `.venv/bin/pytest tests/runtime/test_reasoner.py -q`
+Expected: fails because `LoopReasoner` and `LLMLoopReasoner` are absent.
+
+- [ ] **Step 3: Implement bounded prompts and strict decoding**
+
+Keep each prompt constant plus bounded JSON serialization of typed inputs. Never include prior raw
+responses. Store no request/response history in the reasoner. Count usage from `total_tokens`, or
+safe prompt/completion sum, and expose whether usage was reported.
+
+- [ ] **Step 4: Verify GREEN and no duplicate calls**
+
+Run: `.venv/bin/pytest tests/runtime/test_reasoner.py tests/llm tests/agents/test_structured_output.py -q`
+Expected: all pass, malformed responses make exactly one provider request.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add core/runtime/reasoner.py core/runtime/__init__.py tests/runtime
+git commit -m "feat(runtime): add structured loop reasoner"
+```
+
+### Task 3: Runtime audit contract and PostgreSQL adapter
+
+**Files:**
+- Create: `core/runtime/audit.py`
+- Create: `infrastructure/runtime/__init__.py`
+- Create: `infrastructure/runtime/audit.py`
+- Modify: `core/runtime/__init__.py`
+- Create: `tests/runtime/test_audit_contract.py`
+- Create: `tests/database/test_runtime_audit.py`
+
+**Interfaces:**
+- Produces: `RuntimeAuditStep`, `RuntimeAuditOutcome`, `RuntimeAuditRecord`, and `RuntimeAuditRecorder.record(record) -> None`.
+- Produces: `SQLAlchemyRuntimeAuditRecorder(session: Session)`.
+- Consumes: existing `AuditEvent`, `AuditEventRepository`, scope entities, and caller-owned `Session`.
+
+- [ ] **Step 1: Write RED unit and real-PostgreSQL tests**
+
+Assert one append-only `AuditEvent` per runtime step with `event_type="AGENT_RUNTIME_STEP"`,
+`action="execute_agent_loop"`, agent/project/task/run/correlation scope, allowlisted counters, stable
+outcome/reason, and no prompt, response, rationale, tool arguments/output, paths, or secret markers.
+Assert forged scope and detached session fail safely. Assert recorder never commits, rolls back, or
+closes the session.
+
+- [ ] **Step 2: Run RED**
+
+Run: `.venv/bin/pytest tests/runtime/test_audit_contract.py -q`
+Run: `TEST_POSTGRES_PORT=55432 .venv/bin/pytest tests/database/test_runtime_audit.py -q`
+Expected: fails because runtime audit contracts and adapter are absent.
+
+- [ ] **Step 3: Implement append-only sanitized recording**
+
+Validate exact scope using the same `AgentRun -> Agent -> Task -> Project` relationship as tool
+audit. Add and flush one `AuditEvent`; do not own the transaction. Map exceptions to
+`RuntimeErrorCode.AUDIT_FAILED` and erase raw tracebacks/messages.
+
+- [ ] **Step 4: Verify GREEN and append-only guard compatibility**
+
+Run: `TEST_POSTGRES_PORT=55432 .venv/bin/pytest tests/database/test_runtime_audit.py tests/database/test_append_only.py -q`
+Expected: all pass with no migration because `AuditEvent` already supports the data.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add core/runtime/audit.py core/runtime/__init__.py infrastructure/runtime tests/runtime/test_audit_contract.py tests/database/test_runtime_audit.py
+git commit -m "feat(runtime): audit bounded loop steps"
+```
+
+### Task 4: Deterministic stagnation detector
+
+**Files:**
+- Create: `core/runtime/stagnation.py`
+- Modify: `core/runtime/__init__.py`
+- Create: `tests/runtime/test_stagnation.py`
+
+**Interfaces:**
+- Produces: `StagnationDetector(window: int)` with `observe(decision, verification_or_none) -> bool` and immutable `size`.
+- Consumes: `RuntimeDecision`, `RuntimeVerification`, stable `ToolErrorCode` only.
+
+- [ ] **Step 1: Write RED behavior and secrecy tests**
+
+Assert identical allowlisted progress shapes trigger only when the entire consecutive window is
+full; changed action/tool/argument shape/outcome resets the run; values of arguments, rationale,
+tool output, and secret markers never appear in the retained fingerprint state.
+
+- [ ] **Step 2: Run RED**
+
+Run: `.venv/bin/pytest tests/runtime/test_stagnation.py -q`
+Expected: fails because `StagnationDetector` is absent.
+
+- [ ] **Step 3: Implement canonical SHA-256 fingerprints**
+
+Canonicalize only action, tool name, recursively sorted argument key/type shape, verification
+outcome, and stable tool error code. Retain a deque of at most `window` digests.
+
+- [ ] **Step 4: Verify GREEN**
+
+Run: `.venv/bin/pytest tests/runtime/test_stagnation.py -q`
+Expected: all pass; no raw values are retained.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add core/runtime/stagnation.py core/runtime/__init__.py tests/runtime/test_stagnation.py
+git commit -m "feat(runtime): detect bounded loop stagnation"
+```
+
+### Task 5: Bounded one-agent runtime state machine
+
+**Files:**
+- Create: `core/runtime/runtime.py`
+- Modify: `core/runtime/__init__.py`
+- Create: `tests/runtime/fakes.py`
+- Create: `tests/runtime/test_runtime.py`
+
+**Interfaces:**
+- Produces: `AgentRuntime(reasoner, tool_executor, audit_recorder, limits)`.
+- Produces: `async run(task: RuntimeTask, context: ToolExecutionContext) -> RuntimeResult`.
+- Consumes: Tasks 1–4 plus existing `ToolExecutor.execute()` and `ToolResult`.
+
+- [ ] **Step 1: Write RED scenario tests**
+
+Using concrete `LLMLoopReasoner(FakeLLMProvider(...))`, real `ToolExecutor`, deterministic fake
+tools/permissions/tool audit, and recording runtime audit, cover:
+
+- first-decision completion with zero tool calls;
+- one failed tool result followed by a corrective new iteration and successful verification;
+- normal completion after one successful tool result;
+- permission denial and approval-required immediate escalation;
+- malformed LLM output bounded by `max_failures`;
+- `max_iterations`, `max_tool_calls`, known token budget, and stagnation termination;
+- exactly one report call for normal terminal states;
+- no duplicate provider/tool calls.
+
+```python
+result = asyncio.run(runtime.run(task, context))
+assert result.status is RuntimeTerminalStatus.COMPLETED
+assert result.iterations == 1
+assert result.tool_calls == 1
+assert FakeTool.calls == 1
+assert len(provider.requests) == 5
+```
+
+- [ ] **Step 2: Run RED**
+
+Run: `.venv/bin/pytest tests/runtime/test_runtime.py -q`
+Expected: fails because `AgentRuntime` is absent.
+
+- [ ] **Step 3: Implement the iterative state machine**
+
+Use `for iteration in range(1, max_iterations + 1)` inside one global timeout. Audit every stage
+before/after external work. Check deadline and budgets before every reasoner/tool call. Append only
+safe bounded `RuntimeHistoryEntry` metadata. Route every action through `ToolExecutor`; interpret
+status deterministically; never invoke the same decision twice.
+
+- [ ] **Step 4: Verify GREEN and compatibility**
+
+Run: `.venv/bin/pytest tests/runtime/test_runtime.py tests/tools/test_executor.py tests/agents -q`
+Expected: all pass without changing existing tool or agent semantics.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add core/runtime/runtime.py core/runtime/__init__.py tests/runtime
+git commit -m "feat(runtime): execute bounded one-agent loops"
+```
+
+### Task 6: Timeout, cancellation, and adversarial hardening
+
+**Files:**
+- Modify: `core/runtime/runtime.py`
+- Create: `tests/runtime/test_runtime_safety.py`
+
+**Interfaces:**
+- Strengthens `AgentRuntime.run()` without changing its public signature.
+
+- [ ] **Step 1: Write RED timeout and cancellation tests**
+
+Use blocking async reasoner/tool collaborators to prove global timeout returns `TIMED_OUT`, nested
+tool timeout remains a tool observation, cancellation is immediately propagated, repeated
+cancellation cannot interrupt terminal audit cleanup, and injected collaborators expose no runtime-
+owned `close()` call. Verify audit failures are sanitized and never silently ignored.
+
+- [ ] **Step 2: Run RED**
+
+Run: `.venv/bin/pytest tests/runtime/test_runtime_safety.py -q`
+Expected: intended timeout/cancellation/audit assertions fail before hardening.
+
+- [ ] **Step 3: Implement cancellation-resistant terminal audit**
+
+Run the finite cleanup audit in a separate task awaited through `asyncio.shield`; tolerate repeated
+cancellation until that task finishes, then re-raise the original cancellation. Keep global timeout
+distinct from inner tool/provider failures. Do not add sleeps, retries, or resource ownership.
+
+- [ ] **Step 4: Add data-leak and finite-history assertions**
+
+Place unique markers in task content, system prompt, malformed response, tool arguments/output,
+workspace path, and provider error. Assert none appear in `RuntimeResult`, history, audit records,
+exception strings, or metadata. Assert retained history never exceeds `max_history_entries`.
+
+- [ ] **Step 5: Verify GREEN and commit**
+
+Run: `.venv/bin/pytest tests/runtime/test_runtime_safety.py tests/runtime/test_runtime.py -q`
+Run: `.venv/bin/ruff check core/runtime tests/runtime`
+Run: `.venv/bin/mypy core/runtime tests/runtime`
+Expected: all pass without warnings.
+
+```bash
+git add core/runtime/runtime.py tests/runtime/test_runtime_safety.py
+git commit -m "test(runtime): harden loop safety boundaries"
+```
+
+### Task 7: Documentation, checklist, and full verification
+
+**Files:**
+- Create: `docs/runtime.md`
+- Modify: `README.md`
+- Modify: `AGENTS.md`
+- Modify: `SYNAPSEOS_DEVELOPMENT_CHECKLIST.md`
+
+**Interfaces:**
+- Documents the completed public Phase 13 behavior; adds no runtime API.
+
+- [ ] **Step 1: Document the implemented runtime**
+
+Describe the state machine, immutable inputs/results, terminal statuses, exact budgets, token
+accounting, stagnation fingerprints, tool/permission path, audit allowlist, timeout/cancellation,
+configuration if introduced, operational limits, and Phase 12/14+ exclusions. Keep all code terms
+and comments in English.
+
+- [ ] **Step 2: Update only genuinely completed Phase 13 checkboxes**
+
+Mark each Phase 13 guardrail complete only after its corresponding test passes. Do not change Phase
+12 or Phase 14. Add no claim of cost accounting unless an authoritative injected cost value exists.
+
+- [ ] **Step 3: Run focused and full quality gates**
+
+Run: `TEST_POSTGRES_PORT=55432 .venv/bin/pytest tests/runtime tests/database/test_runtime_audit.py -q`
+Run: `make check`
+Run: `.venv/bin/ruff format --check .`
+Run: `git diff --check phase-11/secure-command-runner..HEAD`
+Expected: every command passes with pristine output.
+
+- [ ] **Step 4: Validate Docker and migrations**
+
+Run: `docker compose build api`
+Run: `docker compose up -d db api`
+Run: `docker compose exec -T api alembic current`
+Run: `curl --fail --silent http://localhost:8000/health`
+Expected: image builds, services are healthy, Alembic remains at the existing head unless a reviewed
+audit schema need was discovered, and health returns `{"status":"ok"}`.
+
+- [ ] **Step 5: Independent review and remediation**
+
+Request a read-only correctness/security review against `phase-11/secure-command-runner`. Reproduce
+every valid finding with a failing test, fix it in TDD order, rerun the complete gates, and obtain a
+merge-ready verdict.
+
+- [ ] **Step 6: Commit documentation**
+
+```bash
+git add docs/runtime.md README.md AGENTS.md SYNAPSEOS_DEVELOPMENT_CHECKLIST.md
+git commit -m "docs(runtime): complete Phase 13 guidance"
+```
+
+- [ ] **Step 7: Push and create the stacked PR**
+
+Push `phase-13/loop-engineering-v1` and create a PR whose base is
+`phase-11/secure-command-runner`. Do not merge it and do not start Phase 14.

--- a/docs/superpowers/plans/2026-08-28-phase-13-loop-engineering-v1.md
+++ b/docs/superpowers/plans/2026-08-28-phase-13-loop-engineering-v1.md
@@ -325,9 +325,10 @@ Expected: intended timeout/cancellation/audit assertions fail before hardening.
 
 - [ ] **Step 3: Implement cancellation-resistant terminal audit**
 
-Run the finite cleanup audit in a separate task awaited through `asyncio.shield`; tolerate repeated
-cancellation until that task finishes, then re-raise the original cancellation. Keep global timeout
-distinct from inner tool/provider failures. Do not add sleeps, retries, or resource ownership.
+Stage the finite cancellation audit through a dedicated prevalidated recorder method that performs
+no query, flush, network I/O, or thread handoff, then re-raise the original cancellation. Keep
+global timeout distinct from inner tool/provider failures. Do not add sleeps, retries, or resource
+ownership.
 
 - [ ] **Step 4: Add data-leak and finite-history assertions**
 

--- a/docs/superpowers/plans/2026-08-28-phase-14-developer-agent.md
+++ b/docs/superpowers/plans/2026-08-28-phase-14-developer-agent.md
@@ -346,4 +346,3 @@
 - [ ] **Step 6: Push and open the stacked pull request**
 
   Push `phase-14/developer-agent`, open a PR against `phase-13/loop-engineering-v1`, and include scope, safeguards, tests, Docker/PostgreSQL evidence, decisions, known limitations, and explicit Phase 15 exclusion.
-

--- a/docs/superpowers/plans/2026-08-28-phase-14-developer-agent.md
+++ b/docs/superpowers/plans/2026-08-28-phase-14-developer-agent.md
@@ -1,0 +1,349 @@
+# Phase 14 Developer Agent Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build one bounded DeveloperAgent that uses the Phase 13 runtime and existing secure tools to inspect, change, and verify a managed repository.
+
+**Architecture:** `DeveloperAgent` is a composition service, not a second loop. Focused modules validate the role boundary, compile eligible skill instructions, collect metadata-only tool evidence, and derive a truthful report after exactly one `AgentRuntime` run.
+
+**Tech Stack:** Python 3.12, Pydantic v2, asyncio, pytest, existing SynapseOS runtime/skills/tools/permissions/workspaces/commands.
+
+**Spec:** `docs/superpowers/specs/2026-08-28-phase-14-developer-agent-design.md`
+
+## Global Constraints
+
+- Implement Phase 14 only; do not add ReviewerAgent, multi-agent orchestration, MCP, memory, reputation, merge, deployment, or Phase 15 behavior.
+- Use the existing `AgentRuntime`, `LLMLoopReasoner`, `ToolExecutor`, workspace tools, and fixed command profiles; do not duplicate those boundaries.
+- Use strict RED-GREEN-REFACTOR TDD and run every new test once in RED before production code.
+- Keep all source code, comments, tests, documentation, branches, and commits in English.
+- Bound skill context to eight complete skills and 12 KiB UTF-8; never truncate instructions.
+- Retain at most 128 metadata-only evidence records and never retain prompts, responses, file contents, patches, command output, absolute paths, environment values, or raw exceptions.
+- Execute each model-selected tool call exactly once with no implicit retry.
+- Preserve mandatory runtime/tool timeouts, cancellation, token/tool/iteration/failure limits, permission checks, and audit behavior.
+- Test repository behavior through real adapters; use `FakeLLMProvider` only at the external model boundary.
+- Do not use `metadata.create_all()`; database verification uses PostgreSQL migrated by Alembic.
+- Never stage or modify `CLAUDE.local.md`.
+
+---
+
+### Task 1: Developer boundary contracts and validation
+
+**Files:**
+- Create: `core/developer/__init__.py`
+- Create: `core/developer/errors.py`
+- Create: `core/developer/types.py`
+- Create: `core/developer/validation.py`
+- Create: `tests/developer/__init__.py`
+- Create: `tests/developer/factories.py`
+- Create: `tests/developer/test_types.py`
+- Create: `tests/developer/test_validation.py`
+
+**Interfaces:**
+- Consumes: `AgentProfile`, `AgentReport`, `RuntimeTask`, `RuntimeResult`, `ToolExecutionContext`, `CommandProfileId`.
+- Produces: `DeveloperErrorCode`, `DeveloperError`, `DeveloperRequest`, `DeveloperCheckResult`, `DeveloperResult`, `validate_developer_request(request) -> ValidatedDeveloperRequest`.
+
+- [ ] **Step 1: Write failing immutable-contract tests**
+
+  Cover strict/frozen models, one-to-four required checks, bounded metadata collections, copied input collections, unique relative changed paths, and rejection of absolute/traversing paths.
+
+- [ ] **Step 2: Run contract tests and verify RED**
+
+  Run: `.venv/bin/pytest tests/developer/test_types.py -q`
+
+  Expected: collection fails because `core.developer` does not exist.
+
+- [ ] **Step 3: Implement minimal contracts and stable sanitized errors**
+
+  Define strict Pydantic models. `DeveloperCheckResult` stores only profile ID, category, status, optional bounded exit code, and truncation. `DeveloperResult` stores the runtime result, existing `AgentReport`, selected/omitted IDs, changed relative paths, and checks.
+
+- [ ] **Step 4: Run contract tests and verify GREEN**
+
+  Run: `.venv/bin/pytest tests/developer/test_types.py -q`
+
+- [ ] **Step 5: Write failing request-validation tests**
+
+  Cover exact Developer role, active status, matching agent/task IDs, canonical permission identifiers, closed tool allowlist, mandatory read/write/command capabilities, declared-context equality, and rejection of Git/unknown required profiles before collaborator calls.
+
+- [ ] **Step 6: Run validation tests and verify RED**
+
+  Run: `.venv/bin/pytest tests/developer/test_validation.py -q`
+
+  Expected: failures name missing validation behavior.
+
+- [ ] **Step 7: Implement fail-closed validation**
+
+  Return a private immutable validated value containing canonical permissions and checks. Map all public validation failures to stable `DeveloperErrorCode` values with input-free messages.
+
+- [ ] **Step 8: Run focused tests and quality checks**
+
+  Run: `.venv/bin/pytest tests/developer/test_types.py tests/developer/test_validation.py -q`
+
+  Run: `.venv/bin/ruff check core/developer tests/developer`
+
+  Run: `.venv/bin/mypy core/developer tests/developer`
+
+- [ ] **Step 9: Commit**
+
+  Commit: `feat(developer): define secure role boundary`
+
+### Task 2: Deterministic skill context policy
+
+**Files:**
+- Create: `core/developer/skills.py`
+- Create: `tests/developer/test_skills.py`
+- Modify: `core/developer/__init__.py`
+
+**Interfaces:**
+- Consumes: `ValidatedDeveloperRequest`, `SkillRegistry`, `SkillSelector`, `SkillSelectionRequest`.
+- Produces: `DeveloperSkillContext(selected_ids, omitted_ids, prompt_fragment)` and `build_skill_context(...)`.
+
+- [ ] **Step 1: Write failing eligibility and ordering tests**
+
+  Use real `SkillRegistry` and `SkillSelector`. Prove undeclared, missing, permission-incompatible, tool-incompatible, and zero-score skills are excluded; selected skills follow selector order and are capped at eight.
+
+- [ ] **Step 2: Run selection tests and verify RED**
+
+  Run: `.venv/bin/pytest tests/developer/test_skills.py -q`
+
+- [ ] **Step 3: Implement deterministic eligibility filtering**
+
+  Select once with the request's domains, technologies, tags, objective, role, and canonical permissions. Intersect results with profile declarations and require recommended tools to be a subset of declared tools.
+
+- [ ] **Step 4: Write failing byte-budget and secrecy tests**
+
+  Prove complete instructions are included or omitted, never truncated; UTF-8 byte count is at most 12,288; final composed prompt is at most 16,384; stable IDs report omissions; exceptions never contain instructions.
+
+- [ ] **Step 5: Run budget tests and verify RED**
+
+  Run: `.venv/bin/pytest tests/developer/test_skills.py -q`
+
+- [ ] **Step 6: Implement the subordinate skill compiler**
+
+  Add a fixed security preamble and deterministic separators. Account for encoded bytes before appending each complete skill and fail closed if the base profile prompt plus compiled context exceeds the reasoner ceiling.
+
+- [ ] **Step 7: Run focused tests and quality checks**
+
+  Run: `.venv/bin/pytest tests/developer/test_skills.py -q`
+
+  Run: `.venv/bin/ruff check core/developer tests/developer`
+
+  Run: `.venv/bin/mypy core/developer tests/developer`
+
+- [ ] **Step 8: Commit**
+
+  Commit: `feat(developer): add bounded skill context`
+
+### Task 3: Metadata-only evidence and deterministic reporting
+
+**Files:**
+- Create: `core/developer/evidence.py`
+- Create: `core/developer/reporting.py`
+- Create: `tests/developer/test_evidence.py`
+- Create: `tests/developer/test_reporting.py`
+- Modify: `core/developer/__init__.py`
+
+**Interfaces:**
+- Consumes: the runtime tool-executor protocol, `ToolResult`, `RuntimeResult`, required command profiles.
+- Produces: `EvidenceCollectingToolExecutor.execute(...)`, immutable evidence snapshot, and `build_developer_result(...) -> DeveloperResult`.
+
+- [ ] **Step 1: Write failing evidence-wrapper tests**
+
+  Prove one delegation per call, a 128-record cap, first-observed unique successful changed paths, latest command result per profile, stable failed-tool codes, and no ownership/close behavior.
+
+- [ ] **Step 2: Run evidence tests and verify RED**
+
+  Run: `.venv/bin/pytest tests/developer/test_evidence.py -q`
+
+- [ ] **Step 3: Implement metadata-only evidence collection**
+
+  Revalidate relative write paths after successful tool results. Parse command output by an explicit allowlist and discard every unknown key, stdout/stderr, content, patch, absolute path, and raw error value.
+
+- [ ] **Step 4: Write failing truthful-report tests**
+
+  Use literal runtime/check fixtures to prove success requires all latest checks to succeed; missing checks are blocked; failed latest checks are failed; approval/permission outcomes need human; limits/timeouts/stagnation are blocked; audit/runtime failures are failed.
+
+- [ ] **Step 5: Run report tests and verify RED**
+
+  Run: `.venv/bin/pytest tests/developer/test_reporting.py -q`
+
+- [ ] **Step 6: Implement deterministic report mapping**
+
+  Build bounded summaries from enums and counts only. Never reuse an LLM completion claim as verification and never hide failed/missing checks.
+
+- [ ] **Step 7: Run focused tests and quality checks**
+
+  Run: `.venv/bin/pytest tests/developer/test_evidence.py tests/developer/test_reporting.py -q`
+
+  Run: `.venv/bin/ruff check core/developer tests/developer`
+
+  Run: `.venv/bin/mypy core/developer tests/developer`
+
+- [ ] **Step 8: Commit**
+
+  Commit: `feat(developer): retain safe execution evidence`
+
+### Task 4: DeveloperAgent composition
+
+**Files:**
+- Create: `core/developer/agent.py`
+- Create: `tests/developer/test_agent.py`
+- Modify: `core/developer/__init__.py`
+
+**Interfaces:**
+- Consumes: validated request, skill context, injected LLM provider, tool executor, runtime audit recorder, skill registry/selector, and `RuntimeLimits`.
+- Produces: `DeveloperAgent.run(request: DeveloperRequest) -> DeveloperResult`.
+
+- [ ] **Step 1: Write failing preflight and composition tests**
+
+  Prove validation and skill compilation happen before provider/tool/audit work; one `LLMLoopReasoner` and one `AgentRuntime` run are used; runtime limits are passed unchanged; no collaborator is closed.
+
+- [ ] **Step 2: Run composition tests and verify RED**
+
+  Run: `.venv/bin/pytest tests/developer/test_agent.py -q`
+
+- [ ] **Step 3: Implement minimal composition service**
+
+  Validate, select/compile skills, create the evidence wrapper, compose the strict reasoner prompt, invoke one runtime run, and derive one deterministic result. Do not add retries, hidden tool calls, persistence, or cleanup of injected collaborators.
+
+- [ ] **Step 4: Write failing propagation tests**
+
+  Cover permission denial, approval escalation, invalid model output, token/tool/iteration/failure limits, timeout, stagnation, cancellation, and audit failure through the public DeveloperAgent boundary.
+
+- [ ] **Step 5: Run propagation tests and verify RED**
+
+  Run: `.venv/bin/pytest tests/developer/test_agent.py -q`
+
+- [ ] **Step 6: Complete terminal mapping without intercepting cancellation**
+
+  Preserve Phase 13 terminal results and immediate `CancelledError` propagation. Sanitize only Phase 14 validation/compilation failures.
+
+- [ ] **Step 7: Run focused tests and quality checks**
+
+  Run: `.venv/bin/pytest tests/developer/test_agent.py -q`
+
+  Run: `.venv/bin/ruff check core/developer tests/developer`
+
+  Run: `.venv/bin/mypy core/developer tests/developer`
+
+- [ ] **Step 8: Commit**
+
+  Commit: `feat(developer): compose bounded agent runtime`
+
+### Task 5: Real-tool deterministic repository integration
+
+**Files:**
+- Create: `tests/developer/test_integration.py`
+- Create: `tests/developer/test_safety.py`
+- Modify: `tests/developer/factories.py`
+
+**Interfaces:**
+- Consumes: concrete `DeveloperAgent`, `FakeLLMProvider`, real `ToolExecutor`, real filesystem/write/Git/command tools, fixed `pytest` command profile, managed temporary repository.
+- Produces: end-to-end evidence that Phase 14 satisfies the deterministic buggy-repository acceptance scenario.
+
+- [ ] **Step 1: Write and run the failing simple-bug integration test**
+
+  Fixture contains a tiny Python function with a wrong result and a real pytest test. Script complete structured provider outputs to inspect, patch once, run fixed pytest, verify, and complete. Assert the file changed, pytest passed, report succeeded, and provider/tool/command call counts contain no duplicates.
+
+  Run: `.venv/bin/pytest tests/developer/test_integration.py::test_developer_fixes_and_verifies_bug -q`
+
+- [ ] **Step 2: Make the smallest integration adjustments and verify GREEN**
+
+  Adjust only production boundary behavior exposed by the real adapters; do not weaken adapters or replace them with mocks.
+
+- [ ] **Step 3: Write and run the failing correction-loop integration test**
+
+  Script an initial wrong patch, failed fixed pytest result, a corrective patch, and a successful rerun. Assert latest evidence wins and the first failure remains observable through bounded history/metadata.
+
+- [ ] **Step 4: Make the correction loop pass**
+
+  Preserve exactly-once calls and bounded history while allowing the existing runtime to continue after deterministic failure.
+
+- [ ] **Step 5: Add adversarial safety scenarios**
+
+  Prove completion without checks is blocked, failed checks beat LLM completion, undeclared/forbidden tools never execute, prompts/skill text/patches/output/secrets are absent from results and audit metadata, and cancellation leaves collaborators open.
+
+- [ ] **Step 6: Run all Phase 14 tests and mutation-check assertions**
+
+  Run: `.venv/bin/pytest tests/developer -q`
+
+  Mentally mutate each authorization, count, byte limit, latest-check branch, and exactly-once delegation; ensure at least one named test fails for each mutation.
+
+- [ ] **Step 7: Commit**
+
+  Commit: `test(developer): verify real repository workflow`
+
+### Task 6: Documentation and Phase 14 checklist
+
+**Files:**
+- Create: `docs/developer-agent.md`
+- Modify: `README.md`
+- Modify: `AGENTS.md`
+- Modify: `SYNAPSEOS_DEVELOPMENT_CHECKLIST.md`
+
+**Interfaces:**
+- Consumes: verified implementation behavior and commands.
+- Produces: operator/developer documentation and truthful Phase 14 completion state.
+
+- [ ] **Step 1: Document the implemented boundary**
+
+  Explain composition, closed tools, skills as subordinate context, fixed check profiles, deterministic evidence/reporting, limits, cancellation, audit, injected resource ownership, security limitations, and an English usage example.
+
+- [ ] **Step 2: Update repository summaries**
+
+  Add Phase 14 architecture and test commands to README/AGENTS without claiming ReviewerAgent, multi-agent workflow, hostile-code sandboxing, or Phase 15 support.
+
+- [ ] **Step 3: Update only genuinely complete Phase 14 checkboxes**
+
+  Leave Phase 12 and Phase 15+ unchanged. Do not check any item lacking an implementation test and full verification evidence.
+
+- [ ] **Step 4: Run documentation-adjacent quality checks**
+
+  Run: `.venv/bin/ruff format --check .`
+
+  Run: `.venv/bin/ruff check .`
+
+  Run: `.venv/bin/mypy .`
+
+- [ ] **Step 5: Commit**
+
+  Commit: `docs(developer): document Phase 14 safeguards`
+
+### Task 7: Full verification, independent review, and delivery
+
+**Files:**
+- Modify only files required to fix verified Phase 14 defects.
+
+**Interfaces:**
+- Consumes: complete Phase 14 branch.
+- Produces: fresh local/Docker evidence, review resolution, pushed branch, and a stacked pull request.
+
+- [ ] **Step 1: Run the complete local gate from a clean process**
+
+  Run: `.venv/bin/pytest -q`
+
+  Run: `.venv/bin/ruff check .`
+
+  Run: `.venv/bin/ruff format --check .`
+
+  Run: `.venv/bin/mypy .`
+
+- [ ] **Step 2: Verify real PostgreSQL and Docker acceptance**
+
+  Build/start the Compose stack, wait for PostgreSQL and API health, run Alembic to head, run the PostgreSQL-backed suite, call `/health`, and stop the stack without deleting user data.
+
+- [ ] **Step 3: Request independent code and security review**
+
+  Review the complete branch against the Phase 14 spec, focusing on duplicate calls, permission bypass, prompt/output retention, path disclosure, cancellation, unbounded collections, resource ownership, and accidental Phase 15 scope.
+
+- [ ] **Step 4: Resolve findings with RED-GREEN cycles**
+
+  Reproduce each valid defect with a failing test before changing production code, rerun focused and full gates, and commit conventional fixes. Reject unsupported feedback with concrete evidence.
+
+- [ ] **Step 5: Verify scope and worktree cleanliness**
+
+  Confirm Phase 12 and Phase 15 remain untouched, no forbidden capability exists, no secret is staged, and `CLAUDE.local.md` remains untracked/unmodified.
+
+- [ ] **Step 6: Push and open the stacked pull request**
+
+  Push `phase-14/developer-agent`, open a PR against `phase-13/loop-engineering-v1`, and include scope, safeguards, tests, Docker/PostgreSQL evidence, decisions, known limitations, and explicit Phase 15 exclusion.
+

--- a/docs/superpowers/specs/2026-08-28-phase-13-loop-engineering-v1-design.md
+++ b/docs/superpowers/specs/2026-08-28-phase-13-loop-engineering-v1-design.md
@@ -123,9 +123,10 @@ The entire run executes under one monotonic `asyncio.timeout`. Existing provider
 remain narrower inner boundaries.
 
 On global timeout, the runtime records one terminal `TIMED_OUT` audit step and returns a bounded
-`TIMED_OUT` result. On `asyncio.CancelledError`, it records `CANCELLED` using cancellation-resistant
-audit cleanup and immediately re-raises cancellation. It never converts cancellation into a
-normal failure and never closes injected providers, executors, sessions, or network clients.
+`TIMED_OUT` result. On `asyncio.CancelledError`, it stages `CANCELLED` through a dedicated
+prevalidated recorder method that performs no query, flush, network I/O, or thread handoff, then
+immediately re-raises cancellation. It never converts cancellation into a normal failure and never
+closes injected providers, executors, sessions, or network clients.
 
 ## Audit model
 

--- a/docs/superpowers/specs/2026-08-28-phase-13-loop-engineering-v1-design.md
+++ b/docs/superpowers/specs/2026-08-28-phase-13-loop-engineering-v1-design.md
@@ -1,0 +1,190 @@
+# Phase 13 Loop Engineering V1 Design
+
+**Date:** 2026-08-28
+**Status:** Approved
+**Scope:** One bounded autonomous agent runtime only
+
+## Goal
+
+Build the first controlled autonomous loop in SynapseOS. One agent observes a task, plans,
+chooses one structured action, executes an already-registered tool through the existing secured
+tool boundary, verifies the result, and either continues, completes, or escalates.
+
+Phase 13 does not implement Phase 12 stack detection, multi-agent coordination, a Developer role,
+free-form shell execution, a reputation engine, memory retrieval, or a scheduler.
+
+## Architectural boundaries
+
+`AgentRuntime` belongs in `core/runtime/`. It coordinates existing provider-neutral contracts and
+must not depend on SQLAlchemy, FastAPI, Ollama, operating-system processes, or concrete tools.
+
+The runtime consumes:
+
+- an `LLMProvider` through a structured `LoopReasoner`;
+- the existing `ToolExecutor` as the only tool execution path;
+- a persistence-neutral `RuntimeAuditRecorder`;
+- an immutable `ToolExecutionContext` that fixes agent, run, project, task, correlation, declared
+  tools, and workspace scope.
+
+The runtime never bypasses the registry, permission engine, human-approval decision, tool timeout,
+or tool audit lifecycle already enforced by `ToolExecutor`.
+
+## Loop state machine
+
+One run follows this non-recursive state machine:
+
+```text
+START
+  -> OBSERVE
+  -> PLAN
+  -> DECIDE
+       -> COMPLETE -> REPORT -> COMPLETED
+       -> ESCALATE -> REPORT -> ESCALATED
+       -> TOOL_CALL -> ACT -> OBSERVE_RESULT -> VERIFY
+            -> complete -> REPORT -> COMPLETED
+            -> continue -> next bounded iteration
+            -> escalate -> REPORT -> ESCALATED
+```
+
+The runtime checks the global deadline and every budget before beginning another external call.
+There is no implicit retry. A second tool call happens only after a new valid LLM decision in a
+new iteration.
+
+## Structured LLM protocol
+
+The concrete `LLMLoopReasoner` sends bounded provider-neutral `LLMRequest` values and decodes each
+response with the existing strict structured-output decoder. It exposes five operations:
+
+- `observe(task, bounded_history) -> RuntimeObservation`
+- `plan(task, observation, bounded_history) -> RuntimePlan`
+- `decide(task, observation, plan, bounded_history) -> RuntimeDecision`
+- `verify(task, decision, tool_result, bounded_history) -> RuntimeVerification`
+- `report(task, terminal_state, bounded_history) -> RuntimeReport`
+
+Every response is one exact JSON object. Unknown fields, invalid enums, blank text, non-finite
+numbers, oversized collections, malformed JSON, and unbounded tool arguments fail closed.
+
+`RuntimeDecision.action` is one of `TOOL_CALL`, `COMPLETE`, or `ESCALATE`. A tool call contains
+only a registered tool name and a bounded JSON object. The LLM cannot provide an executable,
+working directory, environment, timeout override, permission override, or retry instruction.
+
+The reasoner performs at most one provider call per operation and never retries, falls back, or
+owns the injected provider lifecycle.
+
+## Immutable contracts
+
+`RuntimeLimits` contains:
+
+- `max_iterations`: 1 through 100;
+- `timeout_seconds`: finite, greater than zero, at most 3,600;
+- `max_tool_calls`: 0 through 1,000;
+- `max_failures`: 0 through 100;
+- `max_tokens`: 1 through 10,000,000 cumulative reported tokens;
+- `max_history_entries`: 1 through 1,000;
+- `stagnation_window`: 2 through 20;
+- `max_step_tokens`: 1 through 131,072 per LLM request.
+
+`RuntimeTask` contains a bounded task identifier, objective, acceptance criteria, and no secrets.
+The immutable terminal `RuntimeResult` contains only status, safe summary, counters, token usage,
+elapsed duration, iteration count, terminal reason, and bounded safe step metadata.
+
+Terminal statuses are `COMPLETED`, `ESCALATED`, `LIMIT_REACHED`, `TIMED_OUT`, and `FAILED`.
+
+## Budget semantics
+
+- An iteration starts at `OBSERVE` and ends after `VERIFY`, `COMPLETE`, or `ESCALATE`.
+- `max_iterations` counts started iterations.
+- `max_tool_calls` counts calls handed to `ToolExecutor`, including denied and failed calls.
+- `max_failures` counts malformed LLM responses and non-successful tool results. Permission denial
+  and approval-required outcomes escalate immediately instead of consuming retries.
+- Token accounting uses provider-reported `total_tokens`, or the safe sum of reported prompt and
+  completion tokens when total is absent. Missing usage counts as zero and is marked unavailable;
+  it is never estimated or invented.
+- A known token total that would exceed the cumulative budget terminates before another external
+  call.
+- Cost is recorded only when a future injected authoritative cost source provides it. Phase 13
+  does not estimate prices.
+
+## Stagnation detection
+
+After each decision and verification, the runtime computes a deterministic SHA-256 fingerprint of
+an allowlisted canonical structure: action type, tool name, normalized argument shape, terminal
+verification outcome, and stable tool error code. It never hashes prompts, raw LLM responses,
+file content, stdout, or stderr.
+
+If the same fingerprint fills `stagnation_window` consecutive progress observations, the runtime
+returns `ESCALATED` with reason `STAGNATION_DETECTED`. This requires no extra LLM call.
+
+## Timeout and cancellation
+
+The entire run executes under one monotonic `asyncio.timeout`. Existing provider and tool timeouts
+remain narrower inner boundaries.
+
+On global timeout, the runtime records one terminal `TIMED_OUT` audit step and returns a bounded
+`TIMED_OUT` result. On `asyncio.CancelledError`, it records `CANCELLED` using cancellation-resistant
+audit cleanup and immediately re-raises cancellation. It never converts cancellation into a
+normal failure and never closes injected providers, executors, sessions, or network clients.
+
+## Audit model
+
+Every started and terminal runtime step is sent to `RuntimeAuditRecorder` with allowlisted metadata:
+
+- agent, run, project, task, and correlation identifiers;
+- iteration and step;
+- outcome and stable reason/error code;
+- duration, tool-call count, failure count, and reported token count;
+- action category and tool name when applicable.
+
+Audit metadata excludes prompts, LLM responses, reasoning, tool arguments, tool output, filesystem
+paths, environment values, provider errors, secrets, and task content.
+
+Phase 13 adds a PostgreSQL adapter that appends `AuditEvent` records through the existing
+append-only repository. The adapter never commits, rolls back, or closes the injected session.
+An audit-start failure prevents the corresponding step. A terminal audit failure returns or raises
+a sanitized runtime audit error rather than silently losing traceability.
+
+## Error handling
+
+All public failures use stable non-sensitive `RuntimeErrorCode` values. Provider exceptions,
+validation details, raw responses, tool content, paths, and database messages are discarded before
+crossing the runtime boundary.
+
+Malformed LLM output increments the failure counter. If the remaining failure budget permits, the
+next iteration begins from a safe metadata-only history entry; otherwise the run ends as `FAILED`.
+There is no automatic repair prompt in V1.
+
+Tool results are interpreted deterministically:
+
+- `SUCCEEDED`: pass the bounded result to verification;
+- `DENIED` with permission missing: terminal escalation;
+- `DENIED` with approval required: terminal human escalation;
+- `FAILED` or `TIMED_OUT`: increment failures, then verify only if budget remains;
+- cancellation: propagate immediately.
+
+## Testing strategy
+
+Tests use the concrete `LLMLoopReasoner` with `FakeLLMProvider`, real strict response decoding, a
+real `ToolExecutor` with deterministic fake tools and permission/audit collaborators, and a fake
+runtime audit recorder. PostgreSQL integration tests use the real migrated database and append-only
+audit repository.
+
+Required scenarios:
+
+1. completion on the first decision;
+2. tool failure followed by a new corrective decision and success;
+3. maximum iteration termination;
+4. permission denial and approval-required escalation;
+5. malformed LLM response with bounded failure behavior;
+6. global timeout;
+7. normal completion after tool verification;
+8. stagnation escalation;
+9. tool-call, failure, history, and token budget enforcement;
+10. cancellation propagation and terminal audit;
+11. no sensitive prompts, responses, arguments, or outputs in retained history or audit;
+12. no duplicate provider or tool calls and no collaborator lifecycle ownership.
+
+## Documentation and checklist
+
+Add operator and developer documentation for the loop contract, budgets, audit content, terminal
+states, and deliberate exclusions. Update only Phase 13 checkboxes after their corresponding tests
+and implementation are complete. Leave every Phase 12 and Phase 14 checkbox unchanged.

--- a/docs/superpowers/specs/2026-08-28-phase-13-loop-engineering-v1-design.md
+++ b/docs/superpowers/specs/2026-08-28-phase-13-loop-engineering-v1-design.md
@@ -53,13 +53,15 @@ new iteration.
 ## Structured LLM protocol
 
 The concrete `LLMLoopReasoner` sends bounded provider-neutral `LLMRequest` values and decodes each
-response with the existing strict structured-output decoder. It exposes five operations:
+response with the existing strict structured-output decoder. Every operation returns an immutable
+`ReasonerOutput[T]` containing the typed value, reported token count, and usage-availability flag.
+It exposes five operations:
 
-- `observe(task, bounded_history) -> RuntimeObservation`
-- `plan(task, observation, bounded_history) -> RuntimePlan`
-- `decide(task, observation, plan, bounded_history) -> RuntimeDecision`
-- `verify(task, decision, tool_result, bounded_history) -> RuntimeVerification`
-- `report(task, terminal_state, bounded_history) -> RuntimeReport`
+- `observe(task, bounded_history) -> ReasonerOutput[RuntimeObservation]`
+- `plan(task, observation, bounded_history) -> ReasonerOutput[RuntimePlan]`
+- `decide(task, observation, plan, bounded_history) -> ReasonerOutput[RuntimeDecision]`
+- `verify(task, decision, tool_result, bounded_history) -> ReasonerOutput[RuntimeVerification]`
+- `report(task, terminal_state, bounded_history) -> ReasonerOutput[RuntimeReport]`
 
 Every response is one exact JSON object. Unknown fields, invalid enums, blank text, non-finite
 numbers, oversized collections, malformed JSON, and unbounded tool arguments fail closed.

--- a/docs/superpowers/specs/2026-08-28-phase-14-developer-agent-design.md
+++ b/docs/superpowers/specs/2026-08-28-phase-14-developer-agent-design.md
@@ -1,0 +1,178 @@
+# Phase 14 Developer Agent Design
+
+## Scope
+
+Phase 14 introduces one `DeveloperAgent` role that composes the completed Phase 13
+`AgentRuntime`. It can understand one task, select relevant repository-owned skills, inspect one
+managed workspace, modify code through existing transactional tools, execute existing fixed command
+profiles, react to deterministic failures in later bounded iterations, and return a structured
+developer result.
+
+This phase does not add a second loop engine, a free-form shell, arbitrary command arguments,
+permission mutation, branch merge, deployment, self-review, ReviewerAgent, multi-agent workflow,
+MCP, memory, reputation, or Phase 15 behavior. Phase 12 remains deliberately unimplemented.
+
+## Architectural choice
+
+`DeveloperAgent` is a role-specific composition service in `core/developer/`; it is not a subclass
+of `AgentRuntime` and does not duplicate its state machine. The service constructs a strict
+`LLMLoopReasoner`, wraps the existing `ToolExecutor` with a metadata-only evidence collector, and
+delegates exactly one run to `AgentRuntime`.
+
+This is preferred over either a separate developer loop or direct access to workspace and command
+adapters. One loop preserves Phase 13 budgets, cancellation, stagnation, and audit semantics. One
+tool boundary preserves Phase 6–11 registry, permission, transaction, timeout, and output controls.
+
+## Inputs
+
+`DeveloperRequest` is strict, immutable, and bounded. It contains:
+
+- a `RuntimeTask`;
+- an `AgentProfile` whose role is `Developer`;
+- the exact `ToolExecutionContext` for the managed workspace;
+- declared domains, technologies, and tags used for deterministic skill selection;
+- one through four required command profiles from the existing test/lint/build set.
+
+The request is rejected before any LLM, tool, audit, or filesystem action when:
+
+- task, profile, and execution identifiers are inconsistent;
+- the profile is not an active Developer role;
+- a declared tool is outside the closed Phase 14 developer tool set;
+- required read, write, or command capabilities are absent;
+- a required check is a Git profile or unknown profile;
+- canonical profile permissions cannot be resolved.
+
+The closed developer tool set is `read_file`, `list_files`, `search_literal`, `git_status`,
+`git_diff`, `write_file`, `create_file`, `patch_file`, `delete_file`, and
+`run_command_profile`. This allowlist grants no authority: every tool must also be registered,
+declared in `ToolExecutionContext`, and authorized by the existing persisted permission engine.
+
+## Skill selection and prompt boundary
+
+`DeveloperAgent` calls the existing deterministic `SkillSelector` once. Eligibility requires all of
+the following:
+
+1. the skill ID is declared by `AgentProfile.skill_ids`;
+2. the skill exists in the injected immutable `SkillRegistry`;
+3. its required permissions are present in the canonical profile declaration;
+4. the selector produces a positive domain, technology, tag, task, or role match;
+5. its recommended tools are a subset of the developer's declared tool IDs.
+
+At most eight skills are selected. Their complete validated instructions may be compiled into a
+maximum 12 KiB UTF-8 context. Instructions are never truncated: a skill that cannot fit is omitted
+and reported by stable ID. Ordering follows the deterministic selector. The final system prompt
+must remain within the existing 16 KiB `LLMLoopReasoner` ceiling.
+
+Skill instructions are explicitly subordinate to the Company Constitution, the Developer role,
+the task, and the permission/tool boundaries. They are data, cannot grant permissions, cannot add
+tools or command controls, and are never executed directly. Prompts and skill contents are not
+persisted in runtime history, reports, audit events, or errors.
+
+## Execution flow
+
+```text
+DeveloperRequest
+  -> validate role, scope, permissions, tools, and required checks
+  -> select eligible declared skills once
+  -> compile bounded subordinate skill context
+  -> LLMLoopReasoner
+  -> AgentRuntime
+       OBSERVE -> PLAN -> DECIDE
+       -> ToolExecutor -> read/write/fixed command profile
+       -> VERIFY -> next bounded iteration or terminal state
+  -> deterministic evidence gate
+  -> DeveloperResult + AgentReport
+```
+
+The LLM chooses only existing structured `RuntimeAction` values. A tool call is handed to the
+wrapped `ToolExecutor` exactly once. The wrapper observes the returned immutable `ToolResult`; it
+does not retry, mutate arguments, bypass permission evaluation, or close the executor.
+
+Tests are run only through `run_command_profile`. Phase 14 introduces no `TestRunner` duplicate:
+the fixed Phase 11 command profile policy and runner are the V1 test runner required by the
+roadmap. The model supplies only a closed `profile_id`; executable, arguments, cwd, environment,
+timeout, and output limits remain application-owned.
+
+## Evidence and result
+
+The wrapper retains at most 128 successful metadata-only evidence records:
+
+- successful write tool name and validated relative path;
+- command profile ID, category, exit code, terminal status, and truncation flag;
+- stable failed/denied tool name and error code.
+
+It never retains file content, patches, command stdout/stderr, prompts, responses, rationale,
+absolute workspace paths, environment values, provider errors, or database errors.
+
+`DeveloperResult` contains:
+
+- the bounded `RuntimeResult`;
+- one existing `AgentReport`;
+- selected and omitted skill IDs;
+- unique changed relative paths in first-observed order;
+- bounded `DeveloperCheckResult` values for observed command profiles.
+
+The final `AgentReport` is deterministic and does not require another LLM call. Its outcome is:
+
+- `SUCCEEDED` only when the runtime completed and every required check was observed at least once
+  with a latest successful result;
+- `NEEDS_HUMAN` for human approval or permission escalation;
+- `BLOCKED` for loop limits, timeout, stagnation, or missing required check evidence;
+- `FAILED` for runtime/audit failures or any latest required check failure.
+
+An LLM completion claim cannot override deterministic command evidence. A failed required check is
+never hidden. The report does not approve or merge the developer's work.
+
+## Security and resource invariants
+
+- All resource limits remain mandatory and originate in `RuntimeLimits` plus existing tool and
+  command limits.
+- One model decision causes at most one tool call; there are no implicit retries or duplicate
+  calls.
+- Cancellation propagates through `AgentRuntime`; no injected provider, executor, registry,
+  session, or client is closed.
+- Skill context, evidence, and result collections are bounded before work starts.
+- Every action still receives permission evaluation and append-only tool/runtime audit.
+- `git-status` and `git-diff` remain read-only profiles; merge, commit, push, checkout, reset, and
+  deployment are unavailable.
+- Required test/build profiles execute repository code and therefore retain the Phase 11 warning:
+  this application boundary is not a hostile-code sandbox.
+
+## Error handling
+
+All public Phase 14 failures use stable `DeveloperErrorCode` values and sanitized messages.
+Validation and skill compilation fail before external work. Runtime terminal states are returned,
+not reinterpreted by an LLM. Tool and command failures remain deterministic observations. Audit
+failure fails closed. Raw exceptions and rejected content are discarded before crossing the role
+boundary.
+
+## TDD and acceptance scenarios
+
+Tests must observe RED before production implementation and cover:
+
+1. immutable bounded request, evidence, check, and result contracts;
+2. rejection of wrong role, inconsistent scope, undeclared/forbidden tools, and Git checks;
+3. deterministic skill selection restricted by profile, permissions, tools, count, and byte budget;
+4. no skill instruction, prompt, content, patch, stdout/stderr, or absolute path in retained result,
+   evidence, audit metadata, or errors;
+5. one complete run through concrete `LLMLoopReasoner(FakeLLMProvider)`, `AgentRuntime`, real
+   `ToolExecutor`, real read/write/command adapters, and a small managed repository fixture;
+6. a simple bug is inspected, patched once, tested through the fixed `pytest` profile, and reported
+   successful with no duplicate provider/tool/command calls;
+7. failed test followed by a bounded corrective iteration and later success;
+8. completion without required checks is blocked;
+9. failed latest required check is reported failed even if the LLM claims completion;
+10. permission denial/approval escalation, timeout, token/tool/iteration/failure limits,
+    stagnation, cancellation, and audit failure preserve Phase 13 behavior;
+11. injected collaborators are never closed;
+12. Phase 12 and Phase 15 remain absent.
+
+PostgreSQL tests use the real Docker database migrated through Alembic. No `metadata.create_all()`
+is permitted. Full acceptance requires pytest, Ruff, mypy strict, format check, Docker API build,
+Alembic head, health check, and independent review.
+
+## Documentation and checklist
+
+Add `docs/developer-agent.md`, update `README.md` and `AGENTS.md`, and check only genuinely verified
+Phase 14 boxes in `SYNAPSEOS_DEVELOPMENT_CHECKLIST.md`. Phase 12 and every Phase 15+ checkbox remain
+unchanged.

--- a/docs/superpowers/specs/2026-08-28-phase-14-developer-agent-design.md
+++ b/docs/superpowers/specs/2026-08-28-phase-14-developer-agent-design.md
@@ -42,7 +42,7 @@ The request is rejected before any LLM, tool, audit, or filesystem action when:
 - a required check is a Git profile or unknown profile;
 - canonical profile permissions cannot be resolved.
 
-The closed developer tool set is `read_file`, `list_files`, `search_literal`, `git_status`,
+The closed developer tool set is `read_file`, `list_files`, `search_text`, `git_status`,
 `git_diff`, `write_file`, `create_file`, `patch_file`, `delete_file`, and
 `run_command_profile`. This allowlist grants no authority: every tool must also be registered,
 declared in `ToolExecutionContext`, and authorized by the existing persisted permission engine.

--- a/infrastructure/runtime/__init__.py
+++ b/infrastructure/runtime/__init__.py
@@ -1,0 +1,5 @@
+"""Runtime infrastructure adapters."""
+
+from infrastructure.runtime.audit import SQLAlchemyRuntimeAuditRecorder
+
+__all__ = ["SQLAlchemyRuntimeAuditRecorder"]

--- a/infrastructure/runtime/audit.py
+++ b/infrastructure/runtime/audit.py
@@ -17,12 +17,14 @@ class SQLAlchemyRuntimeAuditRecorder:
 
     def __init__(self, session: Session) -> None:
         self._session = session
+        self._validated_scopes: set[tuple[str, object, object, object]] = set()
 
     def record(self, record: RuntimeAuditRecord) -> None:
         """Validate scope and append exactly one allowlisted audit event."""
         validated = self._validate(record)
         if not self._scope_exists(validated):
             raise self._unavailable()
+        self._validated_scopes.add(self._scope_key(validated))
 
         data: dict[str, object] = {
             "iteration": validated.iteration,
@@ -61,6 +63,48 @@ class SQLAlchemyRuntimeAuditRecorder:
             error.__traceback__ = None
             del error
             raise self._unavailable() from None
+
+    def record_cancellation(self, record: RuntimeAuditRecord) -> None:
+        """Stage cancellation after prior scope validation, without database I/O."""
+        validated = self._validate(record)
+        if (
+            validated.outcome is not RuntimeAuditOutcome.CANCELLED
+            or self._scope_key(validated) not in self._validated_scopes
+        ):
+            raise self._unavailable()
+        event = AuditEvent(
+            actor_type=AuditActorType.AGENT,
+            actor_id=validated.agent_id,
+            project_id=validated.project_id,
+            task_id=validated.task_id,
+            agent_run_id=validated.agent_run_id,
+            event_type="AGENT_RUNTIME_STEP",
+            action="execute_agent_loop",
+            resource_type="AGENT_RUNTIME",
+            resource_id=validated.step.value,
+            result=AuditResult.CANCELLED,
+            data={
+                "iteration": validated.iteration,
+                "step": validated.step.value,
+                "outcome": validated.outcome.value,
+                "duration_ms": validated.duration_ms,
+                "tool_calls": validated.tool_calls,
+                "failures": validated.failures,
+                "reported_tokens": validated.reported_tokens,
+                "reason": validated.reason.value if validated.reason is not None else None,
+            },
+            correlation_id=validated.correlation_id,
+        )
+        try:
+            self._session.add(event)
+        except Exception as error:
+            error.__traceback__ = None
+            del error
+            raise self._unavailable() from None
+
+    @staticmethod
+    def _scope_key(record: RuntimeAuditRecord) -> tuple[str, object, object, object]:
+        return (record.agent_id, record.agent_run_id, record.project_id, record.task_id)
 
     def _scope_exists(self, record: RuntimeAuditRecord) -> bool:
         statement = (

--- a/infrastructure/runtime/audit.py
+++ b/infrastructure/runtime/audit.py
@@ -1,0 +1,110 @@
+"""SQLAlchemy-backed sanitized audit records for bounded agent loops."""
+
+from __future__ import annotations
+
+from pydantic import ValidationError
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from core.enums import AuditActorType, AuditResult
+from core.runtime.audit import RuntimeAuditOutcome, RuntimeAuditRecord
+from core.runtime.errors import RuntimeError, RuntimeErrorCode
+from infrastructure.database.models import Agent, AgentRun, AuditEvent, Task
+
+
+class SQLAlchemyRuntimeAuditRecorder:
+    """Append runtime metadata without owning the caller's transaction."""
+
+    def __init__(self, session: Session) -> None:
+        self._session = session
+
+    def record(self, record: RuntimeAuditRecord) -> None:
+        """Validate scope and append exactly one allowlisted audit event."""
+        validated = self._validate(record)
+        if not self._scope_exists(validated):
+            raise self._unavailable()
+
+        data: dict[str, object] = {
+            "iteration": validated.iteration,
+            "step": validated.step.value,
+            "outcome": validated.outcome.value,
+            "duration_ms": validated.duration_ms,
+            "tool_calls": validated.tool_calls,
+            "failures": validated.failures,
+            "reported_tokens": validated.reported_tokens,
+        }
+        for name in ("reason", "action", "error_code"):
+            value = getattr(validated, name)
+            if value is not None:
+                data[name] = value.value
+        if validated.tool_name is not None:
+            data["tool_name"] = validated.tool_name
+
+        event = AuditEvent(
+            actor_type=AuditActorType.AGENT,
+            actor_id=validated.agent_id,
+            project_id=validated.project_id,
+            task_id=validated.task_id,
+            agent_run_id=validated.agent_run_id,
+            event_type="AGENT_RUNTIME_STEP",
+            action="execute_agent_loop",
+            resource_type="AGENT_RUNTIME",
+            resource_id=validated.step.value,
+            result=_audit_result(validated.outcome),
+            data=data,
+            correlation_id=validated.correlation_id,
+        )
+        try:
+            self._session.add(event)
+            self._session.flush()
+        except Exception as error:
+            error.__traceback__ = None
+            del error
+            raise self._unavailable() from None
+
+    def _scope_exists(self, record: RuntimeAuditRecord) -> bool:
+        statement = (
+            select(AgentRun.id)
+            .join(Agent, Agent.id == AgentRun.agent_id)
+            .join(Task, Task.id == AgentRun.task_id)
+            .where(
+                AgentRun.id == record.agent_run_id,
+                Agent.slug == record.agent_id,
+                AgentRun.task_id == record.task_id,
+                Task.project_id == record.project_id,
+            )
+        )
+        try:
+            return self._session.scalar(statement) is not None
+        except Exception as error:
+            error.__traceback__ = None
+            del error
+            raise self._unavailable() from None
+
+    @staticmethod
+    def _validate(record: RuntimeAuditRecord) -> RuntimeAuditRecord:
+        if type(record) is not RuntimeAuditRecord:
+            raise SQLAlchemyRuntimeAuditRecorder._unavailable()
+        try:
+            return RuntimeAuditRecord.model_validate(record.__dict__, strict=True)
+        except (AttributeError, TypeError, ValueError, ValidationError) as error:
+            error.__traceback__ = None
+            del error
+            raise SQLAlchemyRuntimeAuditRecorder._unavailable() from None
+
+    @staticmethod
+    def _unavailable() -> RuntimeError:
+        return RuntimeError(RuntimeErrorCode.AUDIT_FAILED, "Runtime audit is unavailable.")
+
+
+def _audit_result(outcome: RuntimeAuditOutcome) -> AuditResult:
+    if outcome is RuntimeAuditOutcome.CANCELLED:
+        return AuditResult.CANCELLED
+    if outcome is RuntimeAuditOutcome.DENIED:
+        return AuditResult.DENIED
+    if outcome in {
+        RuntimeAuditOutcome.FAILED,
+        RuntimeAuditOutcome.TIMED_OUT,
+    }:
+        return AuditResult.FAILED
+    return AuditResult.SUCCEEDED

--- a/infrastructure/tools/command.py
+++ b/infrastructure/tools/command.py
@@ -46,7 +46,7 @@ class RunCommandProfileTool(Tool[RunCommandProfileInput]):
     name = "run_command_profile"
     description = "Run one bounded built-in command profile in the managed project workspace."
     input_type = RunCommandProfileInput
-    required_permissions = frozenset({Permission.SHELL_EXECUTE})
+    required_permissions = frozenset({Permission.SHELL_EXECUTE, Permission.TESTS_EXECUTE})
     risk_level = ToolRiskLevel.HIGH
     timeout_seconds = 30.0
 

--- a/infrastructure/tools/write.py
+++ b/infrastructure/tools/write.py
@@ -48,6 +48,14 @@ class PatchOperation(BaseModel):
 class PatchFileInput(_StrictWriteInput):
     operations: Annotated[tuple[PatchOperation, ...], Field(min_length=1, max_length=1_024)]
 
+    @field_validator("operations", mode="before")
+    @classmethod
+    def copy_json_operations(cls, value: object) -> object:
+        """Copy the JSON array emitted by structured model tool calls."""
+        if isinstance(value, (list, tuple)):
+            return tuple(value)
+        return value
+
 
 class _WriteToolBase[InputT: BaseModel](Tool[InputT]):
     required_permissions = frozenset({Permission.FILESYSTEM_WRITE})

--- a/tests/database/test_command_tool_execution.py
+++ b/tests/database/test_command_tool_execution.py
@@ -97,13 +97,14 @@ def _executor(
     )
 
 
-def test_persisted_shell_grant_runs_profile_and_keeps_raw_output_out_of_audit(
+def test_persisted_shell_and_test_grants_run_profile_and_keep_raw_output_out_of_audit(
     db_session: Session,
     tmp_path: Path,
 ) -> None:
     marker = "secret-command-output-marker-84f1"
     scope = create_permission_scope(db_session, autonomy_level=3)
     add_permission(db_session, scope, Permission.SHELL_EXECUTE, project=scope.project)
+    add_permission(db_session, scope, Permission.TESTS_EXECUTE, project=scope.project)
     tool, root = _command_tool(tmp_path, scope)
     (root / "test_failure.py").write_text(
         f"def test_failure():\n    assert False, {marker!r}\n",
@@ -150,6 +151,7 @@ def test_shell_permission_requires_autonomy_three_before_process_execution(
 ) -> None:
     scope = create_permission_scope(db_session, autonomy_level=2)
     add_permission(db_session, scope, Permission.SHELL_EXECUTE, project=scope.project)
+    add_permission(db_session, scope, Permission.TESTS_EXECUTE, project=scope.project)
     tool, root = _command_tool(tmp_path, scope)
     side_effect = root / "must-not-be-created"
     (root / "conftest.py").write_text(
@@ -180,6 +182,7 @@ def test_missing_or_cross_project_shell_grant_never_executes(
 ) -> None:
     scope = create_permission_scope(db_session, autonomy_level=3)
     other_scope = create_permission_scope(db_session, autonomy_level=3)
+    add_permission(db_session, scope, Permission.TESTS_EXECUTE, project=scope.project)
     add_permission(db_session, scope, Permission.SHELL_EXECUTE, project=other_scope.project)
     tool, root = _command_tool(tmp_path, scope)
 
@@ -192,3 +195,28 @@ def test_missing_or_cross_project_shell_grant_never_executes(
     )
 
     assert result.error_code is ToolErrorCode.PERMISSION_DENIED
+
+
+def test_missing_persisted_test_grant_never_executes(
+    db_session: Session,
+    tmp_path: Path,
+) -> None:
+    scope = create_permission_scope(db_session, autonomy_level=3)
+    add_permission(db_session, scope, Permission.SHELL_EXECUTE, project=scope.project)
+    tool, root = _command_tool(tmp_path, scope)
+    side_effect = root / "must-not-be-created"
+    (root / "conftest.py").write_text(
+        f"from pathlib import Path\nPath({str(side_effect)!r}).touch()\n",
+        encoding="utf-8",
+    )
+
+    result = asyncio.run(
+        _executor(db_session, scope, tool).execute(
+            "run_command_profile",
+            {"profile_id": "pytest"},
+            _context(scope, root),
+        )
+    )
+
+    assert result.error_code is ToolErrorCode.PERMISSION_DENIED
+    assert not side_effect.exists()

--- a/tests/database/test_runtime_audit.py
+++ b/tests/database/test_runtime_audit.py
@@ -1,0 +1,104 @@
+"""Real-PostgreSQL tests for append-only runtime-step auditing."""
+
+from __future__ import annotations
+
+import uuid
+from unittest.mock import patch
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from core.enums import AuditActorType, AuditResult
+from core.runtime import (
+    RuntimeAuditOutcome,
+    RuntimeAuditRecord,
+    RuntimeError,
+    RuntimeErrorCode,
+    RuntimeStep,
+)
+from infrastructure.database.models import AuditEvent
+from infrastructure.runtime import SQLAlchemyRuntimeAuditRecorder
+from tests.database.permission_fixtures import PermissionScope, create_permission_scope
+
+
+def _record(scope: PermissionScope, **changes: object) -> RuntimeAuditRecord:
+    values: dict[str, object] = {
+        "agent_id": scope.agent.slug,
+        "agent_run_id": scope.run.id,
+        "project_id": scope.project.id,
+        "task_id": scope.task.id,
+        "correlation_id": uuid.uuid4(),
+        "iteration": 1,
+        "step": RuntimeStep.DECIDE,
+        "outcome": RuntimeAuditOutcome.SUCCEEDED,
+        "duration_ms": 7,
+        "tool_calls": 0,
+        "failures": 0,
+        "reported_tokens": 31,
+    }
+    values.update(changes)
+    return RuntimeAuditRecord.model_validate(values, strict=True)
+
+
+def test_runtime_step_appends_only_allowlisted_data(db_session: Session) -> None:
+    scope = create_permission_scope(db_session)
+    record = _record(scope)
+
+    SQLAlchemyRuntimeAuditRecorder(db_session).record(record)
+
+    event = db_session.scalar(
+        select(AuditEvent).where(AuditEvent.event_type == "AGENT_RUNTIME_STEP")
+    )
+    assert event is not None
+    assert event.actor_type is AuditActorType.AGENT
+    assert event.actor_id == scope.agent.slug
+    assert event.project_id == scope.project.id
+    assert event.task_id == scope.task.id
+    assert event.agent_run_id == scope.run.id
+    assert event.action == "execute_agent_loop"
+    assert event.resource_type == "AGENT_RUNTIME"
+    assert event.resource_id == "DECIDE"
+    assert event.result is AuditResult.SUCCEEDED
+    assert event.data == {
+        "duration_ms": 7,
+        "failures": 0,
+        "iteration": 1,
+        "outcome": "SUCCEEDED",
+        "reported_tokens": 31,
+        "step": "DECIDE",
+        "tool_calls": 0,
+    }
+
+
+def test_runtime_audit_rejects_forged_scope(db_session: Session) -> None:
+    scope = create_permission_scope(db_session)
+    forged = _record(scope, task_id=uuid.uuid4())
+
+    with pytest.raises(RuntimeError) as error:
+        SQLAlchemyRuntimeAuditRecorder(db_session).record(forged)
+    assert error.value.code is RuntimeErrorCode.AUDIT_FAILED
+
+
+def test_runtime_audit_never_owns_session_lifecycle(db_session: Session) -> None:
+    scope = create_permission_scope(db_session)
+    recorder = SQLAlchemyRuntimeAuditRecorder(db_session)
+
+    with (
+        patch.object(db_session, "commit", side_effect=AssertionError("commit called")),
+        patch.object(db_session, "rollback", side_effect=AssertionError("rollback called")),
+        patch.object(db_session, "close", side_effect=AssertionError("close called")),
+    ):
+        recorder.record(_record(scope))
+
+
+def test_runtime_audit_failure_is_sanitized(db_session: Session) -> None:
+    scope = create_permission_scope(db_session)
+    marker = "secret-runtime-audit-marker"
+
+    with (
+        patch.object(db_session, "flush", side_effect=ValueError(marker)),
+        pytest.raises(RuntimeError, match="Runtime audit is unavailable") as error,
+    ):
+        SQLAlchemyRuntimeAuditRecorder(db_session).record(_record(scope))
+    assert marker not in str(error.value)

--- a/tests/database/test_runtime_audit.py
+++ b/tests/database/test_runtime_audit.py
@@ -16,6 +16,7 @@ from core.runtime import (
     RuntimeError,
     RuntimeErrorCode,
     RuntimeStep,
+    RuntimeTerminalReason,
 )
 from infrastructure.database.models import AuditEvent
 from infrastructure.runtime import SQLAlchemyRuntimeAuditRecorder
@@ -102,3 +103,22 @@ def test_runtime_audit_failure_is_sanitized(db_session: Session) -> None:
     ):
         SQLAlchemyRuntimeAuditRecorder(db_session).record(_record(scope))
     assert marker not in str(error.value)
+
+
+def test_cancellation_is_staged_without_database_io(db_session: Session) -> None:
+    scope = create_permission_scope(db_session)
+    recorder = SQLAlchemyRuntimeAuditRecorder(db_session)
+    recorder.record(_record(scope))
+    cancellation = _record(
+        scope,
+        step=RuntimeStep.REPORT,
+        outcome=RuntimeAuditOutcome.CANCELLED,
+        reason=RuntimeTerminalReason.CANCELLED,
+    )
+
+    with patch.object(db_session, "flush", side_effect=AssertionError("flush called")):
+        recorder.record_cancellation(cancellation)
+
+    staged = [event for event in db_session.new if isinstance(event, AuditEvent)]
+    assert len(staged) == 1
+    assert staged[0].result is AuditResult.CANCELLED

--- a/tests/developer/__init__.py
+++ b/tests/developer/__init__.py
@@ -1,0 +1,1 @@
+"""Developer Agent tests."""

--- a/tests/developer/factories.py
+++ b/tests/developer/factories.py
@@ -16,7 +16,7 @@ DEVELOPER_TOOLS = frozenset(
     {
         "read_file",
         "list_files",
-        "search_literal",
+        "search_text",
         "write_file",
         "patch_file",
         "run_command_profile",
@@ -38,6 +38,7 @@ def developer_profile(**overrides: object) -> AgentProfile:
             {
                 Permission.FILESYSTEM_READ.value,
                 Permission.FILESYSTEM_WRITE.value,
+                Permission.SHELL_EXECUTE.value,
                 Permission.TESTS_EXECUTE.value,
             }
         ),

--- a/tests/developer/factories.py
+++ b/tests/developer/factories.py
@@ -1,0 +1,90 @@
+"""Hand-checked Phase 14 fixtures."""
+
+from __future__ import annotations
+
+from decimal import Decimal
+from pathlib import Path
+from uuid import uuid4
+
+from core.agents import AgentProfile
+from core.commands import CommandProfileId
+from core.enums import AgentSeniority, AgentStatus, Permission
+from core.runtime import RuntimeTask
+from core.tools import ToolExecutionContext
+
+DEVELOPER_TOOLS = frozenset(
+    {
+        "read_file",
+        "list_files",
+        "search_literal",
+        "write_file",
+        "patch_file",
+        "run_command_profile",
+    }
+)
+
+
+def developer_profile(**overrides: object) -> AgentProfile:
+    values: dict[str, object] = {
+        "id": "developer-01",
+        "name": "Developer One",
+        "role": "Developer",
+        "department": "engineering",
+        "seniority": AgentSeniority.ENGINEER,
+        "status": AgentStatus.WORKING,
+        "system_prompt": "Implement the assigned task through authorized tools.",
+        "autonomy_level": 2,
+        "permission_ids": frozenset(
+            {
+                Permission.FILESYSTEM_READ.value,
+                Permission.FILESYSTEM_WRITE.value,
+                Permission.TESTS_EXECUTE.value,
+            }
+        ),
+        "tool_ids": DEVELOPER_TOOLS,
+        "skill_ids": frozenset({"python-testing"}),
+        "reputation_score": Decimal("0.80"),
+        "reliability_score": Decimal("0.90"),
+    }
+    values.update(overrides)
+    return AgentProfile.model_validate(values)
+
+
+def runtime_task() -> RuntimeTask:
+    return RuntimeTask(
+        task_id=uuid4(),
+        objective="Correct the faulty addition implementation.",
+        acceptance_criteria=("The existing test suite passes.",),
+    )
+
+
+def execution_context(
+    workspace: Path,
+    *,
+    task: RuntimeTask,
+    profile: AgentProfile,
+    declared_tool_ids: frozenset[str] | None = None,
+) -> ToolExecutionContext:
+    return ToolExecutionContext(
+        workspace_root=workspace,
+        agent_id=profile.id,
+        agent_run_id=uuid4(),
+        project_id=uuid4(),
+        task_id=task.task_id,
+        declared_tool_ids=declared_tool_ids or profile.tool_ids,
+        correlation_id=uuid4(),
+    )
+
+
+def request_values(tmp_path: Path) -> dict[str, object]:
+    profile = developer_profile()
+    task = runtime_task()
+    return {
+        "task": task,
+        "profile": profile,
+        "execution_context": execution_context(tmp_path, task=task, profile=profile),
+        "domains": frozenset({"backend"}),
+        "technologies": frozenset({"python"}),
+        "tags": frozenset({"testing"}),
+        "required_check_profiles": (CommandProfileId.PYTEST,),
+    }

--- a/tests/developer/test_agent.py
+++ b/tests/developer/test_agent.py
@@ -1,0 +1,191 @@
+"""Composition tests for the Phase 14 DeveloperAgent."""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Mapping
+from pathlib import Path
+from uuid import uuid4
+
+import pytest
+
+from core.agents import AgentReportOutcome
+from core.commands import CommandProfileId
+from core.developer import DeveloperAgent, DeveloperError, DeveloperRequest
+from core.llm import LLMModelMetadata, LLMResponse, LLMUsage
+from core.runtime import RuntimeLimits
+from core.skills import SkillRegistry
+from core.tools import ToolErrorCode, ToolExecutionContext, ToolResult, ToolResultStatus
+from infrastructure.llm import FakeLLMProvider
+from tests.developer.factories import developer_profile, execution_context, request_values
+from tests.runtime.fakes import RecordingRuntimeAudit
+
+
+def _response(content: str) -> LLMResponse:
+    return LLMResponse(
+        content=content,
+        finish_reason="stop",
+        usage=LLMUsage(prompt_tokens=1, completion_tokens=1, total_tokens=2),
+        model=LLMModelMetadata(provider="fake", model="deterministic-v1"),
+    )
+
+
+def _limits() -> RuntimeLimits:
+    return RuntimeLimits(
+        max_iterations=2,
+        timeout_seconds=2,
+        max_tool_calls=2,
+        max_failures=1,
+        max_tokens=100,
+        max_history_entries=8,
+        stagnation_window=2,
+        max_step_tokens=32,
+    )
+
+
+class _Executor:
+    def __init__(self, result: ToolResult) -> None:
+        self.result = result
+        self.calls = 0
+        self.closed = False
+
+    async def execute(
+        self, tool_name: str, arguments: Mapping[str, object], context: ToolExecutionContext
+    ) -> ToolResult:
+        del tool_name, arguments, context
+        self.calls += 1
+        return self.result
+
+    def close(self) -> None:
+        self.closed = True
+
+
+def _command_result() -> ToolResult:
+    return ToolResult(
+        tool_name="run_command_profile",
+        status=ToolResultStatus.SUCCEEDED,
+        output={
+            "profile_id": "pytest",
+            "category": "TEST",
+            "exit_code": 0,
+            "stdout": "must not be retained",
+            "stderr": "",
+            "terminal_status": "SUCCEEDED",
+            "truncated": False,
+        },
+        duration_ms=1,
+        truncated=False,
+        tool_call_id=uuid4(),
+    )
+
+
+def _denied_result() -> ToolResult:
+    return ToolResult(
+        tool_name="run_command_profile",
+        status=ToolResultStatus.DENIED,
+        output={},
+        error_code=ToolErrorCode.PERMISSION_DENIED,
+        error_message="Permission denied.",
+        duration_ms=1,
+        truncated=False,
+        tool_call_id=uuid4(),
+    )
+
+
+def _request(tmp_path: Path, **profile_changes: object) -> DeveloperRequest:
+    profile = developer_profile(skill_ids=frozenset(), **profile_changes)
+    values = request_values(tmp_path)
+    task = values["task"]
+    values["profile"] = profile
+    values["execution_context"] = execution_context(tmp_path, task=task, profile=profile)  # type: ignore[arg-type]
+    return DeveloperRequest.model_validate(values)
+
+
+def test_invalid_request_fails_before_provider_tool_or_audit_work(tmp_path: Path) -> None:
+    provider = FakeLLMProvider(responses=[])
+    executor = _Executor(_command_result())
+    audit = RecordingRuntimeAudit()
+    agent = DeveloperAgent(provider, executor, audit, SkillRegistry([]), _limits())
+
+    with pytest.raises(DeveloperError):
+        asyncio.run(agent.run(_request(tmp_path, role="Reviewer")))
+
+    assert provider.requests == ()
+    assert executor.calls == 0
+    assert audit.records == []
+
+
+def test_agent_composes_one_runtime_and_reports_verified_completion(tmp_path: Path) -> None:
+    provider = FakeLLMProvider(
+        responses=[
+            _response('{"summary":"Observed","facts":[],"uncertainties":[]}'),
+            _response('{"objective":"Test","steps":["Run"],"success_criteria":["Pass"]}'),
+            _response(
+                '{"action":"TOOL_CALL","tool_name":"run_command_profile",'
+                '"arguments":{"profile_id":"pytest"},"rationale":"Verify","confidence":0.9}'
+            ),
+            _response('{"outcome":"COMPLETE","summary":"Passed","progress_made":true}'),
+            _response('{"summary":"Done","details":[],"next_actions":[]}'),
+        ]
+    )
+    executor = _Executor(_command_result())
+    audit = RecordingRuntimeAudit()
+    agent = DeveloperAgent(provider, executor, audit, SkillRegistry([]), _limits())
+
+    result = asyncio.run(agent.run(_request(tmp_path)))
+
+    assert result.report.outcome is AgentReportOutcome.SUCCEEDED
+    assert result.checks[0].profile_id is CommandProfileId.PYTEST
+    assert executor.calls == 1
+    assert len(provider.requests) == 5
+    assert all(request.max_tokens == 32 for request in provider.requests)
+    assert executor.closed is False
+    assert "must not be retained" not in repr(result)
+
+
+def test_agent_blocks_completion_without_required_check(tmp_path: Path) -> None:
+    provider = FakeLLMProvider(
+        responses=[
+            _response('{"summary":"Observed","facts":[],"uncertainties":[]}'),
+            _response('{"objective":"Stop","steps":["Stop"],"success_criteria":["Claim"]}'),
+            _response(
+                '{"action":"COMPLETE","tool_name":null,"arguments":{},'
+                '"rationale":"Claim complete","confidence":0.9}'
+            ),
+            _response('{"summary":"Done","details":[],"next_actions":[]}'),
+        ]
+    )
+    executor = _Executor(_command_result())
+    agent = DeveloperAgent(
+        provider, executor, RecordingRuntimeAudit(), SkillRegistry([]), _limits()
+    )
+
+    result = asyncio.run(agent.run(_request(tmp_path)))
+
+    assert result.report.outcome is AgentReportOutcome.BLOCKED
+    assert executor.calls == 0
+    assert len(provider.requests) == 4
+
+
+def test_permission_denial_is_reported_as_needing_human_without_retry(tmp_path: Path) -> None:
+    provider = FakeLLMProvider(
+        responses=[
+            _response('{"summary":"Observed","facts":[],"uncertainties":[]}'),
+            _response('{"objective":"Test","steps":["Run"],"success_criteria":["Pass"]}'),
+            _response(
+                '{"action":"TOOL_CALL","tool_name":"run_command_profile",'
+                '"arguments":{"profile_id":"pytest"},"rationale":"Verify","confidence":0.9}'
+            ),
+            _response('{"summary":"Blocked","details":[],"next_actions":[]}'),
+        ]
+    )
+    executor = _Executor(_denied_result())
+    agent = DeveloperAgent(
+        provider, executor, RecordingRuntimeAudit(), SkillRegistry([]), _limits()
+    )
+
+    result = asyncio.run(agent.run(_request(tmp_path)))
+
+    assert result.report.outcome is AgentReportOutcome.NEEDS_HUMAN
+    assert executor.calls == 1
+    assert len(provider.requests) == 4

--- a/tests/developer/test_evidence.py
+++ b/tests/developer/test_evidence.py
@@ -7,6 +7,8 @@ from collections.abc import Mapping
 from pathlib import Path
 from uuid import uuid4
 
+import pytest
+
 from core.commands import CommandCategory, CommandProfileId, CommandTerminalStatus
 from core.developer.evidence import EvidenceCollectingToolExecutor
 from core.tools import ToolErrorCode, ToolExecutionContext, ToolResult, ToolResultStatus
@@ -156,3 +158,38 @@ def test_wrapper_caps_records_and_retains_only_stable_failure_codes(tmp_path: Pa
     assert snapshot.failures[0] == ("read_file", ToolErrorCode.TOOL_FAILED)
     assert "secret.txt" not in repr(snapshot)
     assert delegate.closed is False
+
+
+@pytest.mark.parametrize(
+    ("returned_tool_name", "arguments", "output_changes"),
+    [
+        ("read_file", {"profile_id": "pytest"}, {}),
+        ("run_command_profile", {"profile_id": "ruff"}, {}),
+        ("run_command_profile", {"profile_id": "pytest"}, {"category": "BUILD"}),
+        (
+            "run_command_profile",
+            {"profile_id": "pytest"},
+            {"terminal_status": "SUCCEEDED", "exit_code": 1},
+        ),
+    ],
+)
+def test_wrapper_discards_unbound_or_inconsistent_command_metadata(
+    tmp_path: Path,
+    returned_tool_name: str,
+    arguments: dict[str, object],
+    output_changes: dict[str, object],
+) -> None:
+    output: dict[str, object] = {
+        "profile_id": "pytest",
+        "category": "TEST",
+        "exit_code": 0,
+        "terminal_status": "SUCCEEDED",
+        "truncated": False,
+    }
+    output.update(output_changes)
+    delegate = _Executor([_result(returned_tool_name, output=output)])
+    wrapper = EvidenceCollectingToolExecutor(delegate)
+
+    asyncio.run(wrapper.execute("run_command_profile", arguments, _context(tmp_path)))
+
+    assert wrapper.snapshot().checks == ()

--- a/tests/developer/test_evidence.py
+++ b/tests/developer/test_evidence.py
@@ -1,0 +1,151 @@
+"""Exactly-once and metadata-only Developer tool evidence tests."""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Mapping
+from pathlib import Path
+from uuid import uuid4
+
+from core.commands import CommandCategory, CommandProfileId, CommandTerminalStatus
+from core.developer.evidence import EvidenceCollectingToolExecutor
+from core.tools import ToolErrorCode, ToolExecutionContext, ToolResult, ToolResultStatus
+from tests.developer.factories import developer_profile, execution_context, runtime_task
+
+
+class _Executor:
+    def __init__(self, results: list[ToolResult]) -> None:
+        self.results = list(results)
+        self.calls: list[tuple[str, Mapping[str, object]]] = []
+        self.closed = False
+
+    async def execute(
+        self, tool_name: str, arguments: Mapping[str, object], context: ToolExecutionContext
+    ) -> ToolResult:
+        del context
+        self.calls.append((tool_name, arguments))
+        return self.results.pop(0)
+
+    def close(self) -> None:
+        self.closed = True
+
+
+def _result(
+    tool_name: str,
+    *,
+    status: ToolResultStatus = ToolResultStatus.SUCCEEDED,
+    output: dict[str, object] | None = None,
+    error_code: ToolErrorCode | None = None,
+) -> ToolResult:
+    return ToolResult.model_validate(
+        {
+            "tool_name": tool_name,
+            "status": status,
+            "output": output or {},
+            "error_code": error_code,
+            "error_message": None if error_code is None else "Safe failure.",
+            "duration_ms": 1.0,
+            "truncated": False,
+            "tool_call_id": uuid4(),
+        }
+    )
+
+
+def _context(tmp_path: Path) -> ToolExecutionContext:
+    task = runtime_task()
+    profile = developer_profile()
+    return execution_context(tmp_path, task=task, profile=profile)
+
+
+def test_wrapper_delegates_once_and_retains_unique_successful_paths(tmp_path: Path) -> None:
+    delegate = _Executor([_result("patch_file"), _result("patch_file"), _result("write_file")])
+    wrapper = EvidenceCollectingToolExecutor(delegate)
+    context = _context(tmp_path)
+
+    async def scenario() -> None:
+        await wrapper.execute("patch_file", {"path": "src/calc.py", "patch": "PRIVATE"}, context)
+        await wrapper.execute("patch_file", {"path": "src/calc.py", "patch": "PRIVATE"}, context)
+        await wrapper.execute(
+            "write_file", {"path": "tests/test_calc.py", "content": "SECRET"}, context
+        )
+
+    asyncio.run(scenario())
+
+    assert len(delegate.calls) == 3
+    assert wrapper.snapshot().changed_paths == ("src/calc.py", "tests/test_calc.py")
+    retained = repr(wrapper.snapshot())
+    assert "PRIVATE" not in retained
+    assert "SECRET" not in retained
+
+
+def test_wrapper_retains_latest_allowlisted_command_metadata_only(tmp_path: Path) -> None:
+    failed_output = {
+        "profile_id": "pytest",
+        "category": "TEST",
+        "exit_code": 1,
+        "stdout": "PRIVATE TEST OUTPUT",
+        "stderr": "SECRET TRACE",
+        "terminal_status": "FAILED",
+        "truncated": True,
+        "workspace": "/private/repository",
+    }
+    passed_output = {
+        **failed_output,
+        "exit_code": 0,
+        "terminal_status": "SUCCEEDED",
+        "truncated": False,
+    }
+    delegate = _Executor(
+        [
+            _result("run_command_profile", output=failed_output),
+            _result("run_command_profile", output=passed_output),
+        ]
+    )
+    wrapper = EvidenceCollectingToolExecutor(delegate)
+    context = _context(tmp_path)
+
+    async def scenario() -> None:
+        await wrapper.execute("run_command_profile", {"profile_id": "pytest"}, context)
+        await wrapper.execute("run_command_profile", {"profile_id": "pytest"}, context)
+
+    asyncio.run(scenario())
+
+    assert wrapper.snapshot().checks == (
+        (
+            CommandProfileId.PYTEST,
+            CommandCategory.TEST,
+            CommandTerminalStatus.SUCCEEDED,
+            0,
+            False,
+        ),
+    )
+    retained = repr(wrapper.snapshot())
+    assert "PRIVATE TEST OUTPUT" not in retained
+    assert "SECRET TRACE" not in retained
+    assert "/private/repository" not in retained
+
+
+def test_wrapper_caps_records_and_retains_only_stable_failure_codes(tmp_path: Path) -> None:
+    results = [
+        _result(
+            "read_file",
+            status=ToolResultStatus.FAILED,
+            error_code=ToolErrorCode.TOOL_FAILED,
+        )
+        for _ in range(130)
+    ]
+    delegate = _Executor(results)
+    wrapper = EvidenceCollectingToolExecutor(delegate)
+    context = _context(tmp_path)
+
+    async def scenario() -> None:
+        for _ in range(130):
+            await wrapper.execute("read_file", {"path": "secret.txt"}, context)
+
+    asyncio.run(scenario())
+
+    snapshot = wrapper.snapshot()
+    assert len(snapshot.failures) == 128
+    assert snapshot.failures[0] == ("read_file", ToolErrorCode.TOOL_FAILED)
+    assert "secret.txt" not in repr(snapshot)
+    assert delegate.closed is False

--- a/tests/developer/test_evidence.py
+++ b/tests/developer/test_evidence.py
@@ -114,6 +114,13 @@ def test_wrapper_retains_latest_allowlisted_command_metadata_only(tmp_path: Path
         (
             CommandProfileId.PYTEST,
             CommandCategory.TEST,
+            CommandTerminalStatus.FAILED,
+            1,
+            True,
+        ),
+        (
+            CommandProfileId.PYTEST,
+            CommandCategory.TEST,
             CommandTerminalStatus.SUCCEEDED,
             0,
             False,

--- a/tests/developer/test_integration.py
+++ b/tests/developer/test_integration.py
@@ -145,14 +145,18 @@ def _limits() -> RuntimeLimits:
 
 
 @pytest.mark.parametrize(
-    ("provider_script", "expected_calls"),
-    [(_provider_script(), 3), (_correction_script(), 5)],
+    ("provider_script", "expected_calls", "expected_check_statuses"),
+    [
+        (_provider_script(), 3, ("SUCCEEDED",)),
+        (_correction_script(), 5, ("FAILED", "SUCCEEDED")),
+    ],
     ids=("direct-fix", "failed-test-then-correction"),
 )
 def test_developer_fixes_and_verifies_bug_with_real_repository_tools(
     tmp_path: Path,
     provider_script: list[LLMResponse],
     expected_calls: int,
+    expected_check_statuses: tuple[str, ...],
 ) -> None:
     filesystem = ManagedWorkspaceFilesystem(
         tmp_path / "managed",
@@ -275,6 +279,7 @@ def test_developer_fixes_and_verifies_bug_with_real_repository_tools(
     assert result.report.outcome is AgentReportOutcome.SUCCEEDED
     assert result.changed_paths == ("calc.py",)
     assert result.checks[0].profile_id is CommandProfileId.PYTEST
+    assert tuple(check.status.value for check in result.checks) == expected_check_statuses
     assert len(provider.requests) == len(provider_script)
     assert len(permission_policy.requests) == expected_calls
     assert len(permission_audit.decisions) == expected_calls

--- a/tests/developer/test_integration.py
+++ b/tests/developer/test_integration.py
@@ -1,0 +1,282 @@
+"""Real repository-tool acceptance tests for the Developer Agent."""
+
+from __future__ import annotations
+
+import asyncio
+from decimal import Decimal
+from pathlib import Path
+from uuid import uuid4
+
+import pytest
+
+from core.agents import AgentProfile, AgentReportOutcome
+from core.commands import CommandLimits, CommandProfileId
+from core.developer import DeveloperAgent, DeveloperRequest
+from core.enums import AgentSeniority, AgentStatus, Permission
+from core.llm import LLMModelMetadata, LLMResponse, LLMUsage
+from core.permissions import PermissionEngine, PermissionOutcome, PermissionReasonCode
+from core.runtime import RuntimeLimits, RuntimeTask
+from core.skills import SkillRegistry
+from core.tools import ToolExecutionContext, ToolExecutor
+from core.workspaces import WorkspaceLimits
+from infrastructure.commands import LocalCommandPolicy, LocalCommandRunner
+from infrastructure.llm import FakeLLMProvider
+from infrastructure.tools import LocalTextMutator, MutationLimits, create_default_tool_registry
+from infrastructure.workspaces import ManagedWorkspaceFilesystem
+from tests.permissions.fakes import RecordingPermissionAudit, RecordingPolicy
+from tests.runtime.fakes import RecordingRuntimeAudit, RecordingToolAudit
+
+
+def _response(content: str) -> LLMResponse:
+    return LLMResponse(
+        content=content,
+        finish_reason="stop",
+        usage=LLMUsage(prompt_tokens=1, completion_tokens=1, total_tokens=2),
+        model=LLMModelMetadata(provider="fake", model="deterministic-v1"),
+    )
+
+
+def _phase(instruction: str) -> LLMResponse:
+    return _response(instruction)
+
+
+def _provider_script() -> list[LLMResponse]:
+    return [
+        _phase('{"summary":"Inspect the implementation","facts":[],"uncertainties":[]}'),
+        _phase(
+            '{"objective":"Inspect calc.py","steps":["Read calc.py"],'
+            '"success_criteria":["Implementation observed"]}'
+        ),
+        _phase(
+            '{"action":"TOOL_CALL","tool_name":"read_file",'
+            '"arguments":{"path":"calc.py"},"rationale":"Inspect bug","confidence":0.9}'
+        ),
+        _phase('{"outcome":"CONTINUE","summary":"Bug found","progress_made":true}'),
+        _phase('{"summary":"Patch the defect","facts":[],"uncertainties":[]}'),
+        _phase(
+            '{"objective":"Correct addition","steps":["Patch calc.py"],'
+            '"success_criteria":["Addition is correct"]}'
+        ),
+        _phase(
+            '{"action":"TOOL_CALL","tool_name":"patch_file",'
+            '"arguments":{"path":"calc.py","operations":['
+            '{"old_text":"return a - b","new_text":"return a + b"}]},'
+            '"rationale":"Apply minimal fix","confidence":0.95}'
+        ),
+        _phase('{"outcome":"CONTINUE","summary":"Patch applied","progress_made":true}'),
+        _phase('{"summary":"Verify the repository","facts":[],"uncertainties":[]}'),
+        _phase(
+            '{"objective":"Run tests","steps":["Run pytest profile"],'
+            '"success_criteria":["Tests pass"]}'
+        ),
+        _phase(
+            '{"action":"TOOL_CALL","tool_name":"run_command_profile",'
+            '"arguments":{"profile_id":"pytest"},"rationale":"Verify fix","confidence":0.99}'
+        ),
+        _phase('{"outcome":"COMPLETE","summary":"Tests passed","progress_made":true}'),
+        _phase('{"summary":"Verified","details":[],"next_actions":[]}'),
+    ]
+
+
+def _correction_script() -> list[LLMResponse]:
+    script = _provider_script()[:4]
+    script.extend(
+        [
+            _phase('{"summary":"Apply an initial fix","facts":[],"uncertainties":[]}'),
+            _phase(
+                '{"objective":"Patch addition","steps":["Patch calc.py"],'
+                '"success_criteria":["Implementation changes"]}'
+            ),
+            _phase(
+                '{"action":"TOOL_CALL","tool_name":"patch_file",'
+                '"arguments":{"path":"calc.py","operations":['
+                '{"old_text":"return a - b","new_text":"return a * b"}]},'
+                '"rationale":"Initial correction","confidence":0.7}'
+            ),
+            _phase('{"outcome":"CONTINUE","summary":"Patch applied","progress_made":true}'),
+            _phase('{"summary":"Verify initial fix","facts":[],"uncertainties":[]}'),
+            _phase(
+                '{"objective":"Run tests","steps":["Run pytest"],"success_criteria":["Tests pass"]}'
+            ),
+            _phase(
+                '{"action":"TOOL_CALL","tool_name":"run_command_profile",'
+                '"arguments":{"profile_id":"pytest"},"rationale":"Verify","confidence":0.8}'
+            ),
+            _phase('{"outcome":"CONTINUE","summary":"Tests failed","progress_made":true}'),
+            _phase('{"summary":"Correct failed fix","facts":[],"uncertainties":[]}'),
+            _phase(
+                '{"objective":"Correct operation","steps":["Patch calc.py"],'
+                '"success_criteria":["Addition is correct"]}'
+            ),
+            _phase(
+                '{"action":"TOOL_CALL","tool_name":"patch_file",'
+                '"arguments":{"path":"calc.py","operations":['
+                '{"old_text":"return a * b","new_text":"return a + b"}]},'
+                '"rationale":"Use failed test evidence","confidence":0.95}'
+            ),
+            _phase('{"outcome":"CONTINUE","summary":"Corrected","progress_made":true}'),
+            _phase('{"summary":"Verify correction","facts":[],"uncertainties":[]}'),
+            _phase(
+                '{"objective":"Run tests again","steps":["Run pytest"],'
+                '"success_criteria":["Tests pass"]}'
+            ),
+            _phase(
+                '{"action":"TOOL_CALL","tool_name":"run_command_profile",'
+                '"arguments":{"profile_id":"pytest"},"rationale":"Reverify","confidence":0.99}'
+            ),
+            _phase('{"outcome":"COMPLETE","summary":"Tests passed","progress_made":true}'),
+            _phase('{"summary":"Verified","details":[],"next_actions":[]}'),
+        ]
+    )
+    return script
+
+
+def _limits() -> RuntimeLimits:
+    return RuntimeLimits(
+        max_iterations=6,
+        timeout_seconds=15,
+        max_tool_calls=6,
+        max_failures=2,
+        max_tokens=1_000,
+        max_history_entries=64,
+        stagnation_window=3,
+        max_step_tokens=64,
+    )
+
+
+@pytest.mark.parametrize(
+    ("provider_script", "expected_calls"),
+    [(_provider_script(), 3), (_correction_script(), 5)],
+    ids=("direct-fix", "failed-test-then-correction"),
+)
+def test_developer_fixes_and_verifies_bug_with_real_repository_tools(
+    tmp_path: Path,
+    provider_script: list[LLMResponse],
+    expected_calls: int,
+) -> None:
+    filesystem = ManagedWorkspaceFilesystem(
+        tmp_path / "managed",
+        WorkspaceLimits(
+            git_timeout_seconds=5,
+            git_output_bytes=8_192,
+            max_entries=100,
+            max_total_bytes=1_000_000,
+            max_depth=8,
+            max_local_roots=8,
+            max_remote_hosts=8,
+        ),
+    )
+    project_id = uuid4()
+    root = filesystem.promote(project_id, filesystem.create_staging(project_id))
+    (root / "pyproject.toml").write_text(
+        "[tool.pytest.ini_options]\naddopts = '-q'\n", encoding="utf-8"
+    )
+    (root / "calc.py").write_text(
+        "def add(a: int, b: int) -> int:\n    return a - b\n", encoding="utf-8"
+    )
+    (root / "test_calc.py").write_text(
+        "from calc import add\n\ndef test_add():\n    assert add(2, 3) == 5\n", encoding="utf-8"
+    )
+    mutator = LocalTextMutator(
+        filesystem,
+        MutationLimits(
+            max_input_bytes=8_192,
+            max_existing_bytes=8_192,
+            max_patch_operations=8,
+            max_patch_text_bytes=4_096,
+            max_diff_bytes=8_192,
+        ),
+    )
+    command_limits = CommandLimits(
+        timeout_seconds=10,
+        stdout_max_bytes=8_192,
+        stderr_max_bytes=8_192,
+        marker_max_bytes=4_096,
+        read_chunk_bytes=1_024,
+        termination_grace_seconds=0.5,
+    )
+    registry = create_default_tool_registry(
+        mutator,
+        LocalCommandPolicy(filesystem, command_limits),
+        LocalCommandRunner(),
+    )
+    permission_policy = RecordingPolicy(PermissionOutcome.ALLOW, PermissionReasonCode.GRANTED)
+    permission_audit = RecordingPermissionAudit()
+    tool_audit = RecordingToolAudit()
+    executor = ToolExecutor(
+        registry,
+        tool_audit,
+        PermissionEngine(permission_policy, permission_audit),
+    )
+    task = RuntimeTask(
+        task_id=uuid4(),
+        objective="Fix the addition defect and verify the existing tests.",
+        acceptance_criteria=("The pytest profile succeeds.",),
+    )
+    declared_tools = frozenset({"read_file", "patch_file", "run_command_profile"})
+    profile = AgentProfile(
+        id="developer-01",
+        name="Developer One",
+        role="Developer",
+        department="engineering",
+        seniority=AgentSeniority.ENGINEER,
+        status=AgentStatus.WORKING,
+        system_prompt="Implement the assigned task through authorized tools.",
+        autonomy_level=2,
+        permission_ids=frozenset(
+            {
+                Permission.FILESYSTEM_READ.value,
+                Permission.FILESYSTEM_WRITE.value,
+                Permission.SHELL_EXECUTE.value,
+                Permission.TESTS_EXECUTE.value,
+            }
+        ),
+        tool_ids=declared_tools,
+        skill_ids=frozenset(),
+        reputation_score=Decimal("0.8"),
+        reliability_score=Decimal("0.9"),
+    )
+    context = ToolExecutionContext(
+        workspace_root=root,
+        agent_id=profile.id,
+        agent_run_id=uuid4(),
+        project_id=project_id,
+        task_id=task.task_id,
+        declared_tool_ids=declared_tools,
+        correlation_id=uuid4(),
+    )
+    provider = FakeLLMProvider(responses=provider_script)
+    agent = DeveloperAgent(
+        provider,
+        executor,
+        RecordingRuntimeAudit(),
+        SkillRegistry([]),
+        _limits(),
+    )
+
+    result = asyncio.run(
+        agent.run(
+            DeveloperRequest(
+                task=task,
+                profile=profile,
+                execution_context=context,
+                domains=frozenset({"backend"}),
+                technologies=frozenset({"python"}),
+                tags=frozenset({"testing"}),
+                required_check_profiles=(CommandProfileId.PYTEST,),
+            )
+        )
+    )
+
+    assert (root / "calc.py").read_text(encoding="utf-8").endswith("return a + b\n"), (
+        result.model_dump(mode="json"),
+        [(item.outcome, item.error_code) for item in tool_audit.finishes],
+    )
+    assert result.report.outcome is AgentReportOutcome.SUCCEEDED
+    assert result.changed_paths == ("calc.py",)
+    assert result.checks[0].profile_id is CommandProfileId.PYTEST
+    assert len(provider.requests) == len(provider_script)
+    assert len(permission_policy.requests) == expected_calls
+    assert len(permission_audit.decisions) == expected_calls
+    assert len(tool_audit.starts) == expected_calls
+    assert len(tool_audit.finishes) == expected_calls

--- a/tests/developer/test_reporting.py
+++ b/tests/developer/test_reporting.py
@@ -1,0 +1,98 @@
+"""Truthful deterministic Developer report tests."""
+
+from __future__ import annotations
+
+from core.agents import AgentReportOutcome
+from core.commands import CommandCategory, CommandProfileId, CommandTerminalStatus
+from core.developer import DeveloperCheckResult
+from core.developer.reporting import build_agent_report
+from core.runtime import (
+    RuntimeResult,
+    RuntimeTerminalReason,
+    RuntimeTerminalStatus,
+)
+
+
+def _runtime(
+    status: RuntimeTerminalStatus = RuntimeTerminalStatus.COMPLETED,
+    reason: RuntimeTerminalReason = RuntimeTerminalReason.TASK_COMPLETED,
+) -> RuntimeResult:
+    return RuntimeResult(
+        status=status,
+        reason=reason,
+        summary="Runtime reached a deterministic terminal state.",
+        iterations=1,
+        tool_calls=1,
+        failures=0,
+        reported_tokens=10,
+        usage_available=True,
+        duration_ms=5.0,
+        history=(),
+    )
+
+
+def _check(status: CommandTerminalStatus) -> DeveloperCheckResult:
+    return DeveloperCheckResult(
+        profile_id=CommandProfileId.PYTEST,
+        category=CommandCategory.TEST,
+        status=status,
+        exit_code=0 if status is CommandTerminalStatus.SUCCEEDED else 1,
+        truncated=False,
+    )
+
+
+def test_success_requires_completed_runtime_and_every_required_check() -> None:
+    report = build_agent_report(
+        _runtime(), (CommandProfileId.PYTEST,), (_check(CommandTerminalStatus.SUCCEEDED),)
+    )
+
+    assert report.outcome is AgentReportOutcome.SUCCEEDED
+
+
+def test_missing_check_blocks_llm_completion_claim() -> None:
+    report = build_agent_report(_runtime(), (CommandProfileId.PYTEST,), ())
+
+    assert report.outcome is AgentReportOutcome.BLOCKED
+    assert report.details == ("Required checks are missing: pytest.",)
+
+
+def test_failed_latest_check_fails_llm_completion_claim() -> None:
+    report = build_agent_report(
+        _runtime(), (CommandProfileId.PYTEST,), (_check(CommandTerminalStatus.FAILED),)
+    )
+
+    assert report.outcome is AgentReportOutcome.FAILED
+    assert report.details == ("Required checks failed: pytest.",)
+
+
+def test_permission_and_approval_escalations_need_human() -> None:
+    for reason in (
+        RuntimeTerminalReason.PERMISSION_DENIED,
+        RuntimeTerminalReason.HUMAN_APPROVAL_REQUIRED,
+        RuntimeTerminalReason.AGENT_ESCALATED,
+    ):
+        report = build_agent_report(
+            _runtime(RuntimeTerminalStatus.ESCALATED, reason), (CommandProfileId.PYTEST,), ()
+        )
+        assert report.outcome is AgentReportOutcome.NEEDS_HUMAN
+
+
+def test_limits_timeout_and_stagnation_are_blocked() -> None:
+    cases = (
+        (RuntimeTerminalStatus.LIMIT_REACHED, RuntimeTerminalReason.MAX_ITERATIONS_REACHED),
+        (RuntimeTerminalStatus.TIMED_OUT, RuntimeTerminalReason.GLOBAL_TIMEOUT),
+        (RuntimeTerminalStatus.ESCALATED, RuntimeTerminalReason.STAGNATION_DETECTED),
+    )
+    for status, reason in cases:
+        report = build_agent_report(_runtime(status, reason), (CommandProfileId.PYTEST,), ())
+        assert report.outcome is AgentReportOutcome.BLOCKED
+
+
+def test_runtime_and_audit_failures_are_failed() -> None:
+    report = build_agent_report(
+        _runtime(RuntimeTerminalStatus.FAILED, RuntimeTerminalReason.AUDIT_FAILED),
+        (CommandProfileId.PYTEST,),
+        (),
+    )
+
+    assert report.outcome is AgentReportOutcome.FAILED

--- a/tests/developer/test_safety.py
+++ b/tests/developer/test_safety.py
@@ -1,0 +1,86 @@
+"""Adversarial lifecycle checks for the Developer Agent boundary."""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Mapping
+from pathlib import Path
+
+import pytest
+
+from core.developer import DeveloperAgent, DeveloperRequest
+from core.llm import LLMRequest, LLMResponse
+from core.runtime import RuntimeLimits
+from core.skills import SkillRegistry
+from core.tools import ToolExecutionContext, ToolResult
+from tests.developer.factories import developer_profile, execution_context, request_values
+from tests.runtime.fakes import RecordingRuntimeAudit
+
+
+class _CancellingProvider:
+    def __init__(self) -> None:
+        self.calls = 0
+        self.closed = False
+
+    async def generate(self, request: LLMRequest) -> LLMResponse:
+        del request
+        self.calls += 1
+        raise asyncio.CancelledError
+
+    def close(self) -> None:
+        self.closed = True
+
+
+class _UnusedExecutor:
+    def __init__(self) -> None:
+        self.closed = False
+
+    async def execute(
+        self, tool_name: str, arguments: Mapping[str, object], context: ToolExecutionContext
+    ) -> ToolResult:
+        del tool_name, arguments, context
+        raise AssertionError("cancelled reasoning must not execute a tool")
+
+    def close(self) -> None:
+        self.closed = True
+
+
+def _request(tmp_path: Path) -> DeveloperRequest:
+    profile = developer_profile(skill_ids=frozenset())
+    values = request_values(tmp_path)
+    task = values["task"]
+    values["profile"] = profile
+    values["execution_context"] = execution_context(tmp_path, task=task, profile=profile)  # type: ignore[arg-type]
+    return DeveloperRequest.model_validate(values)
+
+
+def test_cancellation_propagates_and_injected_resources_remain_caller_owned(
+    tmp_path: Path,
+) -> None:
+    provider = _CancellingProvider()
+    executor = _UnusedExecutor()
+    audit = RecordingRuntimeAudit()
+    agent = DeveloperAgent(
+        provider,
+        executor,
+        audit,
+        SkillRegistry([]),
+        RuntimeLimits(
+            max_iterations=2,
+            timeout_seconds=2,
+            max_tool_calls=2,
+            max_failures=1,
+            max_tokens=100,
+            max_history_entries=8,
+            stagnation_window=2,
+            max_step_tokens=32,
+        ),
+    )
+
+    with pytest.raises(asyncio.CancelledError):
+        asyncio.run(agent.run(_request(tmp_path)))
+
+    assert provider.calls == 1
+    assert provider.closed is False
+    assert executor.closed is False
+    assert [record.outcome.value for record in audit.records] == ["STARTED", "CANCELLED"]

--- a/tests/developer/test_skills.py
+++ b/tests/developer/test_skills.py
@@ -1,0 +1,127 @@
+"""Deterministic and bounded Developer skill-context tests."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from core.developer import DeveloperError, DeveloperErrorCode, DeveloperRequest
+from core.developer.skills import build_skill_context
+from core.developer.validation import validate_developer_request
+from core.enums import Permission
+from core.skills import Skill, SkillMetadata, SkillRegistry
+from tests.developer.factories import developer_profile, execution_context, request_values
+
+
+def _skill(
+    skill_id: str,
+    *,
+    instructions: str = "Inspect the Python code, make the smallest change, and run tests.",
+    tools: frozenset[str] = frozenset({"read_file", "patch_file", "run_command_profile"}),
+    permissions: frozenset[Permission] = frozenset(
+        {Permission.FILESYSTEM_READ, Permission.FILESYSTEM_WRITE}
+    ),
+    domains: frozenset[str] = frozenset({"backend"}),
+    tags: frozenset[str] = frozenset({"testing"}),
+    technologies: frozenset[str] = frozenset({"python"}),
+) -> Skill:
+    return Skill(
+        metadata=SkillMetadata(
+            id=skill_id,
+            name=skill_id.replace("-", " ").title(),
+            description=f"Procedure for {skill_id} Python work.",
+            domains=domains,
+            technologies=technologies,
+            tags=tags,
+            version="1.0.0",
+            recommended_tool_ids=tools,
+            required_permissions=permissions,
+        ),
+        instructions=instructions,
+    )
+
+
+def _validated(
+    tmp_path: Path,
+    *,
+    skill_ids: frozenset[str],
+    system_prompt: str = "Implement the task safely.",
+) -> object:
+    profile = developer_profile(skill_ids=skill_ids, system_prompt=system_prompt)
+    values = request_values(tmp_path)
+    task = values["task"]
+    values["profile"] = profile
+    values["execution_context"] = execution_context(tmp_path, task=task, profile=profile)  # type: ignore[arg-type]
+    return validate_developer_request(DeveloperRequest.model_validate(values))
+
+
+def test_context_selects_only_declared_compatible_positive_matches(tmp_path: Path) -> None:
+    registry = SkillRegistry(
+        [
+            _skill("eligible"),
+            _skill("undeclared"),
+            _skill("missing-permission", permissions=frozenset({Permission.DATABASE_WRITE})),
+            _skill("forbidden-tool", tools=frozenset({"deploy_production"})),
+            _skill(
+                "zero-score",
+                domains=frozenset({"unrelated"}),
+                technologies=frozenset({"rust"}),
+                tags=frozenset({"unrelated"}),
+            ),
+        ]
+    )
+    validated = _validated(
+        tmp_path,
+        skill_ids=frozenset({"eligible", "missing-permission", "forbidden-tool", "zero-score"}),
+    )
+
+    context = build_skill_context(validated, registry)  # type: ignore[arg-type]
+
+    assert context.selected_ids == ("eligible",)
+    assert context.omitted_ids == ("forbidden-tool", "missing-permission", "zero-score")
+    assert "undeclared" not in context.prompt_fragment
+    assert "eligible" in context.prompt_fragment
+
+
+def test_context_preserves_selector_order_and_caps_selection_at_eight(tmp_path: Path) -> None:
+    skills = [_skill(f"skill-{index:02d}") for index in range(10)]
+    registry = SkillRegistry(reversed(skills))
+    validated = _validated(tmp_path, skill_ids=frozenset(skill.metadata.id for skill in skills))
+
+    context = build_skill_context(validated, registry)  # type: ignore[arg-type]
+
+    assert context.selected_ids == tuple(f"skill-{index:02d}" for index in range(8))
+    assert context.omitted_ids == ("skill-08", "skill-09")
+
+
+def test_context_never_truncates_instruction_at_utf8_budget(tmp_path: Path) -> None:
+    first = _skill("first", instructions="é" * 5_000)
+    second_secret = "SECOND-INSTRUCTION-MUST-BE-OMITTED"
+    second = _skill("second", instructions=second_secret + ("x" * 4_000))
+    registry = SkillRegistry([first, second])
+    validated = _validated(tmp_path, skill_ids=frozenset({"first", "second"}))
+
+    context = build_skill_context(validated, registry)  # type: ignore[arg-type]
+
+    assert context.selected_ids == ("first",)
+    assert context.omitted_ids == ("second",)
+    assert second_secret not in context.prompt_fragment
+    assert len(context.prompt_fragment.encode("utf-8")) <= 12_288
+    assert context.prompt_fragment.count("é") == 5_000
+
+
+def test_context_rejects_final_prompt_over_reasoner_limit_without_leak(tmp_path: Path) -> None:
+    secret = "PRIVATE-SKILL-INSTRUCTION"
+    registry = SkillRegistry([_skill("eligible", instructions=secret)])
+    validated = _validated(
+        tmp_path,
+        skill_ids=frozenset({"eligible"}),
+        system_prompt="p" * 16_300,
+    )
+
+    with pytest.raises(DeveloperError) as raised:
+        build_skill_context(validated, registry)  # type: ignore[arg-type]
+
+    assert raised.value.code is DeveloperErrorCode.SKILL_CONTEXT_LIMIT
+    assert secret not in str(raised.value)

--- a/tests/developer/test_types.py
+++ b/tests/developer/test_types.py
@@ -1,0 +1,81 @@
+"""Behavioral tests for bounded Developer Agent values."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from pydantic import TypeAdapter, ValidationError
+
+from core.commands import CommandCategory, CommandProfileId, CommandTerminalStatus
+from core.developer import ChangedPath, DeveloperCheckResult, DeveloperRequest
+from tests.developer.factories import request_values
+
+
+def test_request_copies_collections_and_is_immutable(tmp_path: Path) -> None:
+    values = request_values(tmp_path)
+    domains = {"backend"}
+    checks = [CommandProfileId.PYTEST]
+    values["domains"] = domains
+    values["required_check_profiles"] = checks
+
+    request = DeveloperRequest.model_validate(values)
+    domains.add("payments")
+    checks.append(CommandProfileId.RUFF)
+
+    assert request.domains == frozenset({"backend"})
+    assert request.required_check_profiles == (CommandProfileId.PYTEST,)
+    with pytest.raises(ValidationError):
+        request.domains = frozenset({"changed"})  # type: ignore[misc]
+
+
+@pytest.mark.parametrize(
+    "profiles",
+    [
+        (),
+        (
+            CommandProfileId.PYTEST,
+            CommandProfileId.RUFF,
+            CommandProfileId.MYPY,
+            CommandProfileId.NPM_BUILD,
+            CommandProfileId.NPM_TEST,
+        ),
+        (CommandProfileId.PYTEST, CommandProfileId.PYTEST),
+    ],
+)
+def test_request_rejects_invalid_required_check_cardinality(
+    tmp_path: Path, profiles: tuple[CommandProfileId, ...]
+) -> None:
+    values = request_values(tmp_path)
+    values["required_check_profiles"] = profiles
+
+    with pytest.raises(ValidationError):
+        DeveloperRequest.model_validate(values)
+
+
+def test_check_result_retains_only_deterministic_metadata() -> None:
+    check = DeveloperCheckResult(
+        profile_id=CommandProfileId.PYTEST,
+        category=CommandCategory.TEST,
+        status=CommandTerminalStatus.FAILED,
+        exit_code=1,
+        truncated=True,
+    )
+
+    assert check.model_dump(mode="json") == {
+        "profile_id": "pytest",
+        "category": "TEST",
+        "status": "FAILED",
+        "exit_code": 1,
+        "truncated": True,
+    }
+    assert "stdout" not in DeveloperCheckResult.model_fields
+    assert "stderr" not in DeveloperCheckResult.model_fields
+
+
+@pytest.mark.parametrize(
+    "path", ["/private/repository/file.py", "../secret.py", "src/../secret.py"]
+)
+def test_changed_path_validator_rejects_non_relative_scope(path: str) -> None:
+    with pytest.raises(ValidationError):
+        TypeAdapter(ChangedPath).validate_python(path)

--- a/tests/developer/test_types.py
+++ b/tests/developer/test_types.py
@@ -74,6 +74,30 @@ def test_check_result_retains_only_deterministic_metadata() -> None:
 
 
 @pytest.mark.parametrize(
+    "changes",
+    [
+        {"category": CommandCategory.BUILD},
+        {"status": CommandTerminalStatus.SUCCEEDED, "exit_code": 1},
+        {"status": CommandTerminalStatus.FAILED, "exit_code": 0},
+    ],
+)
+def test_check_result_rejects_false_or_inconsistent_metadata(
+    changes: dict[str, object],
+) -> None:
+    values: dict[str, object] = {
+        "profile_id": CommandProfileId.PYTEST,
+        "category": CommandCategory.TEST,
+        "status": CommandTerminalStatus.FAILED,
+        "exit_code": 1,
+        "truncated": False,
+    }
+    values.update(changes)
+
+    with pytest.raises(ValidationError):
+        DeveloperCheckResult.model_validate(values)
+
+
+@pytest.mark.parametrize(
     "path", ["/private/repository/file.py", "../secret.py", "src/../secret.py"]
 )
 def test_changed_path_validator_rejects_non_relative_scope(path: str) -> None:

--- a/tests/developer/test_validation.py
+++ b/tests/developer/test_validation.py
@@ -1,0 +1,116 @@
+"""Fail-closed tests for the Developer Agent preflight boundary."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from uuid import uuid4
+
+import pytest
+
+from core.commands import CommandProfileId
+from core.developer import DeveloperError, DeveloperErrorCode, DeveloperRequest
+from core.developer.validation import validate_developer_request
+from core.enums import AgentStatus
+from tests.developer.factories import developer_profile, execution_context, request_values
+
+
+def _request(tmp_path: Path, **overrides: object) -> DeveloperRequest:
+    values = request_values(tmp_path)
+    values.update(overrides)
+    return DeveloperRequest.model_validate(values)
+
+
+@pytest.mark.parametrize(
+    ("profile_overrides", "code"),
+    [
+        ({"role": "Reviewer"}, DeveloperErrorCode.INVALID_ROLE),
+        ({"status": AgentStatus.OFFLINE}, DeveloperErrorCode.INACTIVE_AGENT),
+        (
+            {"permission_ids": frozenset({"filesystem.read", "unknown.secret"})},
+            DeveloperErrorCode.INVALID_PERMISSION,
+        ),
+    ],
+)
+def test_validation_rejects_invalid_profile_before_work(
+    tmp_path: Path, profile_overrides: dict[str, object], code: DeveloperErrorCode
+) -> None:
+    profile = developer_profile(**profile_overrides)
+    values = request_values(tmp_path)
+    task = values["task"]
+    values["profile"] = profile
+    values["execution_context"] = execution_context(tmp_path, task=task, profile=profile)  # type: ignore[arg-type]
+
+    with pytest.raises(DeveloperError) as raised:
+        validate_developer_request(DeveloperRequest.model_validate(values))
+
+    assert raised.value.code is code
+    assert "unknown.secret" not in str(raised.value)
+
+
+def test_validation_rejects_inconsistent_task_scope(tmp_path: Path) -> None:
+    request = _request(tmp_path)
+    forged = request.execution_context.model_copy(update={"task_id": uuid4()})
+
+    with pytest.raises(DeveloperError) as raised:
+        validate_developer_request(request.model_copy(update={"execution_context": forged}))
+
+    assert raised.value.code is DeveloperErrorCode.INVALID_SCOPE
+
+
+@pytest.mark.parametrize(
+    "tools",
+    [
+        frozenset({"read_file", "write_file", "run_command_profile", "merge_pull_request"}),
+        frozenset({"read_file", "run_command_profile"}),
+        frozenset({"read_file", "write_file"}),
+    ],
+)
+def test_validation_rejects_forbidden_or_incomplete_tool_sets(
+    tmp_path: Path, tools: frozenset[str]
+) -> None:
+    profile = developer_profile(tool_ids=tools)
+    values = request_values(tmp_path)
+    task = values["task"]
+    values["profile"] = profile
+    values["execution_context"] = execution_context(tmp_path, task=task, profile=profile)  # type: ignore[arg-type]
+
+    with pytest.raises(DeveloperError) as raised:
+        validate_developer_request(DeveloperRequest.model_validate(values))
+
+    assert raised.value.code is DeveloperErrorCode.INVALID_TOOLS
+
+
+def test_validation_requires_profile_and_context_tools_to_match(tmp_path: Path) -> None:
+    request = _request(tmp_path)
+    context = request.execution_context.model_copy(
+        update={"declared_tool_ids": frozenset({"read_file", "write_file", "run_command_profile"})}
+    )
+
+    with pytest.raises(DeveloperError) as raised:
+        validate_developer_request(request.model_copy(update={"execution_context": context}))
+
+    assert raised.value.code is DeveloperErrorCode.INVALID_SCOPE
+
+
+@pytest.mark.parametrize(
+    "profile_id", [CommandProfileId.GIT_STATUS, CommandProfileId.GIT_DIFF, CommandProfileId.GIT_LOG]
+)
+def test_validation_rejects_git_profiles_as_required_checks(
+    tmp_path: Path, profile_id: CommandProfileId
+) -> None:
+    request = _request(tmp_path, required_check_profiles=(profile_id,))
+
+    with pytest.raises(DeveloperError) as raised:
+        validate_developer_request(request)
+
+    assert raised.value.code is DeveloperErrorCode.INVALID_CHECK_PROFILE
+
+
+def test_valid_request_returns_canonical_permissions(tmp_path: Path) -> None:
+    validated = validate_developer_request(_request(tmp_path))
+
+    assert {permission.value for permission in validated.permissions} == {
+        "filesystem.read",
+        "filesystem.write",
+        "tests.execute",
+    }

--- a/tests/developer/test_validation.py
+++ b/tests/developer/test_validation.py
@@ -112,5 +112,21 @@ def test_valid_request_returns_canonical_permissions(tmp_path: Path) -> None:
     assert {permission.value for permission in validated.permissions} == {
         "filesystem.read",
         "filesystem.write",
+        "shell.execute",
         "tests.execute",
     }
+
+
+def test_validation_rejects_missing_permission_for_declared_capabilities(tmp_path: Path) -> None:
+    profile = developer_profile(
+        permission_ids=frozenset({"filesystem.read", "filesystem.write", "tests.execute"})
+    )
+    values = request_values(tmp_path)
+    task = values["task"]
+    values["profile"] = profile
+    values["execution_context"] = execution_context(tmp_path, task=task, profile=profile)  # type: ignore[arg-type]
+
+    with pytest.raises(DeveloperError) as raised:
+        validate_developer_request(DeveloperRequest.model_validate(values))
+
+    assert raised.value.code is DeveloperErrorCode.INVALID_PERMISSION

--- a/tests/runtime/__init__.py
+++ b/tests/runtime/__init__.py
@@ -1,0 +1,1 @@
+"""Phase 13 bounded agent runtime tests."""

--- a/tests/runtime/fakes.py
+++ b/tests/runtime/fakes.py
@@ -1,0 +1,102 @@
+"""Deterministic collaborators for bounded runtime tests."""
+
+from __future__ import annotations
+
+from collections import deque
+from collections.abc import Mapping
+from typing import cast
+
+from pydantic import BaseModel
+
+from core.runtime import (
+    ReasonerOutput,
+    RuntimeAuditRecord,
+    RuntimeDecision,
+    RuntimeHistoryEntry,
+    RuntimeObservation,
+    RuntimePlan,
+    RuntimeReport,
+    RuntimeTask,
+    RuntimeTerminalReason,
+    RuntimeTerminalStatus,
+    RuntimeVerification,
+)
+from core.tools import ToolExecutionContext, ToolResult
+
+
+class ScriptedReasoner:
+    """Return a finite script and count every requested operation."""
+
+    def __init__(self, script: list[object], *, tokens: int = 1) -> None:
+        self.script = deque(script)
+        self.tokens = tokens
+        self.calls: list[str] = []
+
+    def _next[ValueT: BaseModel](self, name: str) -> ReasonerOutput[ValueT]:
+        self.calls.append(name)
+        value = self.script.popleft()
+        if isinstance(value, Exception):
+            raise value
+        return ReasonerOutput(
+            value=cast(ValueT, value), reported_tokens=self.tokens, usage_available=True
+        )
+
+    async def observe(
+        self, task: RuntimeTask, history: tuple[RuntimeHistoryEntry, ...]
+    ) -> ReasonerOutput[RuntimeObservation]:
+        return self._next("observe")
+
+    async def plan(
+        self,
+        task: RuntimeTask,
+        observation: RuntimeObservation,
+        history: tuple[RuntimeHistoryEntry, ...],
+    ) -> ReasonerOutput[RuntimePlan]:
+        return self._next("plan")
+
+    async def decide(
+        self,
+        task: RuntimeTask,
+        observation: RuntimeObservation,
+        plan: RuntimePlan,
+        history: tuple[RuntimeHistoryEntry, ...],
+    ) -> ReasonerOutput[RuntimeDecision]:
+        return self._next("decide")
+
+    async def verify(
+        self,
+        task: RuntimeTask,
+        decision: RuntimeDecision,
+        tool_result: ToolResult,
+        history: tuple[RuntimeHistoryEntry, ...],
+    ) -> ReasonerOutput[RuntimeVerification]:
+        return self._next("verify")
+
+    async def report(
+        self,
+        task: RuntimeTask,
+        status: RuntimeTerminalStatus,
+        reason: RuntimeTerminalReason,
+        history: tuple[RuntimeHistoryEntry, ...],
+    ) -> ReasonerOutput[RuntimeReport]:
+        return self._next("report")
+
+
+class RecordingExecutor:
+    def __init__(self, results: list[ToolResult]) -> None:
+        self.results = deque(results)
+        self.calls = 0
+
+    async def execute(
+        self, tool_name: str, arguments: Mapping[str, object], context: ToolExecutionContext
+    ) -> ToolResult:
+        self.calls += 1
+        return self.results.popleft()
+
+
+class RecordingRuntimeAudit:
+    def __init__(self) -> None:
+        self.records: list[RuntimeAuditRecord] = []
+
+    def record(self, record: RuntimeAuditRecord) -> None:
+        self.records.append(record)

--- a/tests/runtime/fakes.py
+++ b/tests/runtime/fakes.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from collections import deque
 from collections.abc import Mapping
 from typing import cast
+from uuid import uuid4
 
 from pydantic import BaseModel
 
@@ -21,16 +22,23 @@ from core.runtime import (
     RuntimeTerminalStatus,
     RuntimeVerification,
 )
-from core.tools import ToolExecutionContext, ToolResult
+from core.tools import (
+    ToolAuditFinish,
+    ToolAuditHandle,
+    ToolAuditStart,
+    ToolExecutionContext,
+    ToolResult,
+)
 
 
 class ScriptedReasoner:
     """Return a finite script and count every requested operation."""
 
-    def __init__(self, script: list[object], *, tokens: int = 1) -> None:
+    def __init__(self, script: list[object], *, tokens: int = 1, max_step_tokens: int = 20) -> None:
         self.script = deque(script)
         self.tokens = tokens
         self.calls: list[str] = []
+        self.max_step_tokens = max_step_tokens
 
     def _next[ValueT: BaseModel](self, name: str) -> ReasonerOutput[ValueT]:
         self.calls.append(name)
@@ -100,3 +108,20 @@ class RecordingRuntimeAudit:
 
     def record(self, record: RuntimeAuditRecord) -> None:
         self.records.append(record)
+
+    def record_cancellation(self, record: RuntimeAuditRecord) -> None:
+        self.records.append(record)
+
+
+class RecordingToolAudit:
+    def __init__(self) -> None:
+        self.starts: list[ToolAuditStart] = []
+        self.finishes: list[ToolAuditFinish] = []
+
+    def begin(self, start: ToolAuditStart) -> ToolAuditHandle:
+        self.starts.append(start)
+        return ToolAuditHandle(tool_call_id=uuid4())
+
+    def finish(self, handle: ToolAuditHandle, finish: ToolAuditFinish) -> None:
+        del handle
+        self.finishes.append(finish)

--- a/tests/runtime/test_audit_contract.py
+++ b/tests/runtime/test_audit_contract.py
@@ -1,0 +1,47 @@
+"""Contract tests for sanitized runtime-step auditing."""
+
+from __future__ import annotations
+
+import uuid
+from typing import Any, cast
+
+import pytest
+from pydantic import ValidationError
+
+from core.runtime import RuntimeAuditOutcome, RuntimeAuditRecord, RuntimeStep
+
+
+def _record(**changes: object) -> RuntimeAuditRecord:
+    values: dict[str, object] = {
+        "agent_id": "developer-agent",
+        "agent_run_id": uuid.uuid4(),
+        "project_id": uuid.uuid4(),
+        "task_id": uuid.uuid4(),
+        "correlation_id": uuid.uuid4(),
+        "iteration": 1,
+        "step": RuntimeStep.PLAN,
+        "outcome": RuntimeAuditOutcome.SUCCEEDED,
+        "duration_ms": 12,
+        "tool_calls": 0,
+        "failures": 0,
+        "reported_tokens": 42,
+    }
+    values.update(changes)
+    return RuntimeAuditRecord.model_validate(values, strict=True)
+
+
+def test_runtime_audit_record_is_immutable_and_rejects_unknown_content() -> None:
+    record = _record()
+
+    with pytest.raises(ValidationError):
+        RuntimeAuditRecord.model_validate(
+            {**record.model_dump(), "prompt": "must never be persisted"}, strict=True
+        )
+    with pytest.raises(ValidationError):
+        cast(Any, record).iteration = 2
+
+
+@pytest.mark.parametrize("field", ["duration_ms", "tool_calls", "failures", "reported_tokens"])
+def test_runtime_audit_counters_cannot_be_negative(field: str) -> None:
+    with pytest.raises(ValidationError):
+        _record(**{field: -1})

--- a/tests/runtime/test_reasoner.py
+++ b/tests/runtime/test_reasoner.py
@@ -110,6 +110,24 @@ def test_missing_usage_is_explicitly_unavailable_and_not_estimated() -> None:
     assert output.usage_available is False
 
 
+def test_oversized_provider_usage_fails_closed_without_retry() -> None:
+    provider = FakeLLMProvider(
+        responses=[
+            _response(
+                '{"summary":"Repository observed.","facts":[],"uncertainties":[]}',
+                LLMUsage(total_tokens=10_000_001),
+            )
+        ]
+    )
+    reasoner = LLMLoopReasoner(provider, system_prompt="Observe safely.", max_step_tokens=128)
+
+    with pytest.raises(RuntimeError) as captured:
+        asyncio.run(reasoner.observe(_task(), ()))
+
+    assert captured.value.code is RuntimeErrorCode.LLM_OUTPUT_INVALID
+    assert len(provider.requests) == 1
+
+
 @pytest.mark.parametrize(
     "content",
     [

--- a/tests/runtime/test_reasoner.py
+++ b/tests/runtime/test_reasoner.py
@@ -1,0 +1,132 @@
+"""Strict one-shot LLM reasoning tests for Phase 13."""
+
+from __future__ import annotations
+
+import asyncio
+from uuid import uuid4
+
+import pytest
+
+from core.llm import LLMModelMetadata, LLMResponse, LLMUsage
+from core.runtime import (
+    LLMLoopReasoner,
+    RuntimeAction,
+    RuntimeError,
+    RuntimeErrorCode,
+    RuntimeObservation,
+    RuntimePlan,
+    RuntimeTask,
+)
+from infrastructure.llm import FakeLLMProvider
+
+
+def _response(content: str, usage: LLMUsage | None = None) -> LLMResponse:
+    return LLMResponse(
+        content=content,
+        finish_reason="stop",
+        usage=usage,
+        model=LLMModelMetadata(provider="fake", model="deterministic-v1"),
+    )
+
+
+def _task() -> RuntimeTask:
+    return RuntimeTask(
+        task_id=uuid4(),
+        objective="Inspect the repository safely.",
+        acceptance_criteria=("The repository was inspected.",),
+    )
+
+
+def _observation() -> RuntimeObservation:
+    return RuntimeObservation(
+        summary="The repository requires inspection.",
+        facts=("README.md is declared as the target.",),
+        uncertainties=(),
+    )
+
+
+def _plan() -> RuntimePlan:
+    return RuntimePlan(
+        objective="Inspect the repository safely.",
+        steps=("Read README.md.",),
+        success_criteria=("The file is observed.",),
+    )
+
+
+def test_decide_decodes_one_closed_tool_action_and_authoritative_usage() -> None:
+    provider = FakeLLMProvider(
+        responses=[
+            _response(
+                '{"action":"TOOL_CALL","tool_name":"fake_read",'
+                '"arguments":{"path":"README.md"},'
+                '"rationale":"Inspect the declared file.","confidence":0.9}',
+                LLMUsage(prompt_tokens=30, completion_tokens=12, total_tokens=42),
+            )
+        ]
+    )
+    reasoner = LLMLoopReasoner(
+        provider,
+        system_prompt="Operate only through structured actions.",
+        max_step_tokens=512,
+    )
+
+    output = asyncio.run(reasoner.decide(_task(), _observation(), _plan(), ()))
+
+    assert output.value.action is RuntimeAction.TOOL_CALL
+    assert output.value.tool_name == "fake_read"
+    assert output.value.arguments == {"path": "README.md"}
+    assert output.reported_tokens == 42
+    assert output.usage_available is True
+    assert len(provider.requests) == 1
+    assert provider.requests[0].max_tokens == 512
+
+
+def test_usage_falls_back_to_reported_prompt_and_completion_sum() -> None:
+    provider = FakeLLMProvider(
+        responses=[
+            _response(
+                '{"summary":"Repository observed.","facts":[],"uncertainties":[]}',
+                LLMUsage(prompt_tokens=7, completion_tokens=5, total_tokens=None),
+            )
+        ]
+    )
+    reasoner = LLMLoopReasoner(provider, system_prompt="Observe safely.", max_step_tokens=128)
+
+    output = asyncio.run(reasoner.observe(_task(), ()))
+
+    assert output.reported_tokens == 12
+    assert output.usage_available is True
+
+
+def test_missing_usage_is_explicitly_unavailable_and_not_estimated() -> None:
+    provider = FakeLLMProvider(
+        responses=[_response('{"summary":"Repository observed.","facts":[],"uncertainties":[]}')]
+    )
+    reasoner = LLMLoopReasoner(provider, system_prompt="Observe safely.", max_step_tokens=128)
+
+    output = asyncio.run(reasoner.observe(_task(), ()))
+
+    assert output.reported_tokens == 0
+    assert output.usage_available is False
+
+
+@pytest.mark.parametrize(
+    "content",
+    [
+        "not-json",
+        '{"action":"COMPLETE","action":"ESCALATE","tool_name":null,'
+        '"arguments":{},"rationale":"duplicate","confidence":0.5}',
+        '{"action":"TOOL_CALL","tool_name":"fake_read","arguments":{},'
+        '"rationale":"extra","confidence":0.5,"unknown":true}',
+    ],
+)
+def test_malformed_decision_fails_closed_without_repair_or_retry(content: str) -> None:
+    provider = FakeLLMProvider(responses=[_response(content), _response(content)])
+    reasoner = LLMLoopReasoner(provider, system_prompt="Decide safely.", max_step_tokens=128)
+
+    with pytest.raises(RuntimeError) as captured:
+        asyncio.run(reasoner.decide(_task(), _observation(), _plan(), ()))
+
+    assert captured.value.code is RuntimeErrorCode.LLM_OUTPUT_INVALID
+    assert "not-json" not in str(captured.value)
+    assert len(provider.requests) == 1

--- a/tests/runtime/test_runtime.py
+++ b/tests/runtime/test_runtime.py
@@ -1,0 +1,288 @@
+"""Scenario tests for the bounded one-agent runtime state machine."""
+
+from __future__ import annotations
+
+import asyncio
+import uuid
+from pathlib import Path
+
+from core.runtime import (
+    AgentRuntime,
+    RuntimeAction,
+    RuntimeDecision,
+    RuntimeError,
+    RuntimeErrorCode,
+    RuntimeLimits,
+    RuntimeObservation,
+    RuntimePlan,
+    RuntimeReport,
+    RuntimeTask,
+    RuntimeTerminalReason,
+    RuntimeTerminalStatus,
+    RuntimeVerification,
+    RuntimeVerificationOutcome,
+)
+from core.tools import ToolErrorCode, ToolExecutionContext, ToolResult, ToolResultStatus
+from tests.runtime.fakes import RecordingExecutor, RecordingRuntimeAudit, ScriptedReasoner
+
+
+def _limits(**changes: object) -> RuntimeLimits:
+    values: dict[str, object] = {
+        "max_iterations": 3,
+        "timeout_seconds": 2.0,
+        "max_tool_calls": 2,
+        "max_failures": 2,
+        "max_tokens": 100,
+        "max_history_entries": 10,
+        "stagnation_window": 3,
+        "max_step_tokens": 20,
+    }
+    values.update(changes)
+    return RuntimeLimits.model_validate(values, strict=True)
+
+
+def _task() -> RuntimeTask:
+    return RuntimeTask(
+        task_id=uuid.uuid4(),
+        objective="Do bounded work",
+        acceptance_criteria=("Done",),
+    )
+
+
+def _context(tmp_path: Path, task: RuntimeTask) -> ToolExecutionContext:
+    return ToolExecutionContext(
+        workspace_root=tmp_path,
+        agent_id="developer-agent",
+        agent_run_id=uuid.uuid4(),
+        project_id=uuid.uuid4(),
+        task_id=task.task_id,
+        declared_tool_ids=frozenset({"read_file"}),
+        correlation_id=uuid.uuid4(),
+    )
+
+
+def _observation() -> RuntimeObservation:
+    return RuntimeObservation(summary="Observed")
+
+
+def _plan() -> RuntimePlan:
+    return RuntimePlan(objective="Act once", steps=("Act",), success_criteria=("Done",))
+
+
+def _decision(action: RuntimeAction = RuntimeAction.COMPLETE) -> RuntimeDecision:
+    return RuntimeDecision(
+        action=action,
+        tool_name="read_file" if action is RuntimeAction.TOOL_CALL else None,
+        arguments={"path": "README.md"} if action is RuntimeAction.TOOL_CALL else {},
+        rationale="Bounded choice",
+        confidence=0.9,
+    )
+
+
+def _report() -> RuntimeReport:
+    return RuntimeReport(summary="Run finished")
+
+
+def _tool_result(
+    status: ToolResultStatus = ToolResultStatus.SUCCEEDED,
+    error_code: ToolErrorCode | None = None,
+) -> ToolResult:
+    return ToolResult(
+        tool_name="read_file",
+        status=status,
+        output={"content": "bounded"} if status is ToolResultStatus.SUCCEEDED else {},
+        error_code=error_code,
+        error_message="Tool did not complete." if error_code is not None else None,
+        duration_ms=1,
+        truncated=False,
+        tool_call_id=uuid.uuid4(),
+    )
+
+
+def test_first_decision_completion_has_no_tool_call(tmp_path: Path) -> None:
+    task = _task()
+    reasoner = ScriptedReasoner([_observation(), _plan(), _decision(), _report()])
+    executor = RecordingExecutor([])
+    audit = RecordingRuntimeAudit()
+
+    result = asyncio.run(
+        AgentRuntime(reasoner, executor, audit, _limits()).run(task, _context(tmp_path, task))
+    )
+
+    assert result.status is RuntimeTerminalStatus.COMPLETED
+    assert result.reason is RuntimeTerminalReason.TASK_COMPLETED
+    assert result.iterations == 1
+    assert result.tool_calls == 0
+    assert executor.calls == 0
+    assert reasoner.calls == ["observe", "plan", "decide", "report"]
+    assert audit.records
+
+
+def test_successful_tool_is_verified_once_then_completed(tmp_path: Path) -> None:
+    task = _task()
+    verification = RuntimeVerification(
+        outcome=RuntimeVerificationOutcome.COMPLETE, summary="Verified", progress_made=True
+    )
+    reasoner = ScriptedReasoner(
+        [_observation(), _plan(), _decision(RuntimeAction.TOOL_CALL), verification, _report()]
+    )
+    tool_result = _tool_result()
+    executor = RecordingExecutor([tool_result])
+
+    result = asyncio.run(
+        AgentRuntime(reasoner, executor, RecordingRuntimeAudit(), _limits()).run(
+            task, _context(tmp_path, task)
+        )
+    )
+
+    assert result.status is RuntimeTerminalStatus.COMPLETED
+    assert result.tool_calls == 1
+    assert executor.calls == 1
+    assert reasoner.calls == ["observe", "plan", "decide", "verify", "report"]
+
+
+def test_tool_budget_stops_before_external_tool_call(tmp_path: Path) -> None:
+    task = _task()
+    reasoner = ScriptedReasoner([_observation(), _plan(), _decision(RuntimeAction.TOOL_CALL)])
+    executor = RecordingExecutor([])
+
+    result = asyncio.run(
+        AgentRuntime(
+            reasoner,
+            executor,
+            RecordingRuntimeAudit(),
+            _limits(max_tool_calls=0),
+        ).run(task, _context(tmp_path, task))
+    )
+
+    assert result.status is RuntimeTerminalStatus.LIMIT_REACHED
+    assert result.reason is RuntimeTerminalReason.MAX_TOOL_CALLS_REACHED
+    assert executor.calls == 0
+
+
+def test_reported_token_budget_stops_before_next_call(tmp_path: Path) -> None:
+    task = _task()
+    reasoner = ScriptedReasoner([_observation()], tokens=5)
+
+    result = asyncio.run(
+        AgentRuntime(
+            reasoner, RecordingExecutor([]), RecordingRuntimeAudit(), _limits(max_tokens=4)
+        ).run(task, _context(tmp_path, task))
+    )
+
+    assert result.status is RuntimeTerminalStatus.LIMIT_REACHED
+    assert result.reason is RuntimeTerminalReason.TOKEN_BUDGET_REACHED
+    assert reasoner.calls == ["observe"]
+
+
+def test_permission_denial_escalates_without_verification(tmp_path: Path) -> None:
+    task = _task()
+    reasoner = ScriptedReasoner(
+        [_observation(), _plan(), _decision(RuntimeAction.TOOL_CALL), _report()]
+    )
+    executor = RecordingExecutor(
+        [_tool_result(ToolResultStatus.DENIED, ToolErrorCode.PERMISSION_DENIED)]
+    )
+
+    result = asyncio.run(
+        AgentRuntime(reasoner, executor, RecordingRuntimeAudit(), _limits()).run(
+            task, _context(tmp_path, task)
+        )
+    )
+
+    assert result.status is RuntimeTerminalStatus.ESCALATED
+    assert result.reason is RuntimeTerminalReason.PERMISSION_DENIED
+    assert reasoner.calls == ["observe", "plan", "decide", "report"]
+    assert executor.calls == 1
+
+
+def test_failed_tool_can_be_corrected_only_by_a_new_iteration(tmp_path: Path) -> None:
+    task = _task()
+    continued = RuntimeVerification(
+        outcome=RuntimeVerificationOutcome.CONTINUE,
+        summary="Try a corrected action",
+        progress_made=True,
+    )
+    completed = RuntimeVerification(
+        outcome=RuntimeVerificationOutcome.COMPLETE,
+        summary="Corrected",
+        progress_made=True,
+    )
+    reasoner = ScriptedReasoner(
+        [
+            _observation(),
+            _plan(),
+            _decision(RuntimeAction.TOOL_CALL),
+            continued,
+            _observation(),
+            _plan(),
+            _decision(RuntimeAction.TOOL_CALL),
+            completed,
+            _report(),
+        ]
+    )
+    executor = RecordingExecutor(
+        [_tool_result(ToolResultStatus.FAILED, ToolErrorCode.TOOL_FAILED), _tool_result()]
+    )
+
+    result = asyncio.run(
+        AgentRuntime(reasoner, executor, RecordingRuntimeAudit(), _limits()).run(
+            task, _context(tmp_path, task)
+        )
+    )
+
+    assert result.status is RuntimeTerminalStatus.COMPLETED
+    assert result.iterations == 2
+    assert result.failures == 1
+    assert executor.calls == 2
+
+
+def test_malformed_reasoning_is_bounded_by_failure_limit(tmp_path: Path) -> None:
+    task = _task()
+    reasoner = ScriptedReasoner(
+        [
+            RuntimeError(RuntimeErrorCode.LLM_OUTPUT_INVALID, "safe"),
+            _report(),
+        ]
+    )
+
+    result = asyncio.run(
+        AgentRuntime(
+            reasoner,
+            RecordingExecutor([]),
+            RecordingRuntimeAudit(),
+            _limits(max_failures=1),
+        ).run(task, _context(tmp_path, task))
+    )
+
+    assert result.status is RuntimeTerminalStatus.FAILED
+    assert result.reason is RuntimeTerminalReason.MAX_FAILURES_REACHED
+    assert result.failures == 1
+    assert reasoner.calls == ["observe", "report"]
+
+
+def test_repeated_progress_shape_escalates_as_stagnation(tmp_path: Path) -> None:
+    task = _task()
+    continued = RuntimeVerification(
+        outcome=RuntimeVerificationOutcome.CONTINUE,
+        summary="No progress",
+        progress_made=False,
+    )
+    script: list[object] = []
+    for _ in range(2):
+        script.extend([_observation(), _plan(), _decision(RuntimeAction.TOOL_CALL), continued])
+    script.append(_report())
+    reasoner = ScriptedReasoner(script)
+
+    result = asyncio.run(
+        AgentRuntime(
+            reasoner,
+            RecordingExecutor([_tool_result(), _tool_result()]),
+            RecordingRuntimeAudit(),
+            _limits(stagnation_window=2),
+        ).run(task, _context(tmp_path, task))
+    )
+
+    assert result.status is RuntimeTerminalStatus.ESCALATED
+    assert result.reason is RuntimeTerminalReason.STAGNATION_DETECTED
+    assert result.iterations == 2

--- a/tests/runtime/test_runtime.py
+++ b/tests/runtime/test_runtime.py
@@ -6,6 +6,8 @@ import asyncio
 import uuid
 from pathlib import Path
 
+import pytest
+
 from core.runtime import (
     AgentRuntime,
     RuntimeAction,
@@ -141,6 +143,36 @@ def test_successful_tool_is_verified_once_then_completed(tmp_path: Path) -> None
     assert reasoner.calls == ["observe", "plan", "decide", "verify", "report"]
 
 
+def test_tool_result_is_audited_before_verification(tmp_path: Path) -> None:
+    task = _task()
+    reasoner = ScriptedReasoner(
+        [
+            _observation(),
+            _plan(),
+            _decision(RuntimeAction.TOOL_CALL),
+            RuntimeVerification(
+                outcome=RuntimeVerificationOutcome.COMPLETE,
+                summary="Verified",
+                progress_made=True,
+            ),
+            _report(),
+        ]
+    )
+    audit = RecordingRuntimeAudit()
+
+    asyncio.run(
+        AgentRuntime(reasoner, RecordingExecutor([_tool_result()]), audit, _limits()).run(
+            task, _context(tmp_path, task)
+        )
+    )
+
+    terminal_steps = [
+        record.step.value for record in audit.records if record.outcome.value != "STARTED"
+    ]
+    assert "OBSERVE_RESULT" in terminal_steps
+    assert terminal_steps.index("OBSERVE_RESULT") < terminal_steps.index("VERIFY")
+
+
 def test_tool_budget_stops_before_external_tool_call(tmp_path: Path) -> None:
     task = _task()
     reasoner = ScriptedReasoner([_observation(), _plan(), _decision(RuntimeAction.TOOL_CALL)])
@@ -173,6 +205,28 @@ def test_reported_token_budget_stops_before_next_call(tmp_path: Path) -> None:
     assert result.status is RuntimeTerminalStatus.LIMIT_REACHED
     assert result.reason is RuntimeTerminalReason.TOKEN_BUDGET_REACHED
     assert reasoner.calls == ["observe"]
+
+
+def test_runtime_rejects_reasoner_with_larger_step_budget() -> None:
+    reasoner = ScriptedReasoner([], max_step_tokens=21)
+
+    with pytest.raises(ValueError, match="step token limit"):
+        AgentRuntime(reasoner, RecordingExecutor([]), RecordingRuntimeAudit(), _limits())
+
+
+def test_mismatched_task_scope_fails_before_audit_or_external_call(tmp_path: Path) -> None:
+    task = _task()
+    context = _context(tmp_path, task).model_copy(update={"task_id": uuid.uuid4()})
+    reasoner = ScriptedReasoner([])
+    audit = RecordingRuntimeAudit()
+
+    with pytest.raises(RuntimeError) as error:
+        asyncio.run(
+            AgentRuntime(reasoner, RecordingExecutor([]), audit, _limits()).run(task, context)
+        )
+    assert error.value.code is RuntimeErrorCode.INVALID_REQUEST
+    assert reasoner.calls == []
+    assert audit.records == []
 
 
 def test_permission_denial_escalates_without_verification(tmp_path: Path) -> None:
@@ -225,16 +279,21 @@ def test_failed_tool_can_be_corrected_only_by_a_new_iteration(tmp_path: Path) ->
         [_tool_result(ToolResultStatus.FAILED, ToolErrorCode.TOOL_FAILED), _tool_result()]
     )
 
+    audit = RecordingRuntimeAudit()
     result = asyncio.run(
-        AgentRuntime(reasoner, executor, RecordingRuntimeAudit(), _limits()).run(
-            task, _context(tmp_path, task)
-        )
+        AgentRuntime(reasoner, executor, audit, _limits()).run(task, _context(tmp_path, task))
     )
 
     assert result.status is RuntimeTerminalStatus.COMPLETED
     assert result.iterations == 2
     assert result.failures == 1
     assert executor.calls == 2
+    failed_action = next(
+        record
+        for record in audit.records
+        if record.step.value == "ACT" and record.outcome.value == "FAILED"
+    )
+    assert failed_action.error_code is ToolErrorCode.TOOL_FAILED
 
 
 def test_malformed_reasoning_is_bounded_by_failure_limit(tmp_path: Path) -> None:
@@ -259,6 +318,70 @@ def test_malformed_reasoning_is_bounded_by_failure_limit(tmp_path: Path) -> None
     assert result.reason is RuntimeTerminalReason.MAX_FAILURES_REACHED
     assert result.failures == 1
     assert reasoner.calls == ["observe", "report"]
+
+
+def test_malformed_verification_is_bounded_by_failure_limit(tmp_path: Path) -> None:
+    task = _task()
+    reasoner = ScriptedReasoner(
+        [
+            _observation(),
+            _plan(),
+            _decision(RuntimeAction.TOOL_CALL),
+            RuntimeError(RuntimeErrorCode.LLM_OUTPUT_INVALID, "safe"),
+            _report(),
+        ]
+    )
+
+    result = asyncio.run(
+        AgentRuntime(
+            reasoner,
+            RecordingExecutor([_tool_result()]),
+            RecordingRuntimeAudit(),
+            _limits(max_failures=1),
+        ).run(task, _context(tmp_path, task))
+    )
+
+    assert result.status is RuntimeTerminalStatus.FAILED
+    assert result.reason is RuntimeTerminalReason.MAX_FAILURES_REACHED
+    assert result.failures == 1
+
+
+def test_report_failure_returns_sanitized_terminal_failure(tmp_path: Path) -> None:
+    task = _task()
+    reasoner = ScriptedReasoner(
+        [
+            _observation(),
+            _plan(),
+            _decision(),
+            RuntimeError(RuntimeErrorCode.LLM_OUTPUT_INVALID, "secret-report-marker"),
+        ]
+    )
+    audit = RecordingRuntimeAudit()
+
+    result = asyncio.run(
+        AgentRuntime(reasoner, RecordingExecutor([]), audit, _limits()).run(
+            task, _context(tmp_path, task)
+        )
+    )
+
+    assert result.status is RuntimeTerminalStatus.FAILED
+    assert result.reason is RuntimeTerminalReason.INVALID_LLM_OUTPUT
+    assert "secret-report-marker" not in repr(result)
+    assert audit.records[-1].reason is RuntimeTerminalReason.INVALID_LLM_OUTPUT
+
+
+def test_report_cannot_cross_known_token_budget(tmp_path: Path) -> None:
+    task = _task()
+    reasoner = ScriptedReasoner([_observation(), _plan(), _decision(), _report()], tokens=1)
+
+    result = asyncio.run(
+        AgentRuntime(
+            reasoner, RecordingExecutor([]), RecordingRuntimeAudit(), _limits(max_tokens=4)
+        ).run(task, _context(tmp_path, task))
+    )
+
+    assert result.status is RuntimeTerminalStatus.LIMIT_REACHED
+    assert result.reason is RuntimeTerminalReason.TOKEN_BUDGET_REACHED
 
 
 def test_repeated_progress_shape_escalates_as_stagnation(tmp_path: Path) -> None:

--- a/tests/runtime/test_runtime_integration.py
+++ b/tests/runtime/test_runtime_integration.py
@@ -1,0 +1,95 @@
+"""Production-boundary integration test for one complete bounded loop."""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from uuid import uuid4
+
+from core.llm import LLMModelMetadata, LLMResponse, LLMUsage
+from core.permissions import PermissionEngine, PermissionOutcome, PermissionReasonCode
+from core.runtime import (
+    AgentRuntime,
+    LLMLoopReasoner,
+    RuntimeLimits,
+    RuntimeTask,
+    RuntimeTerminalStatus,
+)
+from core.tools import ToolExecutionContext, ToolExecutor, ToolRegistry
+from infrastructure.llm import FakeLLMProvider
+from tests.permissions.fakes import RecordingPermissionAudit, RecordingPolicy
+from tests.runtime.fakes import RecordingRuntimeAudit, RecordingToolAudit
+from tests.tools.fakes import FakeTool
+
+
+def _response(content: str) -> LLMResponse:
+    return LLMResponse(
+        content=content,
+        finish_reason="stop",
+        usage=LLMUsage(prompt_tokens=1, completion_tokens=1, total_tokens=2),
+        model=LLMModelMetadata(provider="fake", model="deterministic-v1"),
+    )
+
+
+def test_real_reasoner_and_executor_complete_without_duplicate_calls(tmp_path: Path) -> None:
+    provider = FakeLLMProvider(
+        responses=[
+            _response('{"summary":"Observed","facts":[],"uncertainties":[]}'),
+            _response('{"objective":"Read once","steps":["Read"],"success_criteria":["Observed"]}'),
+            _response(
+                '{"action":"TOOL_CALL","tool_name":"fake_read",'
+                '"arguments":{"path":"README.md"},'
+                '"rationale":"Read declared target","confidence":0.9}'
+            ),
+            _response('{"outcome":"COMPLETE","summary":"Verified","progress_made":true}'),
+            _response('{"summary":"Finished","details":[],"next_actions":[]}'),
+        ]
+    )
+    reasoner = LLMLoopReasoner(provider, system_prompt="Operate safely.", max_step_tokens=32)
+    permission_policy = RecordingPolicy(PermissionOutcome.ALLOW, PermissionReasonCode.GRANTED)
+    permission_audit = RecordingPermissionAudit()
+    tool_audit = RecordingToolAudit()
+    FakeTool.calls = 0
+    executor = ToolExecutor(
+        ToolRegistry([FakeTool()]),
+        tool_audit,
+        PermissionEngine(permission_policy, permission_audit),
+    )
+    task_id = uuid4()
+    task = RuntimeTask(
+        task_id=task_id,
+        objective="Read one declared resource.",
+        acceptance_criteria=("The resource is observed.",),
+    )
+    context = ToolExecutionContext(
+        workspace_root=tmp_path,
+        agent_id="developer-agent",
+        agent_run_id=uuid4(),
+        project_id=uuid4(),
+        task_id=task_id,
+        declared_tool_ids=frozenset({"fake_read"}),
+        correlation_id=uuid4(),
+    )
+    limits = RuntimeLimits(
+        max_iterations=2,
+        timeout_seconds=2,
+        max_tool_calls=1,
+        max_failures=1,
+        max_tokens=100,
+        max_history_entries=4,
+        stagnation_window=2,
+        max_step_tokens=32,
+    )
+
+    result = asyncio.run(
+        AgentRuntime(reasoner, executor, RecordingRuntimeAudit(), limits).run(task, context)
+    )
+
+    assert result.status is RuntimeTerminalStatus.COMPLETED
+    assert len(provider.requests) == 5
+    assert all(request.max_tokens == 32 for request in provider.requests)
+    assert FakeTool.calls == 1
+    assert len(permission_policy.requests) == 1
+    assert len(permission_audit.decisions) == 1
+    assert len(tool_audit.starts) == 1
+    assert len(tool_audit.finishes) == 1

--- a/tests/runtime/test_runtime_safety.py
+++ b/tests/runtime/test_runtime_safety.py
@@ -1,0 +1,177 @@
+"""Adversarial timeout, cancellation, audit, and secrecy tests."""
+
+from __future__ import annotations
+
+import asyncio
+import uuid
+from pathlib import Path
+from typing import Never, cast
+
+from core.runtime import (
+    AgentRuntime,
+    LoopReasoner,
+    RuntimeAuditOutcome,
+    RuntimeAuditRecord,
+    RuntimeError,
+    RuntimeErrorCode,
+    RuntimeLimits,
+    RuntimeReport,
+    RuntimeTask,
+    RuntimeTerminalReason,
+    RuntimeTerminalStatus,
+)
+from core.tools import ToolExecutionContext
+from tests.runtime.fakes import RecordingExecutor, RecordingRuntimeAudit, ScriptedReasoner
+
+
+class BlockingReasoner:
+    def __init__(self) -> None:
+        self.started = asyncio.Event()
+        self.cancelled = False
+        self.close_calls = 0
+
+    async def observe(self, task: object, history: object) -> Never:
+        self.started.set()
+        try:
+            await asyncio.Future()
+        except asyncio.CancelledError:
+            self.cancelled = True
+            raise
+        raise AssertionError("blocking future unexpectedly completed")
+
+    def close(self) -> None:
+        self.close_calls += 1
+
+
+class FailingAudit:
+    def __init__(self) -> None:
+        self.calls = 0
+
+    def record(self, record: RuntimeAuditRecord) -> None:
+        self.calls += 1
+        raise RuntimeError(RuntimeErrorCode.AUDIT_FAILED, "Runtime audit is unavailable.")
+
+
+def _limits(timeout: float = 1.0) -> RuntimeLimits:
+    return RuntimeLimits(
+        max_iterations=2,
+        timeout_seconds=timeout,
+        max_tool_calls=1,
+        max_failures=1,
+        max_tokens=100,
+        max_history_entries=4,
+        stagnation_window=2,
+        max_step_tokens=20,
+    )
+
+
+def _scope(tmp_path: Path, marker: str = "bounded") -> tuple[RuntimeTask, ToolExecutionContext]:
+    task_id = uuid.uuid4()
+    task = RuntimeTask(
+        task_id=task_id,
+        objective=f"Objective {marker}",
+        acceptance_criteria=(f"Criterion {marker}",),
+    )
+    context = ToolExecutionContext(
+        workspace_root=tmp_path,
+        agent_id="developer-agent",
+        agent_run_id=uuid.uuid4(),
+        project_id=uuid.uuid4(),
+        task_id=task_id,
+        declared_tool_ids=frozenset({"read_file"}),
+        correlation_id=uuid.uuid4(),
+    )
+    return task, context
+
+
+def test_global_timeout_cancels_work_and_returns_bounded_result(tmp_path: Path) -> None:
+    task, context = _scope(tmp_path, "secret-timeout-marker")
+    reasoner = BlockingReasoner()
+    audit = RecordingRuntimeAudit()
+
+    result = asyncio.run(
+        AgentRuntime(
+            cast(LoopReasoner, reasoner),
+            RecordingExecutor([]),
+            audit,
+            _limits(0.01),
+        ).run(task, context)
+    )
+
+    assert result.status is RuntimeTerminalStatus.TIMED_OUT
+    assert result.reason is RuntimeTerminalReason.GLOBAL_TIMEOUT
+    assert reasoner.cancelled is True
+    assert reasoner.close_calls == 0
+    assert "secret-timeout-marker" not in repr(result)
+    assert audit.records[-1].outcome is RuntimeAuditOutcome.TIMED_OUT
+
+
+def test_cancellation_is_propagated_after_terminal_audit(tmp_path: Path) -> None:
+    async def scenario() -> tuple[BlockingReasoner, RecordingRuntimeAudit]:
+        task, context = _scope(tmp_path)
+        reasoner = BlockingReasoner()
+        audit = RecordingRuntimeAudit()
+        running = asyncio.create_task(
+            AgentRuntime(
+                cast(LoopReasoner, reasoner), RecordingExecutor([]), audit, _limits()
+            ).run(task, context)
+        )
+        await reasoner.started.wait()
+        running.cancel()
+        try:
+            await running
+        except asyncio.CancelledError:
+            pass
+        else:
+            raise AssertionError("cancellation was swallowed")
+        return reasoner, audit
+
+    reasoner, audit = asyncio.run(scenario())
+    assert reasoner.cancelled is True
+    assert reasoner.close_calls == 0
+    assert audit.records[-1].outcome is RuntimeAuditOutcome.CANCELLED
+    assert audit.records[-1].reason is RuntimeTerminalReason.CANCELLED
+
+
+def test_audit_start_failure_prevents_reasoner_call(tmp_path: Path) -> None:
+    task, context = _scope(tmp_path)
+    reasoner = BlockingReasoner()
+    audit = FailingAudit()
+
+    result = asyncio.run(
+        AgentRuntime(
+            cast(LoopReasoner, reasoner), RecordingExecutor([]), audit, _limits()
+        ).run(task, context)
+    )
+
+    assert result.status is RuntimeTerminalStatus.FAILED
+    assert result.reason is RuntimeTerminalReason.AUDIT_FAILED
+    assert reasoner.started.is_set() is False
+    assert audit.calls == 1
+
+
+def test_failure_history_and_audit_are_bounded_and_secret_free(tmp_path: Path) -> None:
+    marker = "secret-provider-failure-marker"
+    task, context = _scope(tmp_path, marker)
+    reasoner = ScriptedReasoner(
+        [
+            RuntimeError(RuntimeErrorCode.LLM_FAILED, marker),
+            RuntimeError(RuntimeErrorCode.LLM_FAILED, marker),
+            RuntimeError(RuntimeErrorCode.LLM_FAILED, marker),
+            RuntimeReport(summary="Safe terminal report"),
+        ]
+    )
+    audit = RecordingRuntimeAudit()
+    limits = _limits().model_copy(
+        update={"max_iterations": 3, "max_failures": 3, "max_history_entries": 2}
+    )
+
+    result = asyncio.run(
+        AgentRuntime(reasoner, RecordingExecutor([]), audit, limits).run(task, context)
+    )
+
+    assert result.status is RuntimeTerminalStatus.FAILED
+    assert len(result.history) == 2
+    assert result.report is None
+    assert marker not in repr(result)
+    assert marker not in repr(audit.records)

--- a/tests/runtime/test_runtime_safety.py
+++ b/tests/runtime/test_runtime_safety.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import uuid
+from collections.abc import Mapping
 from pathlib import Path
 from typing import Never, cast
 
@@ -20,7 +21,7 @@ from core.runtime import (
     RuntimeTerminalReason,
     RuntimeTerminalStatus,
 )
-from core.tools import ToolExecutionContext
+from core.tools import ToolAuditError, ToolErrorCode, ToolExecutionContext, ToolResult
 from tests.runtime.fakes import RecordingExecutor, RecordingRuntimeAudit, ScriptedReasoner
 
 
@@ -29,6 +30,7 @@ class BlockingReasoner:
         self.started = asyncio.Event()
         self.cancelled = False
         self.close_calls = 0
+        self.max_step_tokens = 20
 
     async def observe(self, task: object, history: object) -> Never:
         self.started.set()
@@ -50,6 +52,20 @@ class FailingAudit:
     def record(self, record: RuntimeAuditRecord) -> None:
         self.calls += 1
         raise RuntimeError(RuntimeErrorCode.AUDIT_FAILED, "Runtime audit is unavailable.")
+
+    def record_cancellation(self, record: RuntimeAuditRecord) -> None:
+        self.record(record)
+
+
+class FailingToolAuditExecutor(RecordingExecutor):
+    async def execute(
+        self,
+        tool_name: str,
+        arguments: Mapping[str, object],
+        context: ToolExecutionContext,
+    ) -> ToolResult:
+        del tool_name, arguments, context
+        raise ToolAuditError(ToolErrorCode.AUDIT_FAILED, "secret-tool-audit-marker")
 
 
 def _limits(timeout: float = 1.0) -> RuntimeLimits:
@@ -112,9 +128,9 @@ def test_cancellation_is_propagated_after_terminal_audit(tmp_path: Path) -> None
         reasoner = BlockingReasoner()
         audit = RecordingRuntimeAudit()
         running = asyncio.create_task(
-            AgentRuntime(
-                cast(LoopReasoner, reasoner), RecordingExecutor([]), audit, _limits()
-            ).run(task, context)
+            AgentRuntime(cast(LoopReasoner, reasoner), RecordingExecutor([]), audit, _limits()).run(
+                task, context
+            )
         )
         await reasoner.started.wait()
         running.cancel()
@@ -139,9 +155,9 @@ def test_audit_start_failure_prevents_reasoner_call(tmp_path: Path) -> None:
     audit = FailingAudit()
 
     result = asyncio.run(
-        AgentRuntime(
-            cast(LoopReasoner, reasoner), RecordingExecutor([]), audit, _limits()
-        ).run(task, context)
+        AgentRuntime(cast(LoopReasoner, reasoner), RecordingExecutor([]), audit, _limits()).run(
+            task, context
+        )
     )
 
     assert result.status is RuntimeTerminalStatus.FAILED
@@ -175,3 +191,43 @@ def test_failure_history_and_audit_are_bounded_and_secret_free(tmp_path: Path) -
     assert result.report is None
     assert marker not in repr(result)
     assert marker not in repr(audit.records)
+
+
+def test_tool_audit_failure_returns_sanitized_runtime_failure(tmp_path: Path) -> None:
+    from core.runtime import RuntimeAction, RuntimeDecision, RuntimeObservation, RuntimePlan
+
+    task, context = _scope(tmp_path)
+    reasoner = ScriptedReasoner(
+        [
+            RuntimeObservation(summary="Observed"),
+            RuntimePlan(objective="Act", steps=("Act",), success_criteria=("Done",)),
+            RuntimeDecision(
+                action=RuntimeAction.TOOL_CALL,
+                tool_name="read_file",
+                arguments={"path": "README.md"},
+                rationale="Act once",
+                confidence=0.8,
+            ),
+        ]
+    )
+
+    audit = RecordingRuntimeAudit()
+    result = asyncio.run(
+        AgentRuntime(
+            reasoner,
+            FailingToolAuditExecutor([]),
+            audit,
+            _limits(),
+        ).run(task, context)
+    )
+
+    assert result.status is RuntimeTerminalStatus.FAILED
+    assert result.reason is RuntimeTerminalReason.AUDIT_FAILED
+    assert "secret-tool-audit-marker" not in repr(result)
+    failed_steps = [
+        (record.step.value, record.outcome.value, record.error_code)
+        for record in audit.records
+        if record.outcome is RuntimeAuditOutcome.FAILED
+    ]
+    assert ("ACT", "FAILED", ToolErrorCode.AUDIT_FAILED) in failed_steps
+    assert ("OBSERVE_RESULT", "FAILED", ToolErrorCode.AUDIT_FAILED) in failed_steps

--- a/tests/runtime/test_stagnation.py
+++ b/tests/runtime/test_stagnation.py
@@ -69,19 +69,31 @@ def test_verification_outcome_and_error_code_are_fingerprinted() -> None:
     detector = StagnationDetector(window=2)
     decision = _decision()
 
-    assert detector.observe(
-        decision, _verification(RuntimeVerificationOutcome.CONTINUE), ToolErrorCode.TOOL_FAILED
-    ) is False
-    assert detector.observe(
-        decision, _verification(RuntimeVerificationOutcome.COMPLETE), ToolErrorCode.TOOL_FAILED
-    ) is False
-    assert detector.observe(
-        decision,
-        _verification(RuntimeVerificationOutcome.COMPLETE),
-        ToolErrorCode.INVALID_INPUT,
-    ) is False
-    assert detector.observe(
-        decision,
-        _verification(RuntimeVerificationOutcome.COMPLETE),
-        ToolErrorCode.INVALID_INPUT,
-    ) is True
+    assert (
+        detector.observe(
+            decision, _verification(RuntimeVerificationOutcome.CONTINUE), ToolErrorCode.TOOL_FAILED
+        )
+        is False
+    )
+    assert (
+        detector.observe(
+            decision, _verification(RuntimeVerificationOutcome.COMPLETE), ToolErrorCode.TOOL_FAILED
+        )
+        is False
+    )
+    assert (
+        detector.observe(
+            decision,
+            _verification(RuntimeVerificationOutcome.COMPLETE),
+            ToolErrorCode.INVALID_INPUT,
+        )
+        is False
+    )
+    assert (
+        detector.observe(
+            decision,
+            _verification(RuntimeVerificationOutcome.COMPLETE),
+            ToolErrorCode.INVALID_INPUT,
+        )
+        is True
+    )

--- a/tests/runtime/test_stagnation.py
+++ b/tests/runtime/test_stagnation.py
@@ -1,0 +1,87 @@
+"""Tests for deterministic, secret-free stagnation detection."""
+
+from __future__ import annotations
+
+from core.runtime import (
+    RuntimeAction,
+    RuntimeDecision,
+    RuntimeVerification,
+    RuntimeVerificationOutcome,
+    StagnationDetector,
+)
+from core.tools import ToolErrorCode
+
+
+def _decision(**changes: object) -> RuntimeDecision:
+    values: dict[str, object] = {
+        "action": RuntimeAction.TOOL_CALL,
+        "tool_name": "read_file",
+        "arguments": {"path": "secret-a.txt", "options": {"limit": 10}},
+        "rationale": "secret rationale",
+        "confidence": 0.8,
+    }
+    values.update(changes)
+    return RuntimeDecision.model_validate(values, strict=True)
+
+
+def _verification(outcome: RuntimeVerificationOutcome) -> RuntimeVerification:
+    return RuntimeVerification(
+        outcome=outcome,
+        summary="secret tool output",
+        progress_made=False,
+    )
+
+
+def test_identical_fingerprints_trigger_only_when_window_is_full() -> None:
+    detector = StagnationDetector(window=3)
+    decision = _decision()
+    verification = _verification(RuntimeVerificationOutcome.CONTINUE)
+
+    assert detector.observe(decision, verification) is False
+    assert detector.observe(decision, verification) is False
+    assert detector.observe(decision, verification) is True
+    assert detector.size == 3
+
+
+def test_argument_values_do_not_change_shape_or_leak_into_state() -> None:
+    detector = StagnationDetector(window=2)
+
+    assert detector.observe(_decision(), None) is False
+    assert detector.observe(
+        _decision(arguments={"path": "different-secret.txt", "options": {"limit": 999}}), None
+    )
+    retained = repr(detector)
+    assert "secret" not in retained
+    assert "different" not in retained
+    assert "rationale" not in retained
+
+
+def test_changed_allowlisted_shape_resets_consecutive_run() -> None:
+    detector = StagnationDetector(window=2)
+    verification = _verification(RuntimeVerificationOutcome.CONTINUE)
+
+    assert detector.observe(_decision(), verification) is False
+    assert detector.observe(_decision(arguments={"path": ["a"]}), verification) is False
+    assert detector.observe(_decision(arguments={"path": ["b"]}), verification) is True
+
+
+def test_verification_outcome_and_error_code_are_fingerprinted() -> None:
+    detector = StagnationDetector(window=2)
+    decision = _decision()
+
+    assert detector.observe(
+        decision, _verification(RuntimeVerificationOutcome.CONTINUE), ToolErrorCode.TOOL_FAILED
+    ) is False
+    assert detector.observe(
+        decision, _verification(RuntimeVerificationOutcome.COMPLETE), ToolErrorCode.TOOL_FAILED
+    ) is False
+    assert detector.observe(
+        decision,
+        _verification(RuntimeVerificationOutcome.COMPLETE),
+        ToolErrorCode.INVALID_INPUT,
+    ) is False
+    assert detector.observe(
+        decision,
+        _verification(RuntimeVerificationOutcome.COMPLETE),
+        ToolErrorCode.INVALID_INPUT,
+    ) is True

--- a/tests/runtime/test_types.py
+++ b/tests/runtime/test_types.py
@@ -1,0 +1,135 @@
+"""Behavioral contracts for bounded immutable loop values."""
+
+from __future__ import annotations
+
+from uuid import uuid4
+
+import pytest
+from pydantic import ValidationError
+
+from core.runtime import (
+    ReasonerOutput,
+    RuntimeAction,
+    RuntimeDecision,
+    RuntimeLimits,
+    RuntimeTask,
+    RuntimeTerminalReason,
+    RuntimeTerminalStatus,
+)
+
+
+def _limits(**overrides: int | float) -> RuntimeLimits:
+    values: dict[str, int | float] = {
+        "max_iterations": 5,
+        "timeout_seconds": 30.0,
+        "max_tool_calls": 5,
+        "max_failures": 2,
+        "max_tokens": 10_000,
+        "max_history_entries": 20,
+        "stagnation_window": 3,
+        "max_step_tokens": 1_024,
+    }
+    values.update(overrides)
+    return RuntimeLimits(**values)
+
+
+def test_limits_reject_invalid_cross_field_and_resource_bounds() -> None:
+    with pytest.raises(ValidationError):
+        _limits(max_iterations=0)
+    with pytest.raises(ValidationError):
+        _limits(timeout_seconds=float("inf"))
+    with pytest.raises(ValidationError):
+        _limits(max_history_entries=2, stagnation_window=3)
+    with pytest.raises(ValidationError):
+        _limits(max_step_tokens=131_073)
+
+
+def test_task_is_bounded_frozen_and_detached_from_mutable_criteria() -> None:
+    criteria = ["Tests pass.", "No hidden failures."]
+    task = RuntimeTask(
+        task_id=uuid4(),
+        objective="Implement the bounded runtime.",
+        acceptance_criteria=criteria,
+    )
+    criteria.append("Mutated later.")
+
+    assert task.acceptance_criteria == ("Tests pass.", "No hidden failures.")
+    with pytest.raises(ValidationError):
+        RuntimeTask(
+            task_id=uuid4(),
+            objective=" ",
+            acceptance_criteria=("Valid criterion.",),
+        )
+    with pytest.raises(ValidationError):
+        task.objective = "changed"  # type: ignore[misc]
+
+
+def test_decision_enforces_action_specific_tool_fields_and_copies_arguments() -> None:
+    arguments: dict[str, object] = {"path": "README.md", "options": ["safe"]}
+    decision = RuntimeDecision(
+        action=RuntimeAction.TOOL_CALL,
+        tool_name="fake_read",
+        arguments=arguments,
+        rationale="Inspect the bounded target.",
+        confidence=0.8,
+    )
+    arguments["path"] = "changed"
+    nested = arguments["options"]
+    assert isinstance(nested, list)
+    nested.append("changed")
+
+    assert decision.arguments == {"path": "README.md", "options": ["safe"]}
+    with pytest.raises(ValidationError):
+        RuntimeDecision(
+            action=RuntimeAction.COMPLETE,
+            tool_name="fake_read",
+            arguments={},
+            rationale="Invalid terminal decision.",
+            confidence=0.8,
+        )
+    with pytest.raises(ValidationError):
+        RuntimeDecision(
+            action=RuntimeAction.TOOL_CALL,
+            tool_name=None,
+            arguments={},
+            rationale="Missing tool.",
+            confidence=0.8,
+        )
+
+
+def test_reasoner_output_requires_consistent_reported_usage() -> None:
+    decision = RuntimeDecision(
+        action=RuntimeAction.COMPLETE,
+        tool_name=None,
+        arguments={},
+        rationale="Acceptance criteria are satisfied.",
+        confidence=0.9,
+    )
+    output: ReasonerOutput[RuntimeDecision] = ReasonerOutput(
+        value=decision,
+        reported_tokens=42,
+        usage_available=True,
+    )
+
+    assert output.value is decision
+    assert output.reported_tokens == 42
+    with pytest.raises(ValidationError):
+        ReasonerOutput(value=decision, reported_tokens=1, usage_available=False)
+
+
+@pytest.mark.parametrize(
+    ("status", "reason"),
+    [
+        (RuntimeTerminalStatus.COMPLETED, RuntimeTerminalReason.TASK_COMPLETED),
+        (RuntimeTerminalStatus.ESCALATED, RuntimeTerminalReason.HUMAN_APPROVAL_REQUIRED),
+        (RuntimeTerminalStatus.LIMIT_REACHED, RuntimeTerminalReason.MAX_ITERATIONS_REACHED),
+        (RuntimeTerminalStatus.TIMED_OUT, RuntimeTerminalReason.GLOBAL_TIMEOUT),
+        (RuntimeTerminalStatus.FAILED, RuntimeTerminalReason.MAX_FAILURES_REACHED),
+    ],
+)
+def test_terminal_status_reason_pairs_are_closed_and_truthful(
+    status: RuntimeTerminalStatus,
+    reason: RuntimeTerminalReason,
+) -> None:
+    assert status.accepts(reason)
+    assert not status.accepts(RuntimeTerminalReason.CANCELLED)

--- a/tests/runtime/test_types.py
+++ b/tests/runtime/test_types.py
@@ -115,6 +115,8 @@ def test_reasoner_output_requires_consistent_reported_usage() -> None:
     assert output.reported_tokens == 42
     with pytest.raises(ValidationError):
         ReasonerOutput(value=decision, reported_tokens=1, usage_available=False)
+    with pytest.raises(ValidationError):
+        ReasonerOutput(value=decision, reported_tokens=10_000_001, usage_available=True)
 
 
 @pytest.mark.parametrize(

--- a/tests/tools/test_command_tool.py
+++ b/tests/tools/test_command_tool.py
@@ -114,7 +114,7 @@ def test_input_rejects_unknown_profiles_and_command_control_fields(
         RunCommandProfileInput.model_validate(values, strict=True)
 
 
-def test_tool_declares_high_risk_shell_permission(tmp_path: Path) -> None:
+def test_tool_declares_high_risk_shell_and_test_permissions(tmp_path: Path) -> None:
     spec = _spec(CommandProfileId.PYTEST, tmp_path)
     result = CommandResult(
         profile_id=CommandProfileId.PYTEST,
@@ -130,7 +130,9 @@ def test_tool_declares_high_risk_shell_permission(tmp_path: Path) -> None:
     tool = RunCommandProfileTool(RecordingPolicy(spec), RecordingRunner(result))
 
     assert tool.name == "run_command_profile"
-    assert tool.required_permissions == frozenset({Permission.SHELL_EXECUTE})
+    assert tool.required_permissions == frozenset(
+        {Permission.SHELL_EXECUTE, Permission.TESTS_EXECUTE}
+    )
     assert tool.risk_level is ToolRiskLevel.HIGH
     assert tool.timeout_seconds == 30.0
 

--- a/tests/tools/test_default_registry.py
+++ b/tests/tools/test_default_registry.py
@@ -86,7 +86,7 @@ def test_default_registry_definitions_are_permissioned_and_bounded(tmp_path: Pat
     assert definitions["patch_file"].risk_level is ToolRiskLevel.MEDIUM
     assert definitions["delete_file"].risk_level is ToolRiskLevel.HIGH
     assert definitions["run_command_profile"].required_permissions == frozenset(
-        {Permission.SHELL_EXECUTE}
+        {Permission.SHELL_EXECUTE, Permission.TESTS_EXECUTE}
     )
     assert definitions["run_command_profile"].risk_level is ToolRiskLevel.HIGH
     assert all(0 < definition.timeout_seconds <= 30 for definition in definitions.values())

--- a/tests/tools/test_write_tools.py
+++ b/tests/tools/test_write_tools.py
@@ -22,6 +22,7 @@ from infrastructure.tools.write import (
     DeleteFileTool,
     PatchFileInput,
     PatchFileTool,
+    PatchOperation,
     WriteFileInput,
     WriteFileTool,
 )
@@ -210,3 +211,15 @@ def test_write_tools_delegate_to_managed_transaction_boundary(tmp_path: Path) ->
     assert (root / "created.py").read_text(encoding="utf-8") == "created\n"
     assert (root / "patch.py").read_text(encoding="utf-8") == "new\n"
     assert not (root / "delete.py").exists()
+
+
+def test_patch_input_accepts_copied_json_array_from_structured_tool_call() -> None:
+    source = [{"old_text": "before", "new_text": "after"}]
+
+    parsed = PatchFileInput.model_validate(
+        {"path": "module.py", "operations": source},
+        strict=True,
+    )
+    source[0]["new_text"] = "mutated"
+
+    assert parsed.operations == (PatchOperation(old_text="before", new_text="after"),)


### PR DESCRIPTION
## Summary

This pull request now contains the reviewed delivery for both Phase 13 and Phase 14.

### Phase 13 — Bounded Loop Engineering V1

- add immutable single-agent loop contracts and a provider-neutral reasoner
- execute bounded observe-plan-decide-act-verify-report loops through the secure ToolExecutor
- enforce iteration, timeout, failure, tool-call, token, history, stagnation, and cancellation limits
- append sanitized PostgreSQL runtime audit events

### Phase 14 — Bounded Developer Agent

- compose a fail-closed Developer role over the Phase 13 runtime
- select repository-owned skills within permission, tool, count, and byte limits
- use only existing audited transactional tools and fixed command profiles
- retain bounded metadata-only test evidence and deterministic reports
- prevent arbitrary shell, merge, push, deployment, permission mutation, and self-review

## Why the scope changed

PR #15 originally delivered Phase 14 into the phase-13/loop-engineering-v1 branch and has already been merged. Consequently, this pull request head now contains both Phase 13 and Phase 14. The title and description have been corrected to match the actual 22-commit diff.

No new implementation was added during this stack repair.

## Verification history

- Phase 13: 881 tests passed; Ruff, mypy strict, format, Docker, PostgreSQL, Alembic, and API health checks passed
- Phase 14: 931 tests passed; Ruff, mypy strict, format, Docker, PostgreSQL, Alembic, and API health checks passed
- both phases received independent merge-readiness review

## Stack

- based on phase-11/secure-command-runner
- Phase 12 remains deliberately unimplemented
- after PR #13 lands on main, retarget this pull request to main before merging
- Phase 15 PR #16 follows this pull request
