### PR TITLE
feat(workflow): add bounded developer-reviewer workflow

### DIFF
--- a/.superpowers/sdd/2026-08-30-phase-16-developer-reviewer-workflow/final-fix-report.md
+++ b/.superpowers/sdd/2026-08-30-phase-16-developer-reviewer-workflow/final-fix-report.md
@@ -1,0 +1,381 @@
+# Phase 16 Developer–Reviewer Workflow Final Fix Report
+
+Date: 2026-08-31
+Branch: `phase-16/developer-reviewer-workflow`
+Reviewed range: `bfb2dcc..2709019`
+Requested commit: `fix(workflow): close Phase 16 safety gaps`
+
+## Outcome
+
+All seven final-review findings are fixed in one wave. The implementation preserves caller-owned
+resources, bounded data, exact correlation, append-only audit history, and the Phase 16-only scope.
+No retry, fallback, QA, Security, generic workflow engine, Phase 17 work, migration, or schema
+change was introduced.
+
+The resumed partial-state baseline passed before further edits:
+
+```text
+TEST_POSTGRES_PORT=55432 .venv/bin/pytest tests/workflows tests/reviewer tests/tasks \
+  tests/database/test_task_state_machine.py tests/database/test_append_only.py -q
+Result: exit 0
+```
+
+Local PostgreSQL access was unavailable inside the filesystem sandbox, so PostgreSQL-backed test
+commands were rerun with the existing local-database permission. No test was replaced by an
+in-memory database, `create_all`, or a mock persistence substitute.
+
+## Finding 1 — stale task overwrite
+
+### RED
+
+The new independent-session race test used real PostgreSQL and
+`sessionmaker(expire_on_commit=False)`. One case moved the task to `WAITING_HUMAN` during the
+Developer call; the other moved it to `CANCELLED` during the Reviewer call.
+
+```text
+TEST_POSTGRES_PORT=55432 .venv/bin/pytest tests/workflows/test_safety.py -q \
+  -k concurrent_human_transition_wins
+Result: FF; 2 failed
+Failure: both stale workflow checkpoints completed instead of raising WorkflowError.
+```
+
+### Design and implementation
+
+- Every checkpoint now starts a transaction, installs its database deadline when supplied, and
+  reloads the task with `SELECT ... FOR UPDATE` plus `populate_existing=True` under
+  `session.no_autoflush`.
+- Every checkpoint declares its exact expected source status and assigned Developer UUID.
+  Assignment alone expects `READY` with no assignee.
+- The locked row is verified before snapshotting, staging a transition, or staging an audit fact.
+- The orchestrator tracks the last committed status and supplies it to safe escalation.
+- A lock/reload mismatch is `INVALID_STATE`. The orchestrator does not attempt a stale
+  `WAITING_HUMAN` escalation for that category, so the concurrent human/cancel state wins without
+  an overwrite or audit lie.
+- Checkpoint commits still occur before each external collaborator call, so no transaction or row
+  lock is held across Developer, handoff-builder, or Reviewer execution.
+
+### GREEN
+
+```text
+TEST_POSTGRES_PORT=55432 .venv/bin/pytest tests/workflows/test_safety.py -q \
+  -k concurrent_human_transition_wins
+Result: ..; 2 passed
+```
+
+The existing stale-assignment, state-machine, append-only, and checkpoint chronology tests also
+remain green.
+
+## Finding 2 — sensitive traceback retention
+
+### RED
+
+Focused tests placed reachable markers in task text, workspace/profile data, diff content,
+Developer report content, and request/session scope. They traversed the public
+`WorkflowError` traceback frames and reachable objects.
+
+```text
+.venv/bin/pytest \
+  tests/workflows/test_validation.py::test_direct_validation_failure_traceback_does_not_retain_workflow_scope \
+  tests/workflows/test_handoff.py::test_direct_handoff_failure_traceback_does_not_retain_evidence_scope \
+  tests/workflows/test_safety.py::test_orchestrator_preflight_failure_traceback_does_not_retain_workflow_scope \
+  -q
+Result: FFF; 3 failed
+Failure: public traceback frames retained request/evidence/session scope.
+```
+
+### Design and implementation
+
+- Workflow request validation and handoff validation now have internal result-or-error paths.
+- All caught failures recursively detach traceback, cause, and context links and clear traceback
+  frames before the stable code leaves the internal path.
+- Direct public wrappers delete request, session, context, result, diff/report/profile, and other
+  sensitive arguments before calling a tiny scope-free raising helper.
+- The orchestrator performs preflight through the result-or-error path and clears all sensitive
+  run locals before its final public raise.
+- Public errors expose only the closed `WorkflowErrorCode` and its existing stable safe message;
+  raw exception messages never reach audit data or the caller.
+
+### GREEN
+
+```text
+.venv/bin/pytest \
+  tests/workflows/test_validation.py::test_direct_validation_failure_traceback_does_not_retain_workflow_scope \
+  tests/workflows/test_handoff.py::test_direct_handoff_failure_traceback_does_not_retain_evidence_scope \
+  tests/workflows/test_safety.py::test_orchestrator_preflight_failure_traceback_does_not_retain_workflow_scope \
+  -q
+Result: ...; 3 passed
+```
+
+## Finding 3 — Reviewer authority was validated too late
+
+### RED
+
+```text
+.venv/bin/pytest \
+  tests/reviewer/test_validation.py::test_profile_authority_validator_reuses_reviewer_read_only_rules \
+  tests/workflows/test_safety.py::test_reviewer_authority_is_rejected_before_workflow_side_effects \
+  -q
+Result: collection error
+Failure: validate_reviewer_profile_authority was not available.
+```
+
+### Design and implementation
+
+- `validate_reviewer_profile_authority` was extracted from the Reviewer request validator and is
+  reused by both direct Reviewer validation and workflow preflight.
+- It exact-type checks and canonicalizes the complete `AgentProfile`, then enforces Reviewer role,
+  active status, required filesystem read access, the read-only permission allowlist, and the
+  Reviewer tool allowlist.
+- Workflow preflight maps unsafe Reviewer authority to the stable `INVALID_AGENT` workflow code.
+- This validation completes before assignment, audit, Developer execution, handoff construction,
+  or Reviewer execution.
+- The existing Reviewer request validation contract and immutable canonical permission result are
+  preserved.
+
+### GREEN
+
+```text
+.venv/bin/pytest \
+  tests/reviewer/test_validation.py::test_profile_authority_validator_reuses_reviewer_read_only_rules \
+  tests/workflows/test_safety.py::test_reviewer_authority_is_rejected_before_workflow_side_effects \
+  -q
+Result: ....; 4 passed parameter cases
+```
+
+## Finding 4 — Developer output canonicalization
+
+### RED
+
+```text
+.venv/bin/pytest \
+  tests/workflows/test_safety.py::test_malformed_developer_result_is_rejected_before_waiting_review_or_handoff \
+  -q
+Result: F; 1 failed
+Failure: malformed output reached later handoff validation and surfaced as UNSAFE_HANDOFF instead
+of failing at the collaborator boundary.
+```
+
+### Design and implementation
+
+- Developer output is now exact-type checked and fully round-trip canonicalized as a complete
+  `DeveloperResult` inside `_invoke_collaborator` immediately after the Developer returns.
+- Canonicalization occurs before `commit_developer_completed_checkpoint`, before the task can
+  enter `WAITING_REVIEW`, and before the handoff builder is called.
+- Type-confused or malformed nested evidence maps to safe `COLLABORATOR_FAILURE`; the existing
+  safe checkpoint moves the still-`IN_PROGRESS` task to `WAITING_HUMAN` exactly once.
+
+### GREEN
+
+```text
+.venv/bin/pytest \
+  tests/workflows/test_safety.py::test_malformed_developer_result_is_rejected_before_waiting_review_or_handoff \
+  -q
+Result: .; 1 passed
+```
+
+## Finding 5 — rollback ownership
+
+### RED
+
+```text
+TEST_POSTGRES_PORT=55432 .venv/bin/pytest \
+  tests/workflows/test_audit.py::test_rollback_failure_invalidates_only_the_poisoned_connection_and_session_cannot_commit \
+  -q
+Result: F; 1 failed
+Failure: caller-owned Session.invalidate was called once.
+```
+
+### Design and implementation
+
+- The active SQLAlchemy `Connection` is captured before checkpoint work starts.
+- If and only if rollback itself fails, recovery invalidates that poisoned connection. It never
+  calls `Session.invalidate()` or `Session.close()`.
+- The result remains fatal `PERSISTENCE_FAILURE`; rollback-failure safety was not downgraded.
+- Best-effort task snapshot restoration and task-status authorization cleanup remain in place.
+- The regression proves the poisoned caller Session cannot later commit partial checkpoint state,
+  while a fresh Session observes the original task and no false workflow audit fact.
+
+### GREEN
+
+```text
+TEST_POSTGRES_PORT=55432 .venv/bin/pytest \
+  tests/workflows/test_audit.py::test_rollback_failure_invalidates_only_the_poisoned_connection_and_session_cannot_commit \
+  -q
+Result: .; 1 passed
+```
+
+## Finding 6 — whole-workflow timeout
+
+### RED
+
+The preflight case performs a real PostgreSQL `pg_sleep`; the checkpoint case uses an independent
+thread/session to hold a real task-row `SELECT FOR UPDATE` lock.
+
+```text
+TEST_POSTGRES_PORT=55432 .venv/bin/pytest \
+  tests/workflows/test_safety.py::test_global_deadline_times_out_blocked_preflight_sql_before_assignment \
+  tests/workflows/test_safety.py::test_global_deadline_times_out_a_blocked_checkpoint_row_lock_without_retry \
+  -q
+Result: FF; 2 failed
+Failure: neither blocked synchronous SQL path raised within the requested workflow timeout.
+```
+
+### Design and implementation
+
+- The request timeout remains exact, finite, positive, and capped at 3,600 seconds.
+- One monotonic work deadline is computed before preflight, and preflight, normal checkpoints, and
+  collaborator calls run inside the outer `asyncio.timeout` scope.
+- Immediately before preflight persistence and every checkpoint, the remaining deadline is
+  installed with PostgreSQL transaction-local `statement_timeout` and `lock_timeout` settings.
+- SQLSTATE `57014` (query cancellation) and `55P03` (lock timeout) map to stable `TIMEOUT`.
+- Timeout settings end with their checkpoint commit or rollback and are never held across an
+  external call.
+- Preflight timeout rolls back its transaction and has zero assignment/audit/collaborator effects.
+- A timeout after workflow start uses the existing fail-closed escalation path without retry or an
+  extra collaborator call. After the work deadline, only that persistence cleanup receives a
+  separate maximum 50-millisecond transaction budget.
+
+### GREEN
+
+```text
+TEST_POSTGRES_PORT=55432 .venv/bin/pytest \
+  tests/workflows/test_safety.py::test_global_deadline_times_out_blocked_preflight_sql_before_assignment \
+  tests/workflows/test_safety.py::test_global_deadline_times_out_a_blocked_checkpoint_row_lock_without_retry \
+  -q
+Result: ..; 2 passed
+```
+
+The pre-existing collaborator timeout and cancellation tests also remain green and prove no retry
+or post-cancellation call.
+
+## Finding 7 — false public audit facts
+
+### RED
+
+```text
+.venv/bin/pytest \
+  tests/workflows/test_audit.py::test_raw_workflow_event_staging_is_not_publicly_exposed -q
+Result: F; 1 failed
+Failure: core.workflows still exposed append_workflow_event.
+```
+
+### Design and implementation
+
+- Raw event staging is now the private `_stage_workflow_event` implementation and is absent from
+  `core.workflows` imports and `__all__`.
+- Public workflow audit entry points are state-coupled checkpoint functions. Each locks and
+  verifies the legal source task state and assigned Developer before it can stage an event.
+- Audit tests now drive assignment, handoff, review, exhaustion, completion, and safe failure
+  facts through legal checkpoint/state sequences, while continuing to assert the bounded scalar
+  allowlist and append-only protection.
+- There is no public path that can append `WORKFLOW_COMPLETED` to a `READY` task.
+
+### GREEN
+
+```text
+.venv/bin/pytest \
+  tests/workflows/test_audit.py::test_raw_workflow_event_staging_is_not_publicly_exposed -q
+Result: .; 1 passed
+```
+
+The complete workflow audit suite passed as part of the focused and full gates.
+
+## Verification
+
+Focused Phase 16 workflow suite:
+
+```text
+TEST_POSTGRES_PORT=55432 .venv/bin/pytest tests/workflows -q
+Result: exit 0
+```
+
+Focused workflow, Reviewer, task-state, and database safety suites:
+
+```text
+TEST_POSTGRES_PORT=55432 .venv/bin/pytest tests/workflows tests/reviewer tests/tasks \
+  tests/database/test_task_state_machine.py tests/database/test_append_only.py -q
+Result: exit 0; 435 tests passed
+```
+
+Focused static checks:
+
+```text
+.venv/bin/ruff check core/workflows core/reviewer tests/workflows tests/reviewer
+All checks passed!
+
+.venv/bin/ruff format --check core/workflows core/reviewer tests/workflows tests/reviewer
+38 files already formatted
+
+.venv/bin/mypy core/workflows core/reviewer tests/workflows tests/reviewer
+Success: no issues found in 38 source files
+```
+
+Final repository gate:
+
+```text
+TEST_POSTGRES_PORT=55432 make check
+.venv/bin/ruff check .
+All checks passed!
+.venv/bin/mypy .
+Success: no issues found in 242 source files
+.venv/bin/pytest
+1174 passed in 9.12s
+Result: exit 0
+```
+
+Final formatting and diff hygiene:
+
+```text
+.venv/bin/ruff format --check .
+306 files already formatted
+
+git diff --check
+Result: exit 0; no output
+
+git diff --cached --check
+Result: exit 0; no output
+```
+
+## Files
+
+Production:
+
+- `core/reviewer/__init__.py`
+- `core/reviewer/validation.py`
+- `core/workflows/__init__.py`
+- `core/workflows/audit.py`
+- `core/workflows/deadline.py`
+- `core/workflows/errors.py`
+- `core/workflows/handoff.py`
+- `core/workflows/orchestrator.py`
+- `core/workflows/validation.py`
+
+Tests:
+
+- `tests/reviewer/test_validation.py`
+- `tests/workflows/test_audit.py`
+- `tests/workflows/test_handoff.py`
+- `tests/workflows/test_safety.py`
+- `tests/workflows/test_validation.py`
+- `tests/workflows/traceback_assertions.py`
+
+Documentation:
+
+- `docs/developer-reviewer-workflow.md`
+- `.superpowers/sdd/2026-08-30-phase-16-developer-reviewer-workflow/final-fix-report.md`
+
+## Self-review and concerns
+
+- Stale `expire_on_commit=False` identity-map state cannot bypass any workflow checkpoint.
+- `INVALID_STATE` from a concurrent human/cancel transition cannot trigger a second stale
+  escalation attempt.
+- Reviewer write/command authority is rejected before every workflow side effect.
+- Malformed Developer output cannot reach `WAITING_REVIEW` or handoff construction.
+- No checkpoint closes or invalidates the caller Session; a rollback-failed Session remains fatal
+  and caller-managed.
+- The normal workflow uses one deadline from before preflight. The only separate budget is the
+  documented, persistence-only, maximum 50-millisecond safe-failure cleanup after work timeout;
+  it cannot call or retry a collaborator.
+- Raw audit staging is private and completion facts are tied to the approving state transition.
+- No known unresolved correctness, safety, typing, formatting, migration, or test concern remains.
+- `CLAUDE.local.md` was not read, changed, staged, or included.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,7 +9,8 @@ model**, **Phase 3 — task state machine**, **Phase 4 — LLM provider boundary
 core**, **Phase 6 — tool registry**, **Phase 7 — permission engine**, **Phase 8 — Skills
 Registry**, **Phase 9 — workspace isolation**, **Phase 10 — transactional write tools**, and
 **Phase 11 — secure command profiles**, **Phase 13 — Loop Engineering V1**, **Phase 14 —
-Developer Agent**, and **Phase 15 — Reviewer Agent**. Phase 12 remains deliberately unimplemented.
+Developer Agent**, **Phase 15 — Reviewer Agent**, and **Phase 16 — Developer–Reviewer workflow**.
+Phase 12 remains deliberately unimplemented.
 It contains a minimal FastAPI application, typed
 SQLAlchemy models, Alembic migrations, append-only history protection, an audited task workflow,
 bounded provider-neutral LLM contracts, an Ollama adapter, a bounded runtime agent with four
@@ -20,8 +21,9 @@ per-project workspaces with audited bounded Git import and cleanup, four permiss
 compensatable UTF-8 file mutation tools, ten fixed test/lint/build/read-only-Git command profiles,
 a bounded provider-neutral single-agent loop with sanitized append-only step auditing, a bounded
 Developer role using deterministic skill context and real secure repository tools, an independent
-read-only Reviewer role with one-shot analysis and deterministic approval gating, and
-real-PostgreSQL integration tests.
+read-only Reviewer role with one-shot analysis and deterministic approval gating, real-PostgreSQL
+integration tests, and a bounded audited Developer–Reviewer workflow with fresh correction-cycle
+handoffs and concrete-agent integration coverage.
 
 Phase 7 authorizes tools exclusively from active persisted `AgentPermission` grants. Phase 8 can
 load and rank local `SKILL.md` packages. Phase 14 may inject only selected, complete, bounded skill
@@ -30,10 +32,10 @@ authority or execute directly. Phase 9 provides local filesystem
 isolation behind a backend-neutral contract; it is not an operating-system sandbox or execution
 container. Phase 11 command execution is an application-level fixed-profile boundary, not a
 hostile-code sandbox. The repository does not include a free-form shell, MCP access, provider
-routing, or multi-agent behavior. Phase 12 and Phase 16+ are not implemented.
-In particular, there is no arbitrary terminal, approval workflow, MCP integration,
-QA/security engine, provider router, or frontend. Do not implement work from a later phase unless
-the user explicitly starts that phase.
+routing, QA/Security execution, or frontend. Phase 12 remains deliberately unimplemented. Phase
+16 provides only the explicit Developer–Reviewer workflow documented in
+`docs/developer-reviewer-workflow.md`; Phase 17 and later phases are not implemented. Do not
+implement work from a later phase unless the user explicitly starts that phase.
 
 Important files:
 
@@ -55,9 +57,11 @@ Current source layout:
 - `core/runtime/` and `infrastructure/runtime/` — bounded one-agent loop and runtime-step audit.
 - `core/developer/` — Phase 14 role validation, skill context, evidence, reporting, and composition.
 - `core/reviewer/` — Phase 15 read-only validation, analysis, gate, scoring, and composition.
+- `core/workflows/` — Phase 16 explicit bounded Developer–Reviewer orchestration, fresh handoff validation, checkpoints, and safe errors.
 - `skills/` — five repository-owned versioned V1 skill packages.
 - `alembic/` — PostgreSQL migrations.
 - `tests/` — unit and real-PostgreSQL integration tests.
+- `docs/developer-reviewer-workflow.md` — Phase 16 flow, contracts, checkpoints, safety boundary, and Phase 17 exclusions.
 
 ## Development commands
 
@@ -97,6 +101,12 @@ For the focused Phase 15 Reviewer tests, run:
 
 ```bash
 .venv/bin/pytest tests/reviewer -q
+```
+
+For the focused Phase 16 concrete-agent PostgreSQL integration tests, run:
+
+```bash
+TEST_POSTGRES_PORT=55432 .venv/bin/pytest tests/workflows/test_integration.py -q
 ```
 
 Run a single test with:

--- a/README.md
+++ b/README.md
@@ -53,8 +53,9 @@ audited task workflow, provider-neutral LLM contracts with an Ollama adapter, a 
 agent, five read-only repository tools, deny-by-default PostgreSQL permission enforcement, a
 bounded deterministic registry of versioned skills, isolated audited project workspaces, and four
 compensatable UTF-8 write tools and fixed, bounded test/lint/build/read-only-Git profiles. A
-free-form shell, MCP, multi-agent coordination, QA and security engines, and the
-frontend remain intentionally unimplemented.
+free-form shell, MCP, general-purpose multi-agent orchestration beyond the explicit
+Developer–Reviewer workflow, QA and security engines, and the frontend remain intentionally
+unimplemented.
 
 What exists today:
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 > The operating system for autonomous AI organizations.
 
-[![Status](https://img.shields.io/badge/status-Phase_15-orange)](SYNAPSEOS_DEVELOPMENT_CHECKLIST.md)
+[![Status](https://img.shields.io/badge/status-Phase_16-orange)](SYNAPSEOS_DEVELOPMENT_CHECKLIST.md)
 [![Python](https://img.shields.io/badge/python-3.12%2B-blue)](https://www.python.org/)
 [![Code style: Ruff](https://img.shields.io/badge/code_style-ruff-blueviolet)](https://docs.astral.sh/ruff/)
 [![Types: mypy](https://img.shields.io/badge/types-mypy-blue)](https://mypy-lang.org/)
@@ -48,7 +48,7 @@ See [`docs/cahier de charges.md`](docs/cahier%20de%20charges.md) for the full pr
 
 ## Status
 
-**Phase 15 — Reviewer Agent completed.** The repository now provides the persistence foundation, an
+**Phase 16 — Developer ↔ Reviewer workflow completed.** The repository now provides the persistence foundation, an
 audited task workflow, provider-neutral LLM contracts with an Ollama adapter, a bounded runtime
 agent, five read-only repository tools, deny-by-default PostgreSQL permission enforcement, a
 bounded deterministic registry of versioned skills, isolated audited project workspaces, and four
@@ -97,6 +97,9 @@ What exists today:
 - An independent read-only Reviewer role with one bounded provider call, strict structured
   findings, explicit required-check evidence, a deterministic approval gate, and a deterministic
   per-review score. Failed or missing mandatory checks can never be approved.
+- A bounded Developer ↔ Reviewer workflow that assigns one persistent READY task, commits audited
+  checkpoints, obtains fresh handoff evidence for each correction cycle, and ends at WAITING_QA on
+  approval or WAITING_HUMAN on review-cycle exhaustion.
 - A full tooling baseline: `pytest`, `Ruff`, `mypy` (strict), plus `Dockerfile` and
   `docker-compose.yml` for the API + PostgreSQL.
 
@@ -144,6 +147,7 @@ make dev         # run the API with autoreload on http://localhost:8000
 apps/api/                 # FastAPI application (Platform API)
 core/                     # Domain and application boundaries
   agents/ commands/ developer/ reviewer/ tasks/ runtime/ memory/ skills/ tools/ scoring/ permissions/ workspaces/
+  workflows/               # Explicit bounded Developer ↔ Reviewer orchestration
   config.py               # Application settings (env-driven)
 infrastructure/           # Adapters to the outside world
   database/               # SQLAlchemy models, sessions, repositories, and append-only guard
@@ -196,6 +200,13 @@ The focused Phase 15 suite covers the independent read-only Reviewer role:
 .venv/bin/pytest tests/reviewer -q
 ```
 
+The focused Phase 16 suite composes concrete Developer and Reviewer agents against real PostgreSQL
+created through Alembic:
+
+```bash
+TEST_POSTGRES_PORT=55432 .venv/bin/pytest tests/workflows/test_integration.py -q
+```
+
 Run `make help` to list every available target.
 
 **Working agreement:** changes are test-driven (write the failing test first), and `make check`
@@ -221,7 +232,8 @@ validated pull request. The near-term sequence is:
 13. **Loop Engineering V1** — completed
 14. **Developer Agent** — completed
 15. **Reviewer Agent** — completed
-16. Developer ↔ Reviewer workflow — not started
+16. **Developer ↔ Reviewer workflow** — completed
+17. QA Agent — not started
 
 The complete phased plan (up to a full engineering organisation) lives in
 [`SYNAPSEOS_DEVELOPMENT_CHECKLIST.md`](SYNAPSEOS_DEVELOPMENT_CHECKLIST.md).
@@ -241,6 +253,7 @@ The complete phased plan (up to a full engineering organisation) lives in
 - **Loop Engineering V1:** [`docs/runtime.md`](docs/runtime.md)
 - **Developer Agent:** [`docs/developer-agent.md`](docs/developer-agent.md)
 - **Reviewer Agent:** [`docs/reviewer-agent.md`](docs/reviewer-agent.md)
+- **Developer ↔ Reviewer workflow:** [`docs/developer-reviewer-workflow.md`](docs/developer-reviewer-workflow.md)
 - **Architecture decisions (ADRs):** [`docs/adr/`](docs/adr/)
 - **Repository working agreement:** [`AGENTS.md`](AGENTS.md)
 

--- a/SYNAPSEOS_DEVELOPMENT_CHECKLIST.md
+++ b/SYNAPSEOS_DEVELOPMENT_CHECKLIST.md
@@ -1171,13 +1171,13 @@ flowchart TD
 
 ## Checklist
 
-- [ ] orchestrateur
-- [ ] assignation
-- [ ] handoff
-- [ ] review cycle
-- [ ] max review cycles
-- [ ] état Task
-- [ ] audit
+- [x] orchestrateur
+- [x] assignation
+- [x] handoff
+- [x] review cycle
+- [x] max review cycles
+- [x] état Task
+- [x] audit
 
 ## Prompt Claude Code — Phase 16
 

--- a/core/reviewer/__init__.py
+++ b/core/reviewer/__init__.py
@@ -14,7 +14,11 @@ from core.reviewer.types import (
     ReviewerResult,
     ReviewFinding,
 )
-from core.reviewer.validation import ValidatedReviewerRequest, validate_reviewer_request
+from core.reviewer.validation import (
+    ValidatedReviewerRequest,
+    validate_reviewer_profile_authority,
+    validate_reviewer_request,
+)
 
 __all__ = [
     "FindingSeverity",
@@ -31,5 +35,6 @@ __all__ = [
     "ReviewerRequest",
     "ReviewerResult",
     "ValidatedReviewerRequest",
+    "validate_reviewer_profile_authority",
     "validate_reviewer_request",
 ]

--- a/core/reviewer/validation.py
+++ b/core/reviewer/validation.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import re
 from dataclasses import dataclass
+from typing import NoReturn
 
 from pydantic import ValidationError
 
@@ -47,26 +48,44 @@ def validate_reviewer_request(request: ReviewerRequest) -> ValidatedReviewerRequ
 
 def validate_reviewer_profile_authority(profile: AgentProfile) -> frozenset[Permission]:
     """Return canonical read-only Reviewer permissions for one complete profile."""
+    permissions, error_code = _validate_reviewer_profile_authority_result(profile)
+    del profile
+    if error_code is not None:
+        del permissions
+        _raise_reviewer_error(error_code)
+    assert permissions is not None
+    return permissions
+
+
+def _validate_reviewer_profile_authority_result(
+    profile: AgentProfile,
+) -> tuple[frozenset[Permission] | None, ReviewerErrorCode | None]:
+    """Return canonical authority or a stable failure without raising publicly."""
     if type(profile) is not AgentProfile:
-        raise ReviewerError(ReviewerErrorCode.INVALID_INPUT)
+        return None, ReviewerErrorCode.INVALID_INPUT
     try:
         canonical_profile = AgentProfile.model_validate(
             profile.model_dump(mode="python", warnings=False)
         )
     except (TypeError, ValueError, ValidationError):
-        raise ReviewerError(ReviewerErrorCode.INVALID_INPUT) from None
+        return None, ReviewerErrorCode.INVALID_INPUT
     if canonical_profile.role != "Reviewer":
-        raise ReviewerError(ReviewerErrorCode.INVALID_ROLE)
+        return None, ReviewerErrorCode.INVALID_ROLE
     if canonical_profile.status not in _ACTIVE_STATUSES:
-        raise ReviewerError(ReviewerErrorCode.INACTIVE_AGENT)
-    permissions = _canonical_permissions(canonical_profile.permission_ids)
+        return None, ReviewerErrorCode.INACTIVE_AGENT
+    try:
+        permissions = frozenset(
+            Permission(permission_id) for permission_id in canonical_profile.permission_ids
+        )
+    except (TypeError, ValueError):
+        return None, ReviewerErrorCode.INVALID_PERMISSION
     if Permission.FILESYSTEM_READ not in permissions or not permissions.issubset(
         _ALLOWED_PERMISSIONS
     ):
-        raise ReviewerError(ReviewerErrorCode.INVALID_PERMISSION)
+        return None, ReviewerErrorCode.INVALID_PERMISSION
     if not canonical_profile.tool_ids.issubset(REVIEWER_TOOL_IDS):
-        raise ReviewerError(ReviewerErrorCode.INVALID_TOOLS)
-    return permissions
+        return None, ReviewerErrorCode.INVALID_TOOLS
+    return permissions, None
 
 
 def _has_consistent_scope(request: ReviewerRequest) -> bool:
@@ -92,8 +111,6 @@ def _canonicalize_request(request: ReviewerRequest) -> ReviewerRequest:
         raise ReviewerError(ReviewerErrorCode.INVALID_INPUT) from None
 
 
-def _canonical_permissions(permission_ids: frozenset[str]) -> frozenset[Permission]:
-    try:
-        return frozenset(Permission(permission_id) for permission_id in permission_ids)
-    except (TypeError, ValueError):
-        raise ReviewerError(ReviewerErrorCode.INVALID_PERMISSION) from None
+def _raise_reviewer_error(code: ReviewerErrorCode) -> NoReturn:
+    """Raise one application-owned error from a scope-free frame."""
+    raise ReviewerError(code) from None

--- a/core/reviewer/validation.py
+++ b/core/reviewer/validation.py
@@ -7,6 +7,7 @@ from dataclasses import dataclass
 
 from pydantic import ValidationError
 
+from core.agents import AgentProfile
 from core.enums import AgentStatus, Permission
 from core.reviewer.errors import ReviewerError, ReviewerErrorCode
 from core.reviewer.types import ReviewerRequest
@@ -40,14 +41,32 @@ def validate_reviewer_request(request: ReviewerRequest) -> ValidatedReviewerRequ
         raise ReviewerError(ReviewerErrorCode.INACTIVE_AGENT)
     if profile.id != canonical_request.reviewer_id:
         raise ReviewerError(ReviewerErrorCode.INVALID_SCOPE)
-    permissions = _canonical_permissions(profile.permission_ids)
+    permissions = validate_reviewer_profile_authority(profile)
+    return ValidatedReviewerRequest(request=canonical_request, permissions=permissions)
+
+
+def validate_reviewer_profile_authority(profile: AgentProfile) -> frozenset[Permission]:
+    """Return canonical read-only Reviewer permissions for one complete profile."""
+    if type(profile) is not AgentProfile:
+        raise ReviewerError(ReviewerErrorCode.INVALID_INPUT)
+    try:
+        canonical_profile = AgentProfile.model_validate(
+            profile.model_dump(mode="python", warnings=False)
+        )
+    except (TypeError, ValueError, ValidationError):
+        raise ReviewerError(ReviewerErrorCode.INVALID_INPUT) from None
+    if canonical_profile.role != "Reviewer":
+        raise ReviewerError(ReviewerErrorCode.INVALID_ROLE)
+    if canonical_profile.status not in _ACTIVE_STATUSES:
+        raise ReviewerError(ReviewerErrorCode.INACTIVE_AGENT)
+    permissions = _canonical_permissions(canonical_profile.permission_ids)
     if Permission.FILESYSTEM_READ not in permissions or not permissions.issubset(
         _ALLOWED_PERMISSIONS
     ):
         raise ReviewerError(ReviewerErrorCode.INVALID_PERMISSION)
-    if not profile.tool_ids.issubset(REVIEWER_TOOL_IDS):
+    if not canonical_profile.tool_ids.issubset(REVIEWER_TOOL_IDS):
         raise ReviewerError(ReviewerErrorCode.INVALID_TOOLS)
-    return ValidatedReviewerRequest(request=canonical_request, permissions=permissions)
+    return permissions
 
 
 def _has_consistent_scope(request: ReviewerRequest) -> bool:

--- a/core/tasks/state_machine.py
+++ b/core/tasks/state_machine.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from collections.abc import Mapping
 from copy import deepcopy
+from uuid import UUID
 
 from sqlalchemy import inspect
 from sqlalchemy.orm import Session, object_session
@@ -118,6 +119,7 @@ class TaskStateMachine:
         actor_id: str | None,
         reason: str,
         metadata: Mapping[str, object] | None = None,
+        correlation_id: UUID | None = None,
     ) -> AuditEvent:
         """Apply one valid transition and stage its audit event without committing."""
         if object_session(task) is not self._session or not inspect(task).persistent:
@@ -156,6 +158,7 @@ class TaskStateMachine:
             action="transition_task_status",
             result=AuditResult.SUCCEEDED,
             data=audit_data,
+            correlation_id=correlation_id,
         )
         authorize_task_status_change(self._session, task, current, target, event)
         self._session.add(event)

--- a/core/workflows/__init__.py
+++ b/core/workflows/__init__.py
@@ -2,7 +2,6 @@
 
 from core.workflows.audit import (
     WorkflowEventType,
-    append_workflow_event,
     commit_assignment_checkpoint,
     commit_developer_completed_checkpoint,
     commit_developer_handoff_checkpoint,
@@ -33,7 +32,6 @@ __all__ = [
     "WorkflowError",
     "WorkflowErrorCode",
     "WorkflowEventType",
-    "append_workflow_event",
     "commit_assignment_checkpoint",
     "commit_developer_completed_checkpoint",
     "commit_developer_handoff_checkpoint",

--- a/core/workflows/__init__.py
+++ b/core/workflows/__init__.py
@@ -10,9 +10,11 @@ from core.workflows.audit import (
     commit_next_review_cycle_checkpoint,
     commit_review_completed_checkpoint,
     commit_review_cycle_exhausted_checkpoint,
+    commit_safe_failure_checkpoint,
 )
 from core.workflows.errors import WorkflowError, WorkflowErrorCode
 from core.workflows.handoff import validate_reviewer_handoff
+from core.workflows.orchestrator import WorkflowOrchestrator
 from core.workflows.ports import DeveloperRunner, ReviewerHandoffBuilder, ReviewerRunner
 from core.workflows.types import (
     DeveloperReviewerWorkflowRequest,
@@ -39,8 +41,10 @@ __all__ = [
     "commit_next_review_cycle_checkpoint",
     "commit_review_completed_checkpoint",
     "commit_review_cycle_exhausted_checkpoint",
+    "commit_safe_failure_checkpoint",
     "WorkflowHandoffContext",
     "WorkflowOutcome",
+    "WorkflowOrchestrator",
     "ValidatedWorkflowScope",
     "validate_reviewer_handoff",
     "validate_workflow_request",

--- a/core/workflows/__init__.py
+++ b/core/workflows/__init__.py
@@ -1,6 +1,8 @@
 """Immutable contracts for the Phase 16 Developer–Reviewer workflow."""
 
 from core.workflows.errors import WorkflowError, WorkflowErrorCode
+from core.workflows.handoff import validate_reviewer_handoff
+from core.workflows.ports import DeveloperRunner, ReviewerHandoffBuilder, ReviewerRunner
 from core.workflows.types import (
     DeveloperReviewerWorkflowRequest,
     DeveloperReviewerWorkflowResult,
@@ -12,10 +14,14 @@ from core.workflows.validation import ValidatedWorkflowScope, validate_workflow_
 __all__ = [
     "DeveloperReviewerWorkflowRequest",
     "DeveloperReviewerWorkflowResult",
+    "DeveloperRunner",
+    "ReviewerHandoffBuilder",
+    "ReviewerRunner",
     "WorkflowError",
     "WorkflowErrorCode",
     "WorkflowHandoffContext",
     "WorkflowOutcome",
     "ValidatedWorkflowScope",
     "validate_workflow_request",
+    "validate_reviewer_handoff",
 ]

--- a/core/workflows/__init__.py
+++ b/core/workflows/__init__.py
@@ -1,0 +1,18 @@
+"""Immutable contracts for the Phase 16 Developer–Reviewer workflow."""
+
+from core.workflows.errors import WorkflowError, WorkflowErrorCode
+from core.workflows.types import (
+    DeveloperReviewerWorkflowRequest,
+    DeveloperReviewerWorkflowResult,
+    WorkflowHandoffContext,
+    WorkflowOutcome,
+)
+
+__all__ = [
+    "DeveloperReviewerWorkflowRequest",
+    "DeveloperReviewerWorkflowResult",
+    "WorkflowError",
+    "WorkflowErrorCode",
+    "WorkflowHandoffContext",
+    "WorkflowOutcome",
+]

--- a/core/workflows/__init__.py
+++ b/core/workflows/__init__.py
@@ -7,6 +7,7 @@ from core.workflows.types import (
     WorkflowHandoffContext,
     WorkflowOutcome,
 )
+from core.workflows.validation import ValidatedWorkflowScope, validate_workflow_request
 
 __all__ = [
     "DeveloperReviewerWorkflowRequest",
@@ -15,4 +16,6 @@ __all__ = [
     "WorkflowErrorCode",
     "WorkflowHandoffContext",
     "WorkflowOutcome",
+    "ValidatedWorkflowScope",
+    "validate_workflow_request",
 ]

--- a/core/workflows/__init__.py
+++ b/core/workflows/__init__.py
@@ -1,5 +1,16 @@
 """Immutable contracts for the Phase 16 Developer–Reviewer workflow."""
 
+from core.workflows.audit import (
+    WorkflowEventType,
+    append_workflow_event,
+    commit_assignment_checkpoint,
+    commit_developer_completed_checkpoint,
+    commit_developer_handoff_checkpoint,
+    commit_developer_started_checkpoint,
+    commit_next_review_cycle_checkpoint,
+    commit_review_completed_checkpoint,
+    commit_review_cycle_exhausted_checkpoint,
+)
 from core.workflows.errors import WorkflowError, WorkflowErrorCode
 from core.workflows.handoff import validate_reviewer_handoff
 from core.workflows.ports import DeveloperRunner, ReviewerHandoffBuilder, ReviewerRunner
@@ -19,9 +30,18 @@ __all__ = [
     "ReviewerRunner",
     "WorkflowError",
     "WorkflowErrorCode",
+    "WorkflowEventType",
+    "append_workflow_event",
+    "commit_assignment_checkpoint",
+    "commit_developer_completed_checkpoint",
+    "commit_developer_handoff_checkpoint",
+    "commit_developer_started_checkpoint",
+    "commit_next_review_cycle_checkpoint",
+    "commit_review_completed_checkpoint",
+    "commit_review_cycle_exhausted_checkpoint",
     "WorkflowHandoffContext",
     "WorkflowOutcome",
     "ValidatedWorkflowScope",
-    "validate_workflow_request",
     "validate_reviewer_handoff",
+    "validate_workflow_request",
 ]

--- a/core/workflows/audit.py
+++ b/core/workflows/audit.py
@@ -4,12 +4,17 @@ from __future__ import annotations
 
 import math
 from collections.abc import Callable
+from dataclasses import dataclass
 from enum import StrEnum
+from functools import partial
 from traceback import clear_frames
+from typing import NoReturn
+from uuid import UUID
 
 from sqlalchemy import select
 from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.orm import Session
+from sqlalchemy.orm.attributes import set_committed_value
 
 from core.enums import AuditActorType, AuditResult, TaskStatus
 from core.reviewer import ReviewDecision
@@ -17,6 +22,7 @@ from core.tasks.state_machine import InvalidTaskTransitionError, TaskStateMachin
 from core.workflows.errors import WorkflowError, WorkflowErrorCode
 from core.workflows.validation import ValidatedWorkflowScope
 from infrastructure.database.models import AuditEvent, Task
+from infrastructure.database.task_status_guard import clear_task_status_authorizations
 
 
 class WorkflowEventType(StrEnum):
@@ -27,6 +33,14 @@ class WorkflowEventType(StrEnum):
     REVIEW_COMPLETED = "REVIEW_COMPLETED"
     REVIEW_CYCLE_EXHAUSTED = "REVIEW_CYCLE_EXHAUSTED"
     WORKFLOW_COMPLETED = "WORKFLOW_COMPLETED"
+
+
+@dataclass(frozen=True)
+class _TaskSnapshot:
+    """The only mutable task fields a checkpoint may stage before committing."""
+
+    status: TaskStatus
+    assigned_agent_id: UUID | None
 
 
 def append_workflow_event(
@@ -80,80 +94,55 @@ def append_workflow_event(
 
 def commit_assignment_checkpoint(session: Session, scope: ValidatedWorkflowScope) -> None:
     """Durably assign the Developer and record the workflow start as one checkpoint."""
-
-    def stage() -> None:
-        task = _locked_ready_task(session, scope)
-        task.assigned_agent_id = scope.developer.id
-        _transition(
-            session,
-            scope,
-            task,
-            TaskStatus.ASSIGNED,
-            actor_type=AuditActorType.AGENT,
-            actor_id=scope.developer.slug,
-            reason="Workflow developer assignment accepted.",
-        )
-        append_workflow_event(session, scope, WorkflowEventType.WORKFLOW_STARTED)
-
-    _commit_checkpoint(session, stage)
+    stage = partial(_stage_assignment, session, scope)
+    failure = _commit_checkpoint(session, scope.task, stage)
+    del stage
+    del scope
+    del session
+    if failure is not None:
+        _raise_failure(failure)
 
 
 def commit_developer_started_checkpoint(
     session: Session, scope: ValidatedWorkflowScope, *, cycle: int
 ) -> None:
     """Durably mark one bounded Developer cycle as in progress."""
-
-    _require_cycle(scope, cycle)
-
-    def stage() -> None:
-        _transition(
-            session,
-            scope,
-            scope.task,
-            TaskStatus.IN_PROGRESS,
-            actor_type=AuditActorType.AGENT,
-            actor_id=scope.developer.slug,
-            reason="Workflow developer cycle started.",
-        )
-
-    _commit_checkpoint(session, stage)
+    stage = partial(_stage_developer_started, session, scope, cycle)
+    failure = _commit_checkpoint(session, scope.task, stage)
+    del stage
+    del scope
+    del session
+    del cycle
+    if failure is not None:
+        _raise_failure(failure)
 
 
 def commit_developer_handoff_checkpoint(
     session: Session, scope: ValidatedWorkflowScope, *, cycle: int
 ) -> None:
     """Durably record creation of one safe Reviewer handoff."""
-    _require_cycle(scope, cycle)
-
-    def stage() -> None:
-        append_workflow_event(
-            session,
-            scope,
-            WorkflowEventType.DEVELOPER_HANDOFF_CREATED,
-            cycle=cycle,
-        )
-
-    _commit_checkpoint(session, stage)
+    stage = partial(_stage_developer_handoff, session, scope, cycle)
+    failure = _commit_checkpoint(session, scope.task, stage)
+    del stage
+    del scope
+    del session
+    del cycle
+    if failure is not None:
+        _raise_failure(failure)
 
 
 def commit_developer_completed_checkpoint(
     session: Session, scope: ValidatedWorkflowScope, *, cycle: int
 ) -> None:
     """Durably mark one bounded Developer cycle ready for independent review."""
-    _require_cycle(scope, cycle)
-
-    def stage() -> None:
-        _transition(
-            session,
-            scope,
-            scope.task,
-            TaskStatus.WAITING_REVIEW,
-            actor_type=AuditActorType.AGENT,
-            actor_id=scope.developer.slug,
-            reason="Workflow developer cycle completed.",
-        )
-
-    _commit_checkpoint(session, stage)
+    stage = partial(_stage_developer_completed, session, scope, cycle)
+    failure = _commit_checkpoint(session, scope.task, stage)
+    del stage
+    del scope
+    del session
+    del cycle
+    if failure is not None:
+        _raise_failure(failure)
 
 
 def commit_review_completed_checkpoint(
@@ -166,6 +155,114 @@ def commit_review_completed_checkpoint(
     finding_count: int,
 ) -> None:
     """Durably record one Reviewer decision and its exact next task state."""
+    stage = partial(
+        _stage_review_completed,
+        session,
+        scope,
+        cycle,
+        decision,
+        review_score,
+        finding_count,
+    )
+    failure = _commit_checkpoint(session, scope.task, stage)
+    del stage
+    del scope
+    del session
+    del cycle
+    del decision
+    del review_score
+    del finding_count
+    if failure is not None:
+        _raise_failure(failure)
+
+
+def commit_review_cycle_exhausted_checkpoint(
+    session: Session,
+    scope: ValidatedWorkflowScope,
+    *,
+    cycle: int,
+    max_review_cycles: int,
+) -> None:
+    """Durably escalate an exhausted review workflow to human attention."""
+    stage = partial(_stage_review_cycle_exhausted, session, scope, cycle, max_review_cycles)
+    failure = _commit_checkpoint(session, scope.task, stage)
+    del stage
+    del scope
+    del session
+    del cycle
+    del max_review_cycles
+    if failure is not None:
+        _raise_failure(failure)
+
+
+def commit_next_review_cycle_checkpoint(
+    session: Session, scope: ValidatedWorkflowScope, *, cycle: int
+) -> None:
+    """Durably start the next bounded Developer cycle after requested changes."""
+    stage = partial(_stage_next_review_cycle, session, scope, cycle)
+    failure = _commit_checkpoint(session, scope.task, stage)
+    del stage
+    del scope
+    del session
+    del cycle
+    if failure is not None:
+        _raise_failure(failure)
+
+
+def _stage_assignment(session: Session, scope: ValidatedWorkflowScope) -> None:
+    task = _locked_ready_task(session, scope)
+    task.assigned_agent_id = scope.developer.id
+    _transition(
+        session,
+        scope,
+        task,
+        TaskStatus.ASSIGNED,
+        actor_type=AuditActorType.AGENT,
+        actor_id=scope.developer.slug,
+        reason="Workflow developer assignment accepted.",
+    )
+    append_workflow_event(session, scope, WorkflowEventType.WORKFLOW_STARTED)
+
+
+def _stage_developer_started(session: Session, scope: ValidatedWorkflowScope, cycle: int) -> None:
+    _require_cycle(scope, cycle)
+    _transition(
+        session,
+        scope,
+        scope.task,
+        TaskStatus.IN_PROGRESS,
+        actor_type=AuditActorType.AGENT,
+        actor_id=scope.developer.slug,
+        reason="Workflow developer cycle started.",
+    )
+
+
+def _stage_developer_handoff(session: Session, scope: ValidatedWorkflowScope, cycle: int) -> None:
+    _require_cycle(scope, cycle)
+    append_workflow_event(session, scope, WorkflowEventType.DEVELOPER_HANDOFF_CREATED, cycle=cycle)
+
+
+def _stage_developer_completed(session: Session, scope: ValidatedWorkflowScope, cycle: int) -> None:
+    _require_cycle(scope, cycle)
+    _transition(
+        session,
+        scope,
+        scope.task,
+        TaskStatus.WAITING_REVIEW,
+        actor_type=AuditActorType.AGENT,
+        actor_id=scope.developer.slug,
+        reason="Workflow developer cycle completed.",
+    )
+
+
+def _stage_review_completed(
+    session: Session,
+    scope: ValidatedWorkflowScope,
+    cycle: int,
+    decision: ReviewDecision,
+    review_score: float,
+    finding_count: int,
+) -> None:
     _require_cycle(scope, cycle)
     _require_review_decision(decision)
     _require_review_score(review_score)
@@ -180,97 +277,75 @@ def commit_review_completed_checkpoint(
         if decision is ReviewDecision.APPROVED
         else "Workflow review requested changes."
     )
-
-    def stage() -> None:
-        _transition(
-            session,
-            scope,
-            scope.task,
-            target,
-            actor_type=AuditActorType.AGENT,
-            actor_id=scope.reviewer.slug,
-            reason=reason,
-        )
-        append_workflow_event(
-            session,
-            scope,
-            WorkflowEventType.REVIEW_COMPLETED,
-            cycle=cycle,
-            decision=decision,
-            review_score=review_score,
-            finding_count=finding_count,
-        )
-        if decision is ReviewDecision.APPROVED:
-            append_workflow_event(
-                session,
-                scope,
-                WorkflowEventType.WORKFLOW_COMPLETED,
-                cycle=cycle,
-            )
-
-    _commit_checkpoint(session, stage)
+    _transition(
+        session,
+        scope,
+        scope.task,
+        target,
+        actor_type=AuditActorType.AGENT,
+        actor_id=scope.reviewer.slug,
+        reason=reason,
+    )
+    append_workflow_event(
+        session,
+        scope,
+        WorkflowEventType.REVIEW_COMPLETED,
+        cycle=cycle,
+        decision=decision,
+        review_score=review_score,
+        finding_count=finding_count,
+    )
+    if decision is ReviewDecision.APPROVED:
+        append_workflow_event(session, scope, WorkflowEventType.WORKFLOW_COMPLETED, cycle=cycle)
 
 
-def commit_review_cycle_exhausted_checkpoint(
-    session: Session,
-    scope: ValidatedWorkflowScope,
-    *,
-    cycle: int,
-    max_review_cycles: int,
+def _stage_review_cycle_exhausted(
+    session: Session, scope: ValidatedWorkflowScope, cycle: int, max_review_cycles: int
 ) -> None:
-    """Durably escalate an exhausted review workflow to human attention."""
     _require_cycle(scope, cycle)
     _require_max_review_cycles(scope, max_review_cycles)
     if cycle != max_review_cycles:
         raise WorkflowError(WorkflowErrorCode.INVALID_INPUT)
-
-    def stage() -> None:
-        _transition(
-            session,
-            scope,
-            scope.task,
-            TaskStatus.WAITING_HUMAN,
-            actor_type=AuditActorType.AGENT,
-            actor_id=scope.reviewer.slug,
-            reason="Workflow review cycles exhausted.",
-        )
-        append_workflow_event(
-            session,
-            scope,
-            WorkflowEventType.REVIEW_CYCLE_EXHAUSTED,
-            cycle=cycle,
-            max_review_cycles=max_review_cycles,
-        )
-
-    _commit_checkpoint(session, stage)
+    _transition(
+        session,
+        scope,
+        scope.task,
+        TaskStatus.WAITING_HUMAN,
+        actor_type=AuditActorType.AGENT,
+        actor_id=scope.reviewer.slug,
+        reason="Workflow review cycles exhausted.",
+    )
+    append_workflow_event(
+        session,
+        scope,
+        WorkflowEventType.REVIEW_CYCLE_EXHAUSTED,
+        cycle=cycle,
+        max_review_cycles=max_review_cycles,
+    )
 
 
-def commit_next_review_cycle_checkpoint(
-    session: Session, scope: ValidatedWorkflowScope, *, cycle: int
-) -> None:
-    """Durably start the next bounded Developer cycle after requested changes."""
+def _stage_next_review_cycle(session: Session, scope: ValidatedWorkflowScope, cycle: int) -> None:
     _require_cycle(scope, cycle)
-
-    def stage() -> None:
-        _transition(
-            session,
-            scope,
-            scope.task,
-            TaskStatus.IN_PROGRESS,
-            actor_type=AuditActorType.AGENT,
-            actor_id=scope.developer.slug,
-            reason="Workflow correction cycle started.",
-        )
-
-    _commit_checkpoint(session, stage)
+    _transition(
+        session,
+        scope,
+        scope.task,
+        TaskStatus.IN_PROGRESS,
+        actor_type=AuditActorType.AGENT,
+        actor_id=scope.developer.slug,
+        reason="Workflow correction cycle started.",
+    )
 
 
-def _commit_checkpoint(session: Session, stage: Callable[[], None]) -> None:
+def _commit_checkpoint(
+    session: Session, task: Task, stage: Callable[[], None]
+) -> WorkflowError | None:
+    snapshot = _TaskSnapshot(status=task.status, assigned_agent_id=task.assigned_agent_id)
     error_code: WorkflowErrorCode | None = None
     try:
         stage()
         session.commit()
-        return
+        return None
     except WorkflowError as error:
         error_code = error.code
         _discard_exception(error)
@@ -287,8 +362,19 @@ def _commit_checkpoint(session: Session, stage: Callable[[], None]) -> None:
         error_code = WorkflowErrorCode.INTERNAL_FAILURE
         _discard_exception(error)
         del error
-    _best_effort_rollback(session)
-    raise WorkflowError(error_code)
+    rollback_failed = _recover_failed_checkpoint(session, task, snapshot)
+    if rollback_failed:
+        error_code = WorkflowErrorCode.PERSISTENCE_FAILURE
+    del snapshot
+    del task
+    del stage
+    del session
+    return WorkflowError(error_code)
+
+
+def _raise_failure(error: WorkflowError) -> NoReturn:
+    """Raise a previously detached public error from a scope-free frame."""
+    raise error
 
 
 def _locked_ready_task(session: Session, scope: ValidatedWorkflowScope) -> Task:
@@ -325,9 +411,45 @@ def _transition(
     )
 
 
-def _best_effort_rollback(session: Session) -> None:
+def _recover_failed_checkpoint(session: Session, task: Task, snapshot: _TaskSnapshot) -> bool:
+    rollback_failed = _best_effort_rollback(session)
+    if rollback_failed:
+        _best_effort_invalidate(session)
+    _best_effort_clear_authorizations(session)
+    _restore_task_snapshot(task, snapshot)
+    return rollback_failed
+
+
+def _best_effort_rollback(session: Session) -> bool:
     try:
         session.rollback()
+    except BaseException as error:
+        _discard_exception(error)
+        del error
+        return True
+    return False
+
+
+def _best_effort_invalidate(session: Session) -> None:
+    try:
+        session.invalidate()
+    except BaseException as error:
+        _discard_exception(error)
+        del error
+
+
+def _best_effort_clear_authorizations(session: Session) -> None:
+    try:
+        clear_task_status_authorizations(session)
+    except BaseException as error:
+        _discard_exception(error)
+        del error
+
+
+def _restore_task_snapshot(task: Task, snapshot: _TaskSnapshot) -> None:
+    try:
+        set_committed_value(task, "status", snapshot.status)
+        set_committed_value(task, "assigned_agent_id", snapshot.assigned_agent_id)
     except BaseException as error:
         _discard_exception(error)
         del error
@@ -385,9 +507,13 @@ def _event_data(
         }
     if event_type is WorkflowEventType.REVIEW_CYCLE_EXHAUSTED:
         _require_absent(decision, review_score, finding_count)
+        validated_cycle = _require_cycle(scope, cycle)
+        validated_max_review_cycles = _require_max_review_cycles(scope, max_review_cycles)
+        if validated_cycle != validated_max_review_cycles:
+            raise WorkflowError(WorkflowErrorCode.INVALID_INPUT)
         return {
-            "cycle": _require_cycle(scope, cycle),
-            "max_review_cycles": _require_max_review_cycles(scope, max_review_cycles),
+            "cycle": validated_cycle,
+            "max_review_cycles": validated_max_review_cycles,
         }
     _require_absent(decision, review_score, finding_count, max_review_cycles)
     return {"cycle": _require_cycle(scope, cycle)}

--- a/core/workflows/audit.py
+++ b/core/workflows/audit.py
@@ -1,0 +1,346 @@
+"""Bounded durable audit checkpoints for the Phase 16 workflow."""
+
+from __future__ import annotations
+
+import math
+from collections.abc import Callable
+from enum import StrEnum
+
+from sqlalchemy.exc import SQLAlchemyError
+from sqlalchemy.orm import Session
+
+from core.enums import AuditActorType, AuditResult, TaskStatus
+from core.reviewer import ReviewDecision
+from core.tasks.state_machine import TaskStateMachine
+from core.workflows.errors import WorkflowError, WorkflowErrorCode
+from core.workflows.validation import ValidatedWorkflowScope
+from infrastructure.database.models import AuditEvent
+
+
+class WorkflowEventType(StrEnum):
+    """Closed append-only workflow facts not represented by task status alone."""
+
+    WORKFLOW_STARTED = "WORKFLOW_STARTED"
+    DEVELOPER_HANDOFF_CREATED = "DEVELOPER_HANDOFF_CREATED"
+    REVIEW_COMPLETED = "REVIEW_COMPLETED"
+    REVIEW_CYCLE_EXHAUSTED = "REVIEW_CYCLE_EXHAUSTED"
+    WORKFLOW_COMPLETED = "WORKFLOW_COMPLETED"
+
+
+def append_workflow_event(
+    session: Session,
+    scope: ValidatedWorkflowScope,
+    event_type: WorkflowEventType,
+    *,
+    cycle: int | None = None,
+    decision: ReviewDecision | None = None,
+    review_score: float | None = None,
+    finding_count: int | None = None,
+    max_review_cycles: int | None = None,
+) -> AuditEvent:
+    """Stage one workflow fact with only its explicitly approved scalar data."""
+    _require_scope(scope)
+    _require_event_type(event_type)
+    data = _event_data(
+        scope,
+        event_type,
+        cycle=cycle,
+        decision=decision,
+        review_score=review_score,
+        finding_count=finding_count,
+        max_review_cycles=max_review_cycles,
+    )
+    actor_id = (
+        scope.developer.slug
+        if event_type in {
+            WorkflowEventType.WORKFLOW_STARTED,
+            WorkflowEventType.DEVELOPER_HANDOFF_CREATED,
+        }
+        else scope.reviewer.slug
+    )
+    event = AuditEvent(
+        actor_type=AuditActorType.AGENT,
+        actor_id=actor_id,
+        project_id=scope.task.project_id,
+        task_id=scope.task.id,
+        event_type=event_type.value,
+        action="record_workflow_checkpoint",
+        resource_type="DEVELOPER_REVIEWER_WORKFLOW",
+        resource_id=str(scope.task.id),
+        result=AuditResult.SUCCEEDED,
+        data=data,
+        correlation_id=scope.request.correlation_id,
+    )
+    session.add(event)
+    return event
+
+
+def commit_assignment_checkpoint(session: Session, scope: ValidatedWorkflowScope) -> None:
+    """Durably assign the Developer and record the workflow start as one checkpoint."""
+
+    def stage() -> None:
+        scope.task.assigned_agent_id = scope.developer.id
+        TaskStateMachine(session).transition(
+            scope.task,
+            TaskStatus.ASSIGNED,
+            actor_type=AuditActorType.AGENT,
+            actor_id=scope.developer.slug,
+            reason="Workflow developer assignment accepted.",
+        )
+        append_workflow_event(session, scope, WorkflowEventType.WORKFLOW_STARTED)
+
+    _commit_checkpoint(session, stage)
+
+
+def commit_developer_started_checkpoint(
+    session: Session, scope: ValidatedWorkflowScope, *, cycle: int
+) -> None:
+    """Durably mark one bounded Developer cycle as in progress."""
+
+    _require_cycle(scope, cycle)
+
+    def stage() -> None:
+        TaskStateMachine(session).transition(
+            scope.task,
+            TaskStatus.IN_PROGRESS,
+            actor_type=AuditActorType.AGENT,
+            actor_id=scope.developer.slug,
+            reason="Workflow developer cycle started.",
+        )
+
+    _commit_checkpoint(session, stage)
+
+
+def commit_developer_handoff_checkpoint(
+    session: Session, scope: ValidatedWorkflowScope, *, cycle: int
+) -> None:
+    """Durably record creation of one safe Reviewer handoff."""
+    _require_cycle(scope, cycle)
+
+    def stage() -> None:
+        append_workflow_event(
+            session,
+            scope,
+            WorkflowEventType.DEVELOPER_HANDOFF_CREATED,
+            cycle=cycle,
+        )
+
+    _commit_checkpoint(session, stage)
+
+
+def commit_developer_completed_checkpoint(
+    session: Session, scope: ValidatedWorkflowScope, *, cycle: int
+) -> None:
+    """Durably mark one bounded Developer cycle ready for independent review."""
+    _require_cycle(scope, cycle)
+
+    def stage() -> None:
+        TaskStateMachine(session).transition(
+            scope.task,
+            TaskStatus.WAITING_REVIEW,
+            actor_type=AuditActorType.AGENT,
+            actor_id=scope.developer.slug,
+            reason="Workflow developer cycle completed.",
+        )
+
+    _commit_checkpoint(session, stage)
+
+
+def commit_review_completed_checkpoint(
+    session: Session,
+    scope: ValidatedWorkflowScope,
+    *,
+    cycle: int,
+    decision: ReviewDecision,
+    review_score: float,
+    finding_count: int,
+) -> None:
+    """Durably record one Reviewer decision and its exact next task state."""
+    _require_cycle(scope, cycle)
+    _require_review_decision(decision)
+    _require_review_score(review_score)
+    _require_finding_count(finding_count)
+    target = (
+        TaskStatus.WAITING_QA
+        if decision is ReviewDecision.APPROVED
+        else TaskStatus.CHANGES_REQUESTED
+    )
+    reason = (
+        "Workflow review approved."
+        if decision is ReviewDecision.APPROVED
+        else "Workflow review requested changes."
+    )
+
+    def stage() -> None:
+        TaskStateMachine(session).transition(
+            scope.task,
+            target,
+            actor_type=AuditActorType.AGENT,
+            actor_id=scope.reviewer.slug,
+            reason=reason,
+        )
+        append_workflow_event(
+            session,
+            scope,
+            WorkflowEventType.REVIEW_COMPLETED,
+            cycle=cycle,
+            decision=decision,
+            review_score=review_score,
+            finding_count=finding_count,
+        )
+        if decision is ReviewDecision.APPROVED:
+            append_workflow_event(
+                session,
+                scope,
+                WorkflowEventType.WORKFLOW_COMPLETED,
+                cycle=cycle,
+            )
+
+    _commit_checkpoint(session, stage)
+
+
+def commit_review_cycle_exhausted_checkpoint(
+    session: Session,
+    scope: ValidatedWorkflowScope,
+    *,
+    cycle: int,
+    max_review_cycles: int,
+) -> None:
+    """Durably escalate an exhausted review workflow to human attention."""
+    _require_cycle(scope, cycle)
+    _require_max_review_cycles(scope, max_review_cycles)
+
+    def stage() -> None:
+        TaskStateMachine(session).transition(
+            scope.task,
+            TaskStatus.WAITING_HUMAN,
+            actor_type=AuditActorType.AGENT,
+            actor_id=scope.reviewer.slug,
+            reason="Workflow review cycles exhausted.",
+        )
+        append_workflow_event(
+            session,
+            scope,
+            WorkflowEventType.REVIEW_CYCLE_EXHAUSTED,
+            cycle=cycle,
+            max_review_cycles=max_review_cycles,
+        )
+
+    _commit_checkpoint(session, stage)
+
+
+def commit_next_review_cycle_checkpoint(
+    session: Session, scope: ValidatedWorkflowScope, *, cycle: int
+) -> None:
+    """Durably start the next bounded Developer cycle after requested changes."""
+    _require_cycle(scope, cycle)
+
+    def stage() -> None:
+        TaskStateMachine(session).transition(
+            scope.task,
+            TaskStatus.IN_PROGRESS,
+            actor_type=AuditActorType.AGENT,
+            actor_id=scope.developer.slug,
+            reason="Workflow correction cycle started.",
+        )
+
+    _commit_checkpoint(session, stage)
+
+
+def _commit_checkpoint(session: Session, stage: Callable[[], None]) -> None:
+    try:
+        stage()
+        session.commit()
+    except SQLAlchemyError:
+        session.rollback()
+        raise WorkflowError(WorkflowErrorCode.PERSISTENCE_FAILURE) from None
+
+
+def _event_data(
+    scope: ValidatedWorkflowScope,
+    event_type: WorkflowEventType,
+    *,
+    cycle: int | None,
+    decision: ReviewDecision | None,
+    review_score: float | None,
+    finding_count: int | None,
+    max_review_cycles: int | None,
+) -> dict[str, object]:
+    if event_type is WorkflowEventType.WORKFLOW_STARTED:
+        _require_absent(cycle, decision, review_score, finding_count, max_review_cycles)
+        return {
+            "developer_agent_id": scope.developer.slug,
+            "reviewer_agent_id": scope.reviewer.slug,
+            "max_review_cycles": scope.request.max_review_cycles,
+        }
+    if event_type is WorkflowEventType.DEVELOPER_HANDOFF_CREATED:
+        _require_absent(decision, review_score, finding_count, max_review_cycles)
+        return {"cycle": _require_cycle(scope, cycle)}
+    if event_type is WorkflowEventType.REVIEW_COMPLETED:
+        _require_absent(max_review_cycles)
+        return {
+            "cycle": _require_cycle(scope, cycle),
+            "decision": _require_review_decision(decision).value,
+            "review_score": _require_review_score(review_score),
+            "finding_count": _require_finding_count(finding_count),
+        }
+    if event_type is WorkflowEventType.REVIEW_CYCLE_EXHAUSTED:
+        _require_absent(decision, review_score, finding_count)
+        return {
+            "cycle": _require_cycle(scope, cycle),
+            "max_review_cycles": _require_max_review_cycles(scope, max_review_cycles),
+        }
+    _require_absent(decision, review_score, finding_count, max_review_cycles)
+    return {"cycle": _require_cycle(scope, cycle)}
+
+
+def _require_scope(scope: ValidatedWorkflowScope) -> None:
+    if type(scope) is not ValidatedWorkflowScope:
+        raise WorkflowError(WorkflowErrorCode.INVALID_INPUT)
+
+
+def _require_event_type(event_type: WorkflowEventType) -> None:
+    if type(event_type) is not WorkflowEventType:
+        raise WorkflowError(WorkflowErrorCode.INVALID_INPUT)
+
+
+def _require_cycle(scope: ValidatedWorkflowScope, cycle: int | None) -> int:
+    if type(cycle) is not int or not 1 <= cycle <= scope.request.max_review_cycles:
+        raise WorkflowError(WorkflowErrorCode.INVALID_INPUT)
+    return cycle
+
+
+def _require_review_decision(decision: ReviewDecision | None) -> ReviewDecision:
+    if type(decision) is not ReviewDecision or decision not in {
+        ReviewDecision.APPROVED,
+        ReviewDecision.CHANGES_REQUESTED,
+    }:
+        raise WorkflowError(WorkflowErrorCode.INVALID_INPUT)
+    return decision
+
+
+def _require_review_score(review_score: float | None) -> float:
+    if (
+        type(review_score) is not float
+        or not math.isfinite(review_score)
+        or not 0.0 <= review_score <= 1.0
+    ):
+        raise WorkflowError(WorkflowErrorCode.INVALID_INPUT)
+    return review_score
+
+
+def _require_finding_count(finding_count: int | None) -> int:
+    if type(finding_count) is not int or finding_count < 0 or finding_count > 128:
+        raise WorkflowError(WorkflowErrorCode.INVALID_INPUT)
+    return finding_count
+
+
+def _require_max_review_cycles(scope: ValidatedWorkflowScope, value: int | None) -> int:
+    if type(value) is not int or value != scope.request.max_review_cycles:
+        raise WorkflowError(WorkflowErrorCode.INVALID_INPUT)
+    return value
+
+
+def _require_absent(*values: object | None) -> None:
+    if any(value is not None for value in values):
+        raise WorkflowError(WorkflowErrorCode.INVALID_INPUT)

--- a/core/workflows/audit.py
+++ b/core/workflows/audit.py
@@ -5,16 +5,18 @@ from __future__ import annotations
 import math
 from collections.abc import Callable
 from enum import StrEnum
+from traceback import clear_frames
 
+from sqlalchemy import select
 from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.orm import Session
 
 from core.enums import AuditActorType, AuditResult, TaskStatus
 from core.reviewer import ReviewDecision
-from core.tasks.state_machine import TaskStateMachine
+from core.tasks.state_machine import InvalidTaskTransitionError, TaskStateMachine
 from core.workflows.errors import WorkflowError, WorkflowErrorCode
 from core.workflows.validation import ValidatedWorkflowScope
-from infrastructure.database.models import AuditEvent
+from infrastructure.database.models import AuditEvent, Task
 
 
 class WorkflowEventType(StrEnum):
@@ -52,7 +54,8 @@ def append_workflow_event(
     )
     actor_id = (
         scope.developer.slug
-        if event_type in {
+        if event_type
+        in {
             WorkflowEventType.WORKFLOW_STARTED,
             WorkflowEventType.DEVELOPER_HANDOFF_CREATED,
         }
@@ -79,9 +82,12 @@ def commit_assignment_checkpoint(session: Session, scope: ValidatedWorkflowScope
     """Durably assign the Developer and record the workflow start as one checkpoint."""
 
     def stage() -> None:
-        scope.task.assigned_agent_id = scope.developer.id
-        TaskStateMachine(session).transition(
-            scope.task,
+        task = _locked_ready_task(session, scope)
+        task.assigned_agent_id = scope.developer.id
+        _transition(
+            session,
+            scope,
+            task,
             TaskStatus.ASSIGNED,
             actor_type=AuditActorType.AGENT,
             actor_id=scope.developer.slug,
@@ -100,7 +106,9 @@ def commit_developer_started_checkpoint(
     _require_cycle(scope, cycle)
 
     def stage() -> None:
-        TaskStateMachine(session).transition(
+        _transition(
+            session,
+            scope,
             scope.task,
             TaskStatus.IN_PROGRESS,
             actor_type=AuditActorType.AGENT,
@@ -135,7 +143,9 @@ def commit_developer_completed_checkpoint(
     _require_cycle(scope, cycle)
 
     def stage() -> None:
-        TaskStateMachine(session).transition(
+        _transition(
+            session,
+            scope,
             scope.task,
             TaskStatus.WAITING_REVIEW,
             actor_type=AuditActorType.AGENT,
@@ -172,7 +182,9 @@ def commit_review_completed_checkpoint(
     )
 
     def stage() -> None:
-        TaskStateMachine(session).transition(
+        _transition(
+            session,
+            scope,
             scope.task,
             target,
             actor_type=AuditActorType.AGENT,
@@ -209,9 +221,13 @@ def commit_review_cycle_exhausted_checkpoint(
     """Durably escalate an exhausted review workflow to human attention."""
     _require_cycle(scope, cycle)
     _require_max_review_cycles(scope, max_review_cycles)
+    if cycle != max_review_cycles:
+        raise WorkflowError(WorkflowErrorCode.INVALID_INPUT)
 
     def stage() -> None:
-        TaskStateMachine(session).transition(
+        _transition(
+            session,
+            scope,
             scope.task,
             TaskStatus.WAITING_HUMAN,
             actor_type=AuditActorType.AGENT,
@@ -236,7 +252,9 @@ def commit_next_review_cycle_checkpoint(
     _require_cycle(scope, cycle)
 
     def stage() -> None:
-        TaskStateMachine(session).transition(
+        _transition(
+            session,
+            scope,
             scope.task,
             TaskStatus.IN_PROGRESS,
             actor_type=AuditActorType.AGENT,
@@ -248,12 +266,93 @@ def commit_next_review_cycle_checkpoint(
 
 
 def _commit_checkpoint(session: Session, stage: Callable[[], None]) -> None:
+    error_code: WorkflowErrorCode | None = None
     try:
         stage()
         session.commit()
-    except SQLAlchemyError:
+        return
+    except WorkflowError as error:
+        error_code = error.code
+        _discard_exception(error)
+        del error
+    except InvalidTaskTransitionError as error:
+        error_code = WorkflowErrorCode.INVALID_STATE
+        _discard_exception(error)
+        del error
+    except SQLAlchemyError as error:
+        error_code = WorkflowErrorCode.PERSISTENCE_FAILURE
+        _discard_exception(error)
+        del error
+    except Exception as error:
+        error_code = WorkflowErrorCode.INTERNAL_FAILURE
+        _discard_exception(error)
+        del error
+    _best_effort_rollback(session)
+    raise WorkflowError(error_code)
+
+
+def _locked_ready_task(session: Session, scope: ValidatedWorkflowScope) -> Task:
+    task = session.scalar(
+        select(Task)
+        .where(Task.id == scope.task.id)
+        .with_for_update()
+        .execution_options(populate_existing=True)
+    )
+    if task is None:
+        raise WorkflowError(WorkflowErrorCode.INVALID_SCOPE)
+    if task.status is not TaskStatus.READY or task.assigned_agent_id is not None:
+        raise WorkflowError(WorkflowErrorCode.INVALID_STATE)
+    return task
+
+
+def _transition(
+    session: Session,
+    scope: ValidatedWorkflowScope,
+    task: Task,
+    target: TaskStatus,
+    *,
+    actor_type: AuditActorType,
+    actor_id: str,
+    reason: str,
+) -> AuditEvent:
+    return TaskStateMachine(session).transition(
+        task,
+        target,
+        actor_type=actor_type,
+        actor_id=actor_id,
+        reason=reason,
+        correlation_id=scope.request.correlation_id,
+    )
+
+
+def _best_effort_rollback(session: Session) -> None:
+    try:
         session.rollback()
-        raise WorkflowError(WorkflowErrorCode.PERSISTENCE_FAILURE) from None
+    except BaseException as error:
+        _discard_exception(error)
+        del error
+
+
+def _discard_exception(error: BaseException) -> None:
+    pending = [error]
+    seen: set[int] = set()
+    while pending:
+        current = pending.pop()
+        if id(current) in seen:
+            continue
+        seen.add(id(current))
+        traceback = current.__traceback__
+        cause = current.__cause__
+        context = current.__context__
+        current.__traceback__ = None
+        current.__cause__ = None
+        current.__context__ = None
+        if traceback is not None:
+            clear_frames(traceback)
+        if cause is not None:
+            pending.append(cause)
+        if context is not None:
+            pending.append(context)
 
 
 def _event_data(

--- a/core/workflows/audit.py
+++ b/core/workflows/audit.py
@@ -95,7 +95,9 @@ def append_workflow_event(
 def commit_assignment_checkpoint(session: Session, scope: ValidatedWorkflowScope) -> None:
     """Durably assign the Developer and record the workflow start as one checkpoint."""
     stage = partial(_stage_assignment, session, scope)
-    failure = _commit_checkpoint(session, scope.task, stage)
+    preflight = partial(_locked_ready_task, session, scope)
+    failure = _commit_checkpoint(session, scope.task, stage, preflight=preflight)
+    del preflight
     del stage
     del scope
     del session
@@ -210,12 +212,11 @@ def commit_next_review_cycle_checkpoint(
 
 
 def _stage_assignment(session: Session, scope: ValidatedWorkflowScope) -> None:
-    task = _locked_ready_task(session, scope)
-    task.assigned_agent_id = scope.developer.id
+    scope.task.assigned_agent_id = scope.developer.id
     _transition(
         session,
         scope,
-        task,
+        scope.task,
         TaskStatus.ASSIGNED,
         actor_type=AuditActorType.AGENT,
         actor_id=scope.developer.slug,
@@ -338,11 +339,18 @@ def _stage_next_review_cycle(session: Session, scope: ValidatedWorkflowScope, cy
 
 
 def _commit_checkpoint(
-    session: Session, task: Task, stage: Callable[[], None]
+    session: Session,
+    task: Task,
+    stage: Callable[[], None],
+    *,
+    preflight: Callable[[], Task] | None = None,
 ) -> WorkflowError | None:
-    snapshot = _TaskSnapshot(status=task.status, assigned_agent_id=task.assigned_agent_id)
+    snapshot: _TaskSnapshot | None = None
     error_code: WorkflowErrorCode | None = None
     try:
+        if preflight is not None:
+            task = preflight()
+        snapshot = _TaskSnapshot(status=task.status, assigned_agent_id=task.assigned_agent_id)
         stage()
         session.commit()
         return None
@@ -365,7 +373,9 @@ def _commit_checkpoint(
     rollback_failed = _recover_failed_checkpoint(session, task, snapshot)
     if rollback_failed:
         error_code = WorkflowErrorCode.PERSISTENCE_FAILURE
+    assert error_code is not None
     del snapshot
+    del preflight
     del task
     del stage
     del session
@@ -411,12 +421,15 @@ def _transition(
     )
 
 
-def _recover_failed_checkpoint(session: Session, task: Task, snapshot: _TaskSnapshot) -> bool:
+def _recover_failed_checkpoint(
+    session: Session, task: Task, snapshot: _TaskSnapshot | None
+) -> bool:
     rollback_failed = _best_effort_rollback(session)
     if rollback_failed:
         _best_effort_invalidate(session)
     _best_effort_clear_authorizations(session)
-    _restore_task_snapshot(task, snapshot)
+    if snapshot is not None:
+        _restore_task_snapshot(task, snapshot)
     return rollback_failed
 
 

--- a/core/workflows/audit.py
+++ b/core/workflows/audit.py
@@ -12,6 +12,7 @@ from typing import NoReturn
 from uuid import UUID
 
 from sqlalchemy import select
+from sqlalchemy.engine import Connection
 from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.orm import Session
 from sqlalchemy.orm.attributes import set_committed_value
@@ -19,6 +20,7 @@ from sqlalchemy.orm.attributes import set_committed_value
 from core.enums import AuditActorType, AuditResult, TaskStatus
 from core.reviewer import ReviewDecision
 from core.tasks.state_machine import InvalidTaskTransitionError, TaskStateMachine
+from core.workflows.deadline import _configure_transaction_timeouts, _is_database_timeout
 from core.workflows.errors import WorkflowError, WorkflowErrorCode
 from core.workflows.validation import ValidatedWorkflowScope
 from infrastructure.database.models import AuditEvent, Task
@@ -43,7 +45,7 @@ class _TaskSnapshot:
     assigned_agent_id: UUID | None
 
 
-def append_workflow_event(
+def _stage_workflow_event(
     session: Session,
     scope: ValidatedWorkflowScope,
     event_type: WorkflowEventType,
@@ -92,57 +94,84 @@ def append_workflow_event(
     return event
 
 
-def commit_assignment_checkpoint(session: Session, scope: ValidatedWorkflowScope) -> None:
+def commit_assignment_checkpoint(
+    session: Session,
+    scope: ValidatedWorkflowScope,
+    *,
+    deadline: float | None = None,
+) -> None:
     """Durably assign the Developer and record the workflow start as one checkpoint."""
     stage = partial(_stage_assignment, session, scope)
-    preflight = partial(_locked_ready_task, session, scope)
-    failure = _commit_checkpoint(session, scope.task, stage, preflight=preflight)
-    del preflight
+    expected = _TaskSnapshot(status=TaskStatus.READY, assigned_agent_id=None)
+    failure = _commit_checkpoint(session, scope, stage, expected=expected, deadline=deadline)
+    del expected
     del stage
     del scope
     del session
+    del deadline
     if failure is not None:
         _raise_failure(failure)
 
 
 def commit_developer_started_checkpoint(
-    session: Session, scope: ValidatedWorkflowScope, *, cycle: int
+    session: Session,
+    scope: ValidatedWorkflowScope,
+    *,
+    cycle: int,
+    deadline: float | None = None,
 ) -> None:
     """Durably mark one bounded Developer cycle as in progress."""
     stage = partial(_stage_developer_started, session, scope, cycle)
-    failure = _commit_checkpoint(session, scope.task, stage)
+    expected = _assigned_task_snapshot(scope, TaskStatus.ASSIGNED)
+    failure = _commit_checkpoint(session, scope, stage, expected=expected, deadline=deadline)
+    del expected
     del stage
     del scope
     del session
     del cycle
+    del deadline
     if failure is not None:
         _raise_failure(failure)
 
 
 def commit_developer_handoff_checkpoint(
-    session: Session, scope: ValidatedWorkflowScope, *, cycle: int
+    session: Session,
+    scope: ValidatedWorkflowScope,
+    *,
+    cycle: int,
+    deadline: float | None = None,
 ) -> None:
     """Durably record creation of one safe Reviewer handoff."""
     stage = partial(_stage_developer_handoff, session, scope, cycle)
-    failure = _commit_checkpoint(session, scope.task, stage)
+    expected = _assigned_task_snapshot(scope, TaskStatus.WAITING_REVIEW)
+    failure = _commit_checkpoint(session, scope, stage, expected=expected, deadline=deadline)
+    del expected
     del stage
     del scope
     del session
     del cycle
+    del deadline
     if failure is not None:
         _raise_failure(failure)
 
 
 def commit_developer_completed_checkpoint(
-    session: Session, scope: ValidatedWorkflowScope, *, cycle: int
+    session: Session,
+    scope: ValidatedWorkflowScope,
+    *,
+    cycle: int,
+    deadline: float | None = None,
 ) -> None:
     """Durably mark one bounded Developer cycle ready for independent review."""
     stage = partial(_stage_developer_completed, session, scope, cycle)
-    failure = _commit_checkpoint(session, scope.task, stage)
+    expected = _assigned_task_snapshot(scope, TaskStatus.IN_PROGRESS)
+    failure = _commit_checkpoint(session, scope, stage, expected=expected, deadline=deadline)
+    del expected
     del stage
     del scope
     del session
     del cycle
+    del deadline
     if failure is not None:
         _raise_failure(failure)
 
@@ -155,6 +184,7 @@ def commit_review_completed_checkpoint(
     decision: ReviewDecision,
     review_score: float,
     finding_count: int,
+    deadline: float | None = None,
 ) -> None:
     """Durably record one Reviewer decision and its exact next task state."""
     stage = partial(
@@ -166,7 +196,9 @@ def commit_review_completed_checkpoint(
         review_score,
         finding_count,
     )
-    failure = _commit_checkpoint(session, scope.task, stage)
+    expected = _assigned_task_snapshot(scope, TaskStatus.WAITING_REVIEW)
+    failure = _commit_checkpoint(session, scope, stage, expected=expected, deadline=deadline)
+    del expected
     del stage
     del scope
     del session
@@ -174,6 +206,7 @@ def commit_review_completed_checkpoint(
     del decision
     del review_score
     del finding_count
+    del deadline
     if failure is not None:
         _raise_failure(failure)
 
@@ -184,29 +217,40 @@ def commit_review_cycle_exhausted_checkpoint(
     *,
     cycle: int,
     max_review_cycles: int,
+    deadline: float | None = None,
 ) -> None:
     """Durably escalate an exhausted review workflow to human attention."""
     stage = partial(_stage_review_cycle_exhausted, session, scope, cycle, max_review_cycles)
-    failure = _commit_checkpoint(session, scope.task, stage)
+    expected = _assigned_task_snapshot(scope, TaskStatus.CHANGES_REQUESTED)
+    failure = _commit_checkpoint(session, scope, stage, expected=expected, deadline=deadline)
+    del expected
     del stage
     del scope
     del session
     del cycle
     del max_review_cycles
+    del deadline
     if failure is not None:
         _raise_failure(failure)
 
 
 def commit_next_review_cycle_checkpoint(
-    session: Session, scope: ValidatedWorkflowScope, *, cycle: int
+    session: Session,
+    scope: ValidatedWorkflowScope,
+    *,
+    cycle: int,
+    deadline: float | None = None,
 ) -> None:
     """Durably start the next bounded Developer cycle after requested changes."""
     stage = partial(_stage_next_review_cycle, session, scope, cycle)
-    failure = _commit_checkpoint(session, scope.task, stage)
+    expected = _assigned_task_snapshot(scope, TaskStatus.CHANGES_REQUESTED)
+    failure = _commit_checkpoint(session, scope, stage, expected=expected, deadline=deadline)
+    del expected
     del stage
     del scope
     del session
     del cycle
+    del deadline
     if failure is not None:
         _raise_failure(failure)
 
@@ -216,14 +260,19 @@ def commit_safe_failure_checkpoint(
     scope: ValidatedWorkflowScope,
     *,
     error_code: WorkflowErrorCode,
+    expected_status: TaskStatus,
+    deadline: float | None = None,
 ) -> None:
     """Durably escalate one started workflow failure using only its stable category."""
     stage = partial(_stage_safe_failure, session, scope, error_code)
-    failure = _commit_checkpoint(session, scope.task, stage)
+    expected = _assigned_task_snapshot(scope, expected_status)
+    failure = _commit_checkpoint(session, scope, stage, expected=expected, deadline=deadline)
+    del expected
     del stage
     del scope
     del session
     del error_code
+    del deadline
     if failure is not None:
         _raise_failure(failure)
 
@@ -239,7 +288,7 @@ def _stage_assignment(session: Session, scope: ValidatedWorkflowScope) -> None:
         actor_id=scope.developer.slug,
         reason="Workflow developer assignment accepted.",
     )
-    append_workflow_event(session, scope, WorkflowEventType.WORKFLOW_STARTED)
+    _stage_workflow_event(session, scope, WorkflowEventType.WORKFLOW_STARTED)
 
 
 def _stage_developer_started(session: Session, scope: ValidatedWorkflowScope, cycle: int) -> None:
@@ -257,7 +306,7 @@ def _stage_developer_started(session: Session, scope: ValidatedWorkflowScope, cy
 
 def _stage_developer_handoff(session: Session, scope: ValidatedWorkflowScope, cycle: int) -> None:
     _require_cycle(scope, cycle)
-    append_workflow_event(session, scope, WorkflowEventType.DEVELOPER_HANDOFF_CREATED, cycle=cycle)
+    _stage_workflow_event(session, scope, WorkflowEventType.DEVELOPER_HANDOFF_CREATED, cycle=cycle)
 
 
 def _stage_developer_completed(session: Session, scope: ValidatedWorkflowScope, cycle: int) -> None:
@@ -304,7 +353,7 @@ def _stage_review_completed(
         actor_id=scope.reviewer.slug,
         reason=reason,
     )
-    append_workflow_event(
+    _stage_workflow_event(
         session,
         scope,
         WorkflowEventType.REVIEW_COMPLETED,
@@ -314,7 +363,7 @@ def _stage_review_completed(
         finding_count=finding_count,
     )
     if decision is ReviewDecision.APPROVED:
-        append_workflow_event(session, scope, WorkflowEventType.WORKFLOW_COMPLETED, cycle=cycle)
+        _stage_workflow_event(session, scope, WorkflowEventType.WORKFLOW_COMPLETED, cycle=cycle)
 
 
 def _stage_review_cycle_exhausted(
@@ -333,7 +382,7 @@ def _stage_review_cycle_exhausted(
         actor_id=scope.reviewer.slug,
         reason="Workflow review cycles exhausted.",
     )
-    append_workflow_event(
+    _stage_workflow_event(
         session,
         scope,
         WorkflowEventType.REVIEW_CYCLE_EXHAUSTED,
@@ -373,16 +422,21 @@ def _stage_safe_failure(
 
 def _commit_checkpoint(
     session: Session,
-    task: Task,
+    scope: ValidatedWorkflowScope,
     stage: Callable[[], None],
     *,
-    preflight: Callable[[], Task] | None = None,
+    expected: _TaskSnapshot,
+    deadline: float | None,
 ) -> WorkflowError | None:
     snapshot: _TaskSnapshot | None = None
+    connection: Connection | None = None
     error_code: WorkflowErrorCode | None = None
+    task = scope.task
     try:
-        if preflight is not None:
-            task = preflight()
+        connection = session.connection()
+        if deadline is not None:
+            _configure_transaction_timeouts(session, deadline)
+        task = _locked_expected_task(session, scope, expected)
         snapshot = _TaskSnapshot(status=task.status, assigned_agent_id=task.assigned_agent_id)
         stage()
         session.commit()
@@ -396,19 +450,26 @@ def _commit_checkpoint(
         _discard_exception(error)
         del error
     except SQLAlchemyError as error:
-        error_code = WorkflowErrorCode.PERSISTENCE_FAILURE
+        error_code = (
+            WorkflowErrorCode.TIMEOUT
+            if _is_database_timeout(error)
+            else WorkflowErrorCode.PERSISTENCE_FAILURE
+        )
         _discard_exception(error)
         del error
     except Exception as error:
         error_code = WorkflowErrorCode.INTERNAL_FAILURE
         _discard_exception(error)
         del error
-    rollback_failed = _recover_failed_checkpoint(session, task, snapshot)
+    rollback_failed = _recover_failed_checkpoint(session, connection, task, snapshot)
     if rollback_failed:
         error_code = WorkflowErrorCode.PERSISTENCE_FAILURE
     assert error_code is not None
     del snapshot
-    del preflight
+    del expected
+    del scope
+    del connection
+    del deadline
     del task
     del stage
     del session
@@ -420,18 +481,27 @@ def _raise_failure(error: WorkflowError) -> NoReturn:
     raise error
 
 
-def _locked_ready_task(session: Session, scope: ValidatedWorkflowScope) -> Task:
-    task = session.scalar(
-        select(Task)
-        .where(Task.id == scope.task.id)
-        .with_for_update()
-        .execution_options(populate_existing=True)
-    )
+def _locked_expected_task(
+    session: Session,
+    scope: ValidatedWorkflowScope,
+    expected: _TaskSnapshot,
+) -> Task:
+    with session.no_autoflush:
+        task = session.scalar(
+            select(Task)
+            .where(Task.id == scope.task.id)
+            .with_for_update()
+            .execution_options(populate_existing=True)
+        )
     if task is None:
         raise WorkflowError(WorkflowErrorCode.INVALID_SCOPE)
-    if task.status is not TaskStatus.READY or task.assigned_agent_id is not None:
+    if task.status is not expected.status or task.assigned_agent_id != expected.assigned_agent_id:
         raise WorkflowError(WorkflowErrorCode.INVALID_STATE)
     return task
+
+
+def _assigned_task_snapshot(scope: ValidatedWorkflowScope, status: TaskStatus) -> _TaskSnapshot:
+    return _TaskSnapshot(status=status, assigned_agent_id=scope.developer.id)
 
 
 def _transition(
@@ -457,11 +527,14 @@ def _transition(
 
 
 def _recover_failed_checkpoint(
-    session: Session, task: Task, snapshot: _TaskSnapshot | None
+    session: Session,
+    connection: Connection | None,
+    task: Task,
+    snapshot: _TaskSnapshot | None,
 ) -> bool:
     rollback_failed = _best_effort_rollback(session)
-    if rollback_failed:
-        _best_effort_invalidate(session)
+    if rollback_failed and connection is not None:
+        _best_effort_invalidate(connection)
     _best_effort_clear_authorizations(session)
     if snapshot is not None:
         _restore_task_snapshot(task, snapshot)
@@ -478,9 +551,9 @@ def _best_effort_rollback(session: Session) -> bool:
     return False
 
 
-def _best_effort_invalidate(session: Session) -> None:
+def _best_effort_invalidate(connection: Connection) -> None:
     try:
-        session.invalidate()
+        connection.invalidate()
     except BaseException as error:
         _discard_exception(error)
         del error

--- a/core/workflows/audit.py
+++ b/core/workflows/audit.py
@@ -211,6 +211,23 @@ def commit_next_review_cycle_checkpoint(
         _raise_failure(failure)
 
 
+def commit_safe_failure_checkpoint(
+    session: Session,
+    scope: ValidatedWorkflowScope,
+    *,
+    error_code: WorkflowErrorCode,
+) -> None:
+    """Durably escalate one started workflow failure using only its stable category."""
+    stage = partial(_stage_safe_failure, session, scope, error_code)
+    failure = _commit_checkpoint(session, scope.task, stage)
+    del stage
+    del scope
+    del session
+    del error_code
+    if failure is not None:
+        _raise_failure(failure)
+
+
 def _stage_assignment(session: Session, scope: ValidatedWorkflowScope) -> None:
     scope.task.assigned_agent_id = scope.developer.id
     _transition(
@@ -338,6 +355,22 @@ def _stage_next_review_cycle(session: Session, scope: ValidatedWorkflowScope, cy
     )
 
 
+def _stage_safe_failure(
+    session: Session, scope: ValidatedWorkflowScope, error_code: WorkflowErrorCode
+) -> None:
+    _require_safe_failure_code(error_code)
+    _transition(
+        session,
+        scope,
+        scope.task,
+        TaskStatus.WAITING_HUMAN,
+        actor_type=AuditActorType.SYSTEM,
+        actor_id=None,
+        reason="Workflow safely escalated for human attention.",
+        metadata={"workflow_error_code": error_code.value},
+    )
+
+
 def _commit_checkpoint(
     session: Session,
     task: Task,
@@ -408,8 +441,9 @@ def _transition(
     target: TaskStatus,
     *,
     actor_type: AuditActorType,
-    actor_id: str,
+    actor_id: str | None,
     reason: str,
+    metadata: dict[str, object] | None = None,
 ) -> AuditEvent:
     return TaskStateMachine(session).transition(
         task,
@@ -417,6 +451,7 @@ def _transition(
         actor_type=actor_type,
         actor_id=actor_id,
         reason=reason,
+        metadata=metadata,
         correlation_id=scope.request.correlation_id,
     )
 
@@ -530,6 +565,20 @@ def _event_data(
         }
     _require_absent(decision, review_score, finding_count, max_review_cycles)
     return {"cycle": _require_cycle(scope, cycle)}
+
+
+def _require_safe_failure_code(error_code: WorkflowErrorCode) -> None:
+    allowed_codes = frozenset(
+        {
+            WorkflowErrorCode.UNSAFE_HANDOFF,
+            WorkflowErrorCode.TIMEOUT,
+            WorkflowErrorCode.COLLABORATOR_FAILURE,
+            WorkflowErrorCode.PERSISTENCE_FAILURE,
+            WorkflowErrorCode.INTERNAL_FAILURE,
+        }
+    )
+    if type(error_code) is not WorkflowErrorCode or error_code not in allowed_codes:
+        raise WorkflowError(WorkflowErrorCode.INVALID_INPUT)
 
 
 def _require_scope(scope: ValidatedWorkflowScope) -> None:

--- a/core/workflows/deadline.py
+++ b/core/workflows/deadline.py
@@ -1,0 +1,70 @@
+"""PostgreSQL transaction-local enforcement for one workflow deadline."""
+
+from __future__ import annotations
+
+from math import floor
+from time import monotonic
+
+from sqlalchemy import text
+from sqlalchemy.exc import SQLAlchemyError
+from sqlalchemy.orm import Session
+
+from core.workflows.errors import (
+    WorkflowError,
+    WorkflowErrorCode,
+    _discard_exception,
+)
+
+_TIMEOUT_SQLSTATES = frozenset({"55P03", "57014"})
+
+
+def _configure_transaction_timeouts(session: Session, deadline: float) -> None:
+    """Apply the remaining global budget to the current PostgreSQL transaction."""
+    remaining = deadline - monotonic()
+    if remaining <= 0.0:
+        raise WorkflowError(WorkflowErrorCode.TIMEOUT)
+    timeout_milliseconds = max(1, floor(remaining * 1_000.0))
+    timeout_setting = f"{timeout_milliseconds}ms"
+    try:
+        session.execute(
+            text(
+                "SELECT "
+                "set_config('statement_timeout', :timeout_setting, true), "
+                "set_config('lock_timeout', :timeout_setting, true)"
+            ),
+            {"timeout_setting": timeout_setting},
+        )
+    except SQLAlchemyError as error:
+        code = (
+            WorkflowErrorCode.TIMEOUT
+            if _is_database_timeout(error) or monotonic() >= deadline
+            else WorkflowErrorCode.PERSISTENCE_FAILURE
+        )
+        _discard_exception(error)
+        del error
+        raise WorkflowError(code) from None
+    if monotonic() >= deadline:
+        raise WorkflowError(WorkflowErrorCode.TIMEOUT)
+
+
+def _is_database_timeout(error: BaseException) -> bool:
+    pending = [error]
+    seen: set[int] = set()
+    while pending:
+        current = pending.pop()
+        if id(current) in seen:
+            continue
+        seen.add(id(current))
+        sqlstate = getattr(current, "sqlstate", None) or getattr(current, "pgcode", None)
+        if sqlstate in _TIMEOUT_SQLSTATES:
+            return True
+        original = getattr(current, "orig", None)
+        cause = current.__cause__
+        context = current.__context__
+        if isinstance(original, BaseException):
+            pending.append(original)
+        if cause is not None:
+            pending.append(cause)
+        if context is not None:
+            pending.append(context)
+    return False

--- a/core/workflows/errors.py
+++ b/core/workflows/errors.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 from enum import StrEnum
+from traceback import clear_frames
+from typing import NoReturn
 
 
 class WorkflowErrorCode(StrEnum):
@@ -43,3 +45,31 @@ class WorkflowError(Exception):
         self.code = code
         self.safe_message = _SAFE_MESSAGES[code]
         super().__init__(self.safe_message)
+
+
+def _discard_exception(error: BaseException) -> None:
+    """Clear traceback links and frames before replacing an internal failure."""
+    pending = [error]
+    seen: set[int] = set()
+    while pending:
+        current = pending.pop()
+        if id(current) in seen:
+            continue
+        seen.add(id(current))
+        traceback = current.__traceback__
+        cause = current.__cause__
+        context = current.__context__
+        current.__traceback__ = None
+        current.__cause__ = None
+        current.__context__ = None
+        if traceback is not None:
+            clear_frames(traceback)
+        if cause is not None:
+            pending.append(cause)
+        if context is not None:
+            pending.append(context)
+
+
+def _raise_workflow_error(code: WorkflowErrorCode) -> NoReturn:
+    """Raise one application-owned error from a scope-free frame."""
+    raise WorkflowError(code) from None

--- a/core/workflows/errors.py
+++ b/core/workflows/errors.py
@@ -1,0 +1,45 @@
+"""Stable sanitized failures for the Phase 16 workflow boundary."""
+
+from __future__ import annotations
+
+from enum import StrEnum
+
+
+class WorkflowErrorCode(StrEnum):
+    """Closed public failure classifications for the Developer–Reviewer workflow."""
+
+    INVALID_INPUT = "INVALID_INPUT"
+    INVALID_SCOPE = "INVALID_SCOPE"
+    INVALID_STATE = "INVALID_STATE"
+    INVALID_ROLE = "INVALID_ROLE"
+    INVALID_AGENT = "INVALID_AGENT"
+    UNSAFE_HANDOFF = "UNSAFE_HANDOFF"
+    TIMEOUT = "TIMEOUT"
+    COLLABORATOR_FAILURE = "COLLABORATOR_FAILURE"
+    PERSISTENCE_FAILURE = "PERSISTENCE_FAILURE"
+    INTERNAL_FAILURE = "INTERNAL_FAILURE"
+
+
+_SAFE_MESSAGES = {
+    WorkflowErrorCode.INVALID_INPUT: "Workflow input is invalid.",
+    WorkflowErrorCode.INVALID_SCOPE: "Workflow scope is invalid.",
+    WorkflowErrorCode.INVALID_STATE: "Workflow task state is invalid.",
+    WorkflowErrorCode.INVALID_ROLE: "Workflow agent role is invalid.",
+    WorkflowErrorCode.INVALID_AGENT: "Workflow agent is invalid.",
+    WorkflowErrorCode.UNSAFE_HANDOFF: "Workflow handoff is unsafe.",
+    WorkflowErrorCode.TIMEOUT: "Workflow timed out.",
+    WorkflowErrorCode.COLLABORATOR_FAILURE: "Workflow collaborator failed.",
+    WorkflowErrorCode.PERSISTENCE_FAILURE: "Workflow persistence failed.",
+    WorkflowErrorCode.INTERNAL_FAILURE: "Workflow internal failure.",
+}
+
+
+class WorkflowError(Exception):
+    """A leak-resistant workflow error carrying a stable safe message."""
+
+    def __init__(self, code: WorkflowErrorCode) -> None:
+        if type(code) is not WorkflowErrorCode:
+            raise TypeError("code must be a WorkflowErrorCode")
+        self.code = code
+        self.safe_message = _SAFE_MESSAGES[code]
+        super().__init__(self.safe_message)

--- a/core/workflows/handoff.py
+++ b/core/workflows/handoff.py
@@ -6,7 +6,12 @@ from pydantic import ValidationError
 
 from core.developer import DeveloperResult
 from core.reviewer import ReviewCheck, ReviewerError, ReviewerRequest, validate_reviewer_request
-from core.workflows.errors import WorkflowError, WorkflowErrorCode
+from core.workflows.errors import (
+    WorkflowError,
+    WorkflowErrorCode,
+    _discard_exception,
+    _raise_workflow_error,
+)
 from core.workflows.types import WorkflowHandoffContext
 
 
@@ -16,24 +21,47 @@ def validate_reviewer_handoff(
     request: ReviewerRequest,
 ) -> ReviewerRequest:
     """Return only a fresh Reviewer request derived from the latest Developer evidence."""
-    if (
-        type(context) is not WorkflowHandoffContext
-        or type(developer_result) is not DeveloperResult
-        or type(request) is not ReviewerRequest
-    ):
-        raise WorkflowError(WorkflowErrorCode.UNSAFE_HANDOFF)
-    canonical_context = _canonicalize_context(context)
-    canonical_developer_result = _canonicalize_developer_result(developer_result)
-    canonical_request = _canonicalize_reviewer_request(request)
-    _require_exact_handoff(
-        canonical_context,
-        canonical_developer_result,
-        canonical_request,
-    )
+    result, error_code = _validate_reviewer_handoff_result(context, developer_result, request)
+    del context
+    del developer_result
+    del request
+    if error_code is not None:
+        del result
+        _raise_workflow_error(error_code)
+    assert result is not None
+    return result
+
+
+def _validate_reviewer_handoff_result(
+    context: WorkflowHandoffContext,
+    developer_result: DeveloperResult,
+    request: ReviewerRequest,
+) -> tuple[ReviewerRequest | None, WorkflowErrorCode | None]:
+    """Return a canonical handoff or one detached stable failure."""
     try:
-        return validate_reviewer_request(canonical_request).request
-    except ReviewerError:
-        raise WorkflowError(WorkflowErrorCode.UNSAFE_HANDOFF) from None
+        if (
+            type(context) is not WorkflowHandoffContext
+            or type(developer_result) is not DeveloperResult
+            or type(request) is not ReviewerRequest
+        ):
+            return None, WorkflowErrorCode.UNSAFE_HANDOFF
+        canonical_context = _canonicalize_context(context)
+        canonical_developer_result = _canonicalize_developer_result(developer_result)
+        canonical_request = _canonicalize_reviewer_request(request)
+        _require_exact_handoff(
+            canonical_context,
+            canonical_developer_result,
+            canonical_request,
+        )
+        return validate_reviewer_request(canonical_request).request, None
+    except (ReviewerError, WorkflowError) as error:
+        _discard_exception(error)
+        del error
+        return None, WorkflowErrorCode.UNSAFE_HANDOFF
+    except Exception as error:
+        _discard_exception(error)
+        del error
+        return None, WorkflowErrorCode.UNSAFE_HANDOFF
 
 
 def _canonicalize_context(context: WorkflowHandoffContext) -> WorkflowHandoffContext:

--- a/core/workflows/handoff.py
+++ b/core/workflows/handoff.py
@@ -77,6 +77,8 @@ def _require_exact_handoff(
         or request.acceptance_criteria != context.acceptance_criteria
         or request.developer_report != developer_result.report
         or request.required_check_profiles != context.required_check_profiles
+        or tuple(check.profile_id for check in developer_result.checks)
+        != context.required_check_profiles
         or request.checks != _convert_checks(developer_result)
     ):
         raise WorkflowError(WorkflowErrorCode.UNSAFE_HANDOFF)

--- a/core/workflows/handoff.py
+++ b/core/workflows/handoff.py
@@ -1,0 +1,95 @@
+"""Fail-closed revalidation for fresh Developer-to-Reviewer handoffs."""
+
+from __future__ import annotations
+
+from pydantic import ValidationError
+
+from core.developer import DeveloperResult
+from core.reviewer import ReviewCheck, ReviewerError, ReviewerRequest, validate_reviewer_request
+from core.workflows.errors import WorkflowError, WorkflowErrorCode
+from core.workflows.types import WorkflowHandoffContext
+
+
+def validate_reviewer_handoff(
+    context: WorkflowHandoffContext,
+    developer_result: DeveloperResult,
+    request: ReviewerRequest,
+) -> ReviewerRequest:
+    """Return only a fresh Reviewer request derived from the latest Developer evidence."""
+    if (
+        type(context) is not WorkflowHandoffContext
+        or type(developer_result) is not DeveloperResult
+        or type(request) is not ReviewerRequest
+    ):
+        raise WorkflowError(WorkflowErrorCode.UNSAFE_HANDOFF)
+    canonical_context = _canonicalize_context(context)
+    canonical_developer_result = _canonicalize_developer_result(developer_result)
+    canonical_request = _canonicalize_reviewer_request(request)
+    _require_exact_handoff(
+        canonical_context,
+        canonical_developer_result,
+        canonical_request,
+    )
+    try:
+        return validate_reviewer_request(canonical_request).request
+    except ReviewerError:
+        raise WorkflowError(WorkflowErrorCode.UNSAFE_HANDOFF) from None
+
+
+def _canonicalize_context(context: WorkflowHandoffContext) -> WorkflowHandoffContext:
+    try:
+        return WorkflowHandoffContext.model_validate(
+            context.model_dump(mode="python", warnings=False)
+        )
+    except (TypeError, ValueError, ValidationError):
+        raise WorkflowError(WorkflowErrorCode.UNSAFE_HANDOFF) from None
+
+
+def _canonicalize_developer_result(developer_result: DeveloperResult) -> DeveloperResult:
+    try:
+        return DeveloperResult.model_validate(
+            developer_result.model_dump(mode="python", warnings=False)
+        )
+    except (TypeError, ValueError, ValidationError):
+        raise WorkflowError(WorkflowErrorCode.UNSAFE_HANDOFF) from None
+
+
+def _canonicalize_reviewer_request(request: ReviewerRequest) -> ReviewerRequest:
+    try:
+        return ReviewerRequest.model_validate(request.model_dump(mode="python", warnings=False))
+    except (TypeError, ValueError, ValidationError):
+        raise WorkflowError(WorkflowErrorCode.UNSAFE_HANDOFF) from None
+
+
+def _require_exact_handoff(
+    context: WorkflowHandoffContext,
+    developer_result: DeveloperResult,
+    request: ReviewerRequest,
+) -> None:
+    if (
+        request.task_id != context.task_id
+        or request.project_id != context.project_id
+        or request.developer_id != context.developer_id
+        or request.reviewer_id != context.reviewer_id
+        or request.profile != context.reviewer_profile
+        or request.task_title != context.task_title
+        or request.task_description != context.task_description
+        or request.acceptance_criteria != context.acceptance_criteria
+        or request.developer_report != developer_result.report
+        or request.required_check_profiles != context.required_check_profiles
+        or request.checks != _convert_checks(developer_result)
+    ):
+        raise WorkflowError(WorkflowErrorCode.UNSAFE_HANDOFF)
+
+
+def _convert_checks(developer_result: DeveloperResult) -> tuple[ReviewCheck, ...]:
+    return tuple(
+        ReviewCheck(
+            profile_id=check.profile_id,
+            category=check.category,
+            status=check.status,
+            exit_code=check.exit_code,
+            truncated=check.truncated,
+        )
+        for check in developer_result.checks
+    )

--- a/core/workflows/orchestrator.py
+++ b/core/workflows/orchestrator.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+from collections.abc import Awaitable, Callable
 from traceback import clear_frames
 from typing import NoReturn
 
@@ -77,16 +78,21 @@ class WorkflowOrchestrator:
                         commit_developer_started_checkpoint(self._session, scope, cycle=cycle)
                     else:
                         commit_next_review_cycle_checkpoint(self._session, scope, cycle=cycle)
-                    developer_result = await self._developer.run(scope.request.developer_request)
+                    developer_result = await _invoke_collaborator(
+                        self._developer.run(scope.request.developer_request)
+                    )
                     commit_developer_completed_checkpoint(self._session, scope, cycle=cycle)
-                    handoff = await self._handoff_builder.build(
-                        scope.handoff_context, developer_result, cycle
+                    handoff = await _invoke_collaborator(
+                        self._handoff_builder.build(scope.handoff_context, developer_result, cycle)
                     )
                     reviewer_request = validate_reviewer_handoff(
                         scope.handoff_context, developer_result, handoff
                     )
                     commit_developer_handoff_checkpoint(self._session, scope, cycle=cycle)
-                    reviewer_result = await self._reviewer.run(reviewer_request)
+                    reviewer_result = await _invoke_collaborator(
+                        self._reviewer.run(reviewer_request),
+                        canonicalize=_canonicalize_reviewer_result,
+                    )
                     commit_review_completed_checkpoint(
                         self._session,
                         scope,
@@ -121,7 +127,7 @@ class WorkflowOrchestrator:
             _discard_exception(error)
             del error
         except Exception as error:
-            failure_code = WorkflowErrorCode.COLLABORATOR_FAILURE
+            failure_code = WorkflowErrorCode.INTERNAL_FAILURE
             _discard_exception(error)
             del error
 
@@ -171,9 +177,16 @@ def _exhausted_result(
     )
 
 
+def _canonicalize_reviewer_result(reviewer_result: ReviewerResult) -> ReviewerResult:
+    if type(reviewer_result) is not ReviewerResult:
+        raise TypeError("reviewer result must be a ReviewerResult")
+    return ReviewerResult.model_validate(reviewer_result.model_dump(mode="python", warnings=False))
+
+
 def _normalization_code(error: WorkflowError) -> WorkflowErrorCode:
     if error.code in {
         WorkflowErrorCode.UNSAFE_HANDOFF,
+        WorkflowErrorCode.COLLABORATOR_FAILURE,
         WorkflowErrorCode.PERSISTENCE_FAILURE,
     }:
         return error.code
@@ -195,6 +208,28 @@ def _safe_escalation_code(
         del error
         return safe_code
     return failure_code
+
+
+async def _invoke_collaborator[ResultT](
+    operation: Awaitable[ResultT],
+    *,
+    canonicalize: Callable[[ResultT], ResultT] | None = None,
+) -> ResultT:
+    try:
+        result = await operation
+        if canonicalize is not None:
+            result = canonicalize(result)
+        return result
+    except asyncio.CancelledError:
+        del operation
+        del canonicalize
+        raise
+    except Exception as error:
+        _discard_exception(error)
+        del error
+    del operation
+    del canonicalize
+    _raise_workflow_error(WorkflowErrorCode.COLLABORATOR_FAILURE)
 
 
 def _discard_exception(error: Exception) -> None:

--- a/core/workflows/orchestrator.py
+++ b/core/workflows/orchestrator.py
@@ -1,0 +1,225 @@
+"""Explicit bounded Developer–Reviewer orchestration for Phase 16."""
+
+from __future__ import annotations
+
+import asyncio
+from traceback import clear_frames
+from typing import NoReturn
+
+from sqlalchemy.orm import Session
+
+from core.developer import DeveloperResult
+from core.reviewer import ReviewDecision, ReviewerRequest, ReviewerResult
+from core.workflows.audit import (
+    commit_assignment_checkpoint,
+    commit_developer_completed_checkpoint,
+    commit_developer_handoff_checkpoint,
+    commit_developer_started_checkpoint,
+    commit_next_review_cycle_checkpoint,
+    commit_review_completed_checkpoint,
+    commit_review_cycle_exhausted_checkpoint,
+    commit_safe_failure_checkpoint,
+)
+from core.workflows.errors import WorkflowError, WorkflowErrorCode
+from core.workflows.handoff import validate_reviewer_handoff
+from core.workflows.ports import DeveloperRunner, ReviewerHandoffBuilder, ReviewerRunner
+from core.workflows.types import (
+    DeveloperReviewerWorkflowRequest,
+    DeveloperReviewerWorkflowResult,
+    WorkflowOutcome,
+)
+from core.workflows.validation import ValidatedWorkflowScope, validate_workflow_request
+
+
+class WorkflowOrchestrator:
+    """Run the one explicit Phase 16 Developer–Reviewer workflow."""
+
+    __slots__ = ("_developer", "_handoff_builder", "_reviewer", "_session")
+
+    def __init__(
+        self,
+        session: Session,
+        developer: DeveloperRunner,
+        reviewer: ReviewerRunner,
+        handoff_builder: ReviewerHandoffBuilder,
+    ) -> None:
+        self._session = session
+        self._developer = developer
+        self._reviewer = reviewer
+        self._handoff_builder = handoff_builder
+
+    async def run(
+        self, request: DeveloperReviewerWorkflowRequest
+    ) -> DeveloperReviewerWorkflowResult:
+        """Validate before beginning the one bounded, caller-owned workflow run."""
+        scope = validate_workflow_request(self._session, request)
+        operation = self._run_validated_scope(scope)
+        del scope
+        del request
+        return await operation
+
+    async def _run_validated_scope(
+        self, scope: ValidatedWorkflowScope
+    ) -> DeveloperReviewerWorkflowResult:
+        """Run checkpoints and external calls with one overall timeout."""
+        failure_code: WorkflowErrorCode | None = None
+        workflow_started = False
+        developer_result: DeveloperResult | None = None
+        handoff: ReviewerRequest | None = None
+        reviewer_request: ReviewerRequest | None = None
+        reviewer_result: ReviewerResult | None = None
+        try:
+            async with asyncio.timeout(scope.request.timeout_seconds):
+                commit_assignment_checkpoint(self._session, scope)
+                workflow_started = True
+                for cycle in range(1, scope.request.max_review_cycles + 1):
+                    if cycle == 1:
+                        commit_developer_started_checkpoint(self._session, scope, cycle=cycle)
+                    else:
+                        commit_next_review_cycle_checkpoint(self._session, scope, cycle=cycle)
+                    developer_result = await self._developer.run(scope.request.developer_request)
+                    commit_developer_completed_checkpoint(self._session, scope, cycle=cycle)
+                    handoff = await self._handoff_builder.build(
+                        scope.handoff_context, developer_result, cycle
+                    )
+                    reviewer_request = validate_reviewer_handoff(
+                        scope.handoff_context, developer_result, handoff
+                    )
+                    commit_developer_handoff_checkpoint(self._session, scope, cycle=cycle)
+                    reviewer_result = await self._reviewer.run(reviewer_request)
+                    commit_review_completed_checkpoint(
+                        self._session,
+                        scope,
+                        cycle=cycle,
+                        decision=reviewer_result.decision,
+                        review_score=reviewer_result.review_score,
+                        finding_count=len(reviewer_result.findings),
+                    )
+                    if reviewer_result.decision is ReviewDecision.APPROVED:
+                        return _approved_result(scope, cycle, developer_result, reviewer_result)
+                    if cycle == scope.request.max_review_cycles:
+                        commit_review_cycle_exhausted_checkpoint(
+                            self._session,
+                            scope,
+                            cycle=cycle,
+                            max_review_cycles=scope.request.max_review_cycles,
+                        )
+                        return _exhausted_result(scope, cycle, developer_result, reviewer_result)
+        except asyncio.CancelledError:
+            developer_result = None
+            handoff = None
+            reviewer_request = None
+            reviewer_result = None
+            del scope
+            raise
+        except TimeoutError as error:
+            failure_code = WorkflowErrorCode.TIMEOUT
+            _discard_exception(error)
+            del error
+        except WorkflowError as error:
+            failure_code = _normalization_code(error)
+            _discard_exception(error)
+            del error
+        except Exception as error:
+            failure_code = WorkflowErrorCode.COLLABORATOR_FAILURE
+            _discard_exception(error)
+            del error
+
+        if workflow_started:
+            failure_code = _safe_escalation_code(self._session, scope, failure_code)
+        developer_result = None
+        handoff = None
+        reviewer_request = None
+        reviewer_result = None
+        del scope
+        _raise_workflow_error(failure_code)
+
+
+def _approved_result(
+    scope: ValidatedWorkflowScope,
+    cycle: int,
+    developer_result: DeveloperResult,
+    reviewer_result: ReviewerResult,
+) -> DeveloperReviewerWorkflowResult:
+    return DeveloperReviewerWorkflowResult(
+        task_status=scope.task.status,
+        outcome=WorkflowOutcome.APPROVED,
+        max_review_cycles=scope.request.max_review_cycles,
+        developer_cycles=cycle,
+        reviewer_cycles=cycle,
+        developer_report=developer_result.report,
+        reviewer_result=reviewer_result,
+        correlation_id=scope.request.correlation_id,
+    )
+
+
+def _exhausted_result(
+    scope: ValidatedWorkflowScope,
+    cycle: int,
+    developer_result: DeveloperResult,
+    reviewer_result: ReviewerResult,
+) -> DeveloperReviewerWorkflowResult:
+    return DeveloperReviewerWorkflowResult(
+        task_status=scope.task.status,
+        outcome=WorkflowOutcome.REVIEW_CYCLES_EXHAUSTED,
+        max_review_cycles=scope.request.max_review_cycles,
+        developer_cycles=cycle,
+        reviewer_cycles=cycle,
+        developer_report=developer_result.report,
+        reviewer_result=reviewer_result,
+        correlation_id=scope.request.correlation_id,
+    )
+
+
+def _normalization_code(error: WorkflowError) -> WorkflowErrorCode:
+    if error.code in {
+        WorkflowErrorCode.UNSAFE_HANDOFF,
+        WorkflowErrorCode.PERSISTENCE_FAILURE,
+    }:
+        return error.code
+    return WorkflowErrorCode.INTERNAL_FAILURE
+
+
+def _safe_escalation_code(
+    session: Session,
+    scope: ValidatedWorkflowScope,
+    failure_code: WorkflowErrorCode | None,
+) -> WorkflowErrorCode:
+    if failure_code is None:
+        return WorkflowErrorCode.INTERNAL_FAILURE
+    try:
+        commit_safe_failure_checkpoint(session, scope, error_code=failure_code)
+    except WorkflowError as error:
+        safe_code = _normalization_code(error)
+        _discard_exception(error)
+        del error
+        return safe_code
+    return failure_code
+
+
+def _discard_exception(error: Exception) -> None:
+    pending = [error]
+    seen: set[int] = set()
+    while pending:
+        current = pending.pop()
+        if id(current) in seen:
+            continue
+        seen.add(id(current))
+        traceback = current.__traceback__
+        cause = current.__cause__
+        context = current.__context__
+        current.__traceback__ = None
+        current.__cause__ = None
+        current.__context__ = None
+        if traceback is not None:
+            clear_frames(traceback)
+        if isinstance(cause, Exception):
+            pending.append(cause)
+        if isinstance(context, Exception):
+            pending.append(context)
+
+
+def _raise_workflow_error(code: WorkflowErrorCode | None) -> NoReturn:
+    if code is None:
+        code = WorkflowErrorCode.INTERNAL_FAILURE
+    raise WorkflowError(code)

--- a/core/workflows/orchestrator.py
+++ b/core/workflows/orchestrator.py
@@ -3,13 +3,14 @@
 from __future__ import annotations
 
 import asyncio
+import math
 from collections.abc import Awaitable, Callable
-from traceback import clear_frames
-from typing import NoReturn
+from time import monotonic
 
 from sqlalchemy.orm import Session
 
 from core.developer import DeveloperResult
+from core.enums import TaskStatus
 from core.reviewer import ReviewDecision, ReviewerRequest, ReviewerResult
 from core.workflows.audit import (
     commit_assignment_checkpoint,
@@ -21,7 +22,12 @@ from core.workflows.audit import (
     commit_review_cycle_exhausted_checkpoint,
     commit_safe_failure_checkpoint,
 )
-from core.workflows.errors import WorkflowError, WorkflowErrorCode
+from core.workflows.errors import (
+    WorkflowError,
+    WorkflowErrorCode,
+    _discard_exception,
+    _raise_workflow_error,
+)
 from core.workflows.handoff import validate_reviewer_handoff
 from core.workflows.ports import DeveloperRunner, ReviewerHandoffBuilder, ReviewerRunner
 from core.workflows.types import (
@@ -29,7 +35,10 @@ from core.workflows.types import (
     DeveloperReviewerWorkflowResult,
     WorkflowOutcome,
 )
-from core.workflows.validation import ValidatedWorkflowScope, validate_workflow_request
+from core.workflows.validation import (
+    ValidatedWorkflowScope,
+    _validate_workflow_request_result,
+)
 
 
 class WorkflowOrchestrator:
@@ -53,42 +62,75 @@ class WorkflowOrchestrator:
         self, request: DeveloperReviewerWorkflowRequest
     ) -> DeveloperReviewerWorkflowResult:
         """Validate before beginning the one bounded, caller-owned workflow run."""
-        scope = validate_workflow_request(self._session, request)
-        operation = self._run_validated_scope(scope)
-        del scope
+        timeout_seconds = _request_timeout_seconds(request)
+        if timeout_seconds is None:
+            del request
+            del self
+            _raise_workflow_error(WorkflowErrorCode.INVALID_INPUT)
+        deadline = monotonic() + timeout_seconds
+        operation = self._run_with_deadline(request, timeout_seconds, deadline)
         del request
+        del timeout_seconds
+        del deadline
+        del self
         return await operation
 
-    async def _run_validated_scope(
-        self, scope: ValidatedWorkflowScope
+    async def _run_with_deadline(
+        self,
+        request: DeveloperReviewerWorkflowRequest,
+        timeout_seconds: float,
+        deadline: float,
     ) -> DeveloperReviewerWorkflowResult:
-        """Run checkpoints and external calls with one overall timeout."""
+        """Run preflight, checkpoints, and collaborators under one global deadline."""
         failure_code: WorkflowErrorCode | None = None
         workflow_started = False
+        scope: ValidatedWorkflowScope | None = None
         developer_result: DeveloperResult | None = None
         handoff: ReviewerRequest | None = None
         reviewer_request: ReviewerRequest | None = None
         reviewer_result: ReviewerResult | None = None
+        checkpoint_status = TaskStatus.READY
         try:
-            async with asyncio.timeout(scope.request.timeout_seconds):
-                commit_assignment_checkpoint(self._session, scope)
+            async with asyncio.timeout(timeout_seconds):
+                scope, preflight_error = _validate_workflow_request_result(
+                    self._session,
+                    request,
+                    deadline=deadline,
+                )
+                del request
+                if preflight_error is not None:
+                    _raise_workflow_error(preflight_error)
+                assert scope is not None
+                commit_assignment_checkpoint(self._session, scope, deadline=deadline)
                 workflow_started = True
+                checkpoint_status = TaskStatus.ASSIGNED
                 for cycle in range(1, scope.request.max_review_cycles + 1):
                     if cycle == 1:
-                        commit_developer_started_checkpoint(self._session, scope, cycle=cycle)
+                        commit_developer_started_checkpoint(
+                            self._session, scope, cycle=cycle, deadline=deadline
+                        )
                     else:
-                        commit_next_review_cycle_checkpoint(self._session, scope, cycle=cycle)
+                        commit_next_review_cycle_checkpoint(
+                            self._session, scope, cycle=cycle, deadline=deadline
+                        )
+                    checkpoint_status = TaskStatus.IN_PROGRESS
                     developer_result = await _invoke_collaborator(
-                        self._developer.run(scope.request.developer_request)
+                        self._developer.run(scope.request.developer_request),
+                        canonicalize=_canonicalize_developer_result,
                     )
-                    commit_developer_completed_checkpoint(self._session, scope, cycle=cycle)
+                    commit_developer_completed_checkpoint(
+                        self._session, scope, cycle=cycle, deadline=deadline
+                    )
+                    checkpoint_status = TaskStatus.WAITING_REVIEW
                     handoff = await _invoke_collaborator(
                         self._handoff_builder.build(scope.handoff_context, developer_result, cycle)
                     )
                     reviewer_request = validate_reviewer_handoff(
                         scope.handoff_context, developer_result, handoff
                     )
-                    commit_developer_handoff_checkpoint(self._session, scope, cycle=cycle)
+                    commit_developer_handoff_checkpoint(
+                        self._session, scope, cycle=cycle, deadline=deadline
+                    )
                     reviewer_result = await _invoke_collaborator(
                         self._reviewer.run(reviewer_request),
                         canonicalize=_canonicalize_reviewer_result,
@@ -100,6 +142,12 @@ class WorkflowOrchestrator:
                         decision=reviewer_result.decision,
                         review_score=reviewer_result.review_score,
                         finding_count=len(reviewer_result.findings),
+                        deadline=deadline,
+                    )
+                    checkpoint_status = (
+                        TaskStatus.WAITING_QA
+                        if reviewer_result.decision is ReviewDecision.APPROVED
+                        else TaskStatus.CHANGES_REQUESTED
                     )
                     if reviewer_result.decision is ReviewDecision.APPROVED:
                         return _approved_result(scope, cycle, developer_result, reviewer_result)
@@ -109,7 +157,9 @@ class WorkflowOrchestrator:
                             scope,
                             cycle=cycle,
                             max_review_cycles=scope.request.max_review_cycles,
+                            deadline=deadline,
                         )
+                        checkpoint_status = TaskStatus.WAITING_HUMAN
                         return _exhausted_result(scope, cycle, developer_result, reviewer_result)
         except asyncio.CancelledError:
             developer_result = None
@@ -117,13 +167,16 @@ class WorkflowOrchestrator:
             reviewer_request = None
             reviewer_result = None
             del scope
+            del timeout_seconds
+            del deadline
+            del self
             raise
         except TimeoutError as error:
             failure_code = WorkflowErrorCode.TIMEOUT
             _discard_exception(error)
             del error
         except WorkflowError as error:
-            failure_code = _normalization_code(error)
+            failure_code = error.code if not workflow_started else _normalization_code(error)
             _discard_exception(error)
             del error
         except Exception as error:
@@ -131,13 +184,30 @@ class WorkflowOrchestrator:
             _discard_exception(error)
             del error
 
-        if workflow_started:
-            failure_code = _safe_escalation_code(self._session, scope, failure_code)
+        if (
+            workflow_started
+            and scope is not None
+            and failure_code is not WorkflowErrorCode.INVALID_STATE
+        ):
+            recovery_deadline = monotonic() + min(timeout_seconds, 0.05)
+            failure_code = _safe_escalation_code(
+                self._session,
+                scope,
+                failure_code,
+                expected_status=checkpoint_status,
+                deadline=recovery_deadline,
+            )
         developer_result = None
         handoff = None
         reviewer_request = None
         reviewer_result = None
+        if failure_code is None:
+            failure_code = WorkflowErrorCode.INTERNAL_FAILURE
         del scope
+        del timeout_seconds
+        del deadline
+        del self
+
         _raise_workflow_error(failure_code)
 
 
@@ -183,11 +253,21 @@ def _canonicalize_reviewer_result(reviewer_result: ReviewerResult) -> ReviewerRe
     return ReviewerResult.model_validate(reviewer_result.model_dump(mode="python", warnings=False))
 
 
+def _canonicalize_developer_result(developer_result: DeveloperResult) -> DeveloperResult:
+    if type(developer_result) is not DeveloperResult:
+        raise TypeError("developer result must be a DeveloperResult")
+    return DeveloperResult.model_validate(
+        developer_result.model_dump(mode="python", warnings=False)
+    )
+
+
 def _normalization_code(error: WorkflowError) -> WorkflowErrorCode:
     if error.code in {
         WorkflowErrorCode.UNSAFE_HANDOFF,
         WorkflowErrorCode.COLLABORATOR_FAILURE,
         WorkflowErrorCode.PERSISTENCE_FAILURE,
+        WorkflowErrorCode.INVALID_STATE,
+        WorkflowErrorCode.TIMEOUT,
     }:
         return error.code
     return WorkflowErrorCode.INTERNAL_FAILURE
@@ -197,17 +277,46 @@ def _safe_escalation_code(
     session: Session,
     scope: ValidatedWorkflowScope,
     failure_code: WorkflowErrorCode | None,
+    *,
+    expected_status: TaskStatus,
+    deadline: float,
 ) -> WorkflowErrorCode:
     if failure_code is None:
         return WorkflowErrorCode.INTERNAL_FAILURE
     try:
-        commit_safe_failure_checkpoint(session, scope, error_code=failure_code)
+        safe_failure_code = (
+            WorkflowErrorCode.INTERNAL_FAILURE
+            if failure_code is WorkflowErrorCode.INVALID_STATE
+            else failure_code
+        )
+        commit_safe_failure_checkpoint(
+            session,
+            scope,
+            error_code=safe_failure_code,
+            expected_status=expected_status,
+            deadline=deadline,
+        )
     except WorkflowError as error:
         safe_code = _normalization_code(error)
         _discard_exception(error)
         del error
         return safe_code
     return failure_code
+
+
+def _request_timeout_seconds(
+    request: DeveloperReviewerWorkflowRequest,
+) -> float | None:
+    if type(request) is not DeveloperReviewerWorkflowRequest:
+        return None
+    timeout_seconds = request.timeout_seconds
+    if (
+        type(timeout_seconds) is not float
+        or not math.isfinite(timeout_seconds)
+        or not 0.0 < timeout_seconds <= 3_600.0
+    ):
+        return None
+    return timeout_seconds
 
 
 async def _invoke_collaborator[ResultT](
@@ -230,31 +339,3 @@ async def _invoke_collaborator[ResultT](
     del operation
     del canonicalize
     _raise_workflow_error(WorkflowErrorCode.COLLABORATOR_FAILURE)
-
-
-def _discard_exception(error: Exception) -> None:
-    pending = [error]
-    seen: set[int] = set()
-    while pending:
-        current = pending.pop()
-        if id(current) in seen:
-            continue
-        seen.add(id(current))
-        traceback = current.__traceback__
-        cause = current.__cause__
-        context = current.__context__
-        current.__traceback__ = None
-        current.__cause__ = None
-        current.__context__ = None
-        if traceback is not None:
-            clear_frames(traceback)
-        if isinstance(cause, Exception):
-            pending.append(cause)
-        if isinstance(context, Exception):
-            pending.append(context)
-
-
-def _raise_workflow_error(code: WorkflowErrorCode | None) -> NoReturn:
-    if code is None:
-        code = WorkflowErrorCode.INTERNAL_FAILURE
-    raise WorkflowError(code)

--- a/core/workflows/ports.py
+++ b/core/workflows/ports.py
@@ -1,0 +1,35 @@
+"""Narrow agent collaboration ports for the Phase 16 workflow."""
+
+from __future__ import annotations
+
+from typing import Protocol, runtime_checkable
+
+from core.developer import DeveloperRequest, DeveloperResult
+from core.reviewer import ReviewerRequest, ReviewerResult
+from core.workflows.types import WorkflowHandoffContext
+
+
+@runtime_checkable
+class DeveloperRunner(Protocol):
+    """Run one fully validated Developer cycle."""
+
+    async def run(self, request: DeveloperRequest) -> DeveloperResult: ...
+
+
+@runtime_checkable
+class ReviewerRunner(Protocol):
+    """Run one fully validated independent Reviewer cycle."""
+
+    async def run(self, request: ReviewerRequest) -> ReviewerResult: ...
+
+
+@runtime_checkable
+class ReviewerHandoffBuilder(Protocol):
+    """Build one fresh bounded Reviewer request from the latest Developer result."""
+
+    async def build(
+        self,
+        context: WorkflowHandoffContext,
+        developer_result: DeveloperResult,
+        cycle: int,
+    ) -> ReviewerRequest: ...

--- a/core/workflows/types.py
+++ b/core/workflows/types.py
@@ -46,6 +46,14 @@ NonblankTaskTitle = Annotated[TaskTitle, AfterValidator(_require_nonblank)]
 NonblankTaskDescription = Annotated[TaskDescription, AfterValidator(_require_nonblank)]
 
 
+def _canonicalize_nested_model[ModelT: BaseModel](
+    value: object, model_type: type[ModelT]
+) -> ModelT:
+    if isinstance(value, BaseModel):
+        return model_type.model_validate(value.model_dump(mode="python", warnings=False))
+    return model_type.model_validate(value)
+
+
 class WorkflowOutcome(StrEnum):
     """The only terminal outcomes the Phase 16 workflow may report."""
 
@@ -77,9 +85,25 @@ class DeveloperReviewerWorkflowRequest(_ImmutableWorkflowModel):
     timeout_seconds: Annotated[float, Field(gt=0.0, le=3600.0, allow_inf_nan=False)]
     correlation_id: UUID
 
+    @field_validator("developer_request", mode="before")
+    @classmethod
+    def canonicalize_developer_request(cls, value: object) -> DeveloperRequest:
+        return _canonicalize_nested_model(value, DeveloperRequest)
+
+    @field_validator("reviewer_profile", mode="before")
+    @classmethod
+    def canonicalize_reviewer_profile(cls, value: object) -> AgentProfile:
+        return _canonicalize_nested_model(value, AgentProfile)
+
+    @model_validator(mode="after")
+    def require_distinct_persistent_agent_ids(self) -> Self:
+        if self.developer_agent_id == self.reviewer_agent_id:
+            raise ValueError("developer and reviewer agents must be distinct")
+        return self
+
 
 class WorkflowHandoffContext(_ImmutableWorkflowModel):
-    """Bounded persistent scope used to build one independent Reviewer request."""
+    """Bounded transient validated scope used to build one independent Reviewer request."""
 
     task_id: CanonicalUUIDText
     project_id: CanonicalUUIDText
@@ -101,6 +125,11 @@ class WorkflowHandoffContext(_ImmutableWorkflowModel):
         if isinstance(value, (list, tuple)):
             return tuple(value)
         return value
+
+    @field_validator("reviewer_profile", mode="before")
+    @classmethod
+    def canonicalize_reviewer_profile(cls, value: object) -> AgentProfile:
+        return _canonicalize_nested_model(value, AgentProfile)
 
     @field_validator("acceptance_criteria")
     @classmethod
@@ -124,11 +153,22 @@ class DeveloperReviewerWorkflowResult(_ImmutableWorkflowModel):
 
     task_status: TaskStatus
     outcome: WorkflowOutcome
+    max_review_cycles: Annotated[int, Field(ge=1, le=10)]
     developer_cycles: Annotated[int, Field(ge=1, le=10)]
     reviewer_cycles: Annotated[int, Field(ge=1, le=10)]
     developer_report: AgentReport
     reviewer_result: ReviewerResult
     correlation_id: UUID
+
+    @field_validator("developer_report", mode="before")
+    @classmethod
+    def canonicalize_developer_report(cls, value: object) -> AgentReport:
+        return _canonicalize_nested_model(value, AgentReport)
+
+    @field_validator("reviewer_result", mode="before")
+    @classmethod
+    def canonicalize_reviewer_result(cls, value: object) -> ReviewerResult:
+        return _canonicalize_nested_model(value, ReviewerResult)
 
     @model_validator(mode="after")
     def require_truthful_terminal_result(self) -> Self:
@@ -140,6 +180,13 @@ class DeveloperReviewerWorkflowResult(_ImmutableWorkflowModel):
             raise ValueError("workflow terminal status and outcome are inconsistent")
         if self.developer_cycles != self.reviewer_cycles:
             raise ValueError("developer and reviewer cycle counts must match")
+        if self.developer_cycles > self.max_review_cycles:
+            raise ValueError("workflow cycle counts exceed the configured limit")
+        if (
+            self.outcome is WorkflowOutcome.REVIEW_CYCLES_EXHAUSTED
+            and self.developer_cycles != self.max_review_cycles
+        ):
+            raise ValueError("exhausted workflow cycle counts must equal the configured limit")
         expected_decision = (
             ReviewDecision.APPROVED
             if self.outcome is WorkflowOutcome.APPROVED

--- a/core/workflows/types.py
+++ b/core/workflows/types.py
@@ -1,0 +1,150 @@
+"""Strict immutable values for the Phase 16 Developer–Reviewer workflow."""
+
+from __future__ import annotations
+
+from enum import StrEnum
+from typing import Annotated, Self
+from uuid import UUID
+
+from pydantic import AfterValidator, BaseModel, ConfigDict, Field, field_validator, model_validator
+
+from core.agents import AgentProfile, AgentReport
+from core.commands import CommandProfileId
+from core.developer import DeveloperRequest
+from core.enums import TaskStatus
+from core.reviewer import ReviewDecision, ReviewerResult
+
+Identifier = Annotated[str, Field(pattern=r"^[a-z0-9][a-z0-9._:-]{0,127}$")]
+Criterion = Annotated[str, Field(min_length=1, max_length=1_024)]
+TaskTitle = Annotated[str, Field(min_length=1, max_length=255)]
+TaskDescription = Annotated[str, Field(min_length=1, max_length=8_192)]
+
+
+def _require_nonblank(value: str) -> str:
+    if not value.strip():
+        raise ValueError("text must not be blank")
+    return value
+
+
+def _require_canonical_uuid_text(value: str) -> str:
+    try:
+        parsed = UUID(value)
+    except (TypeError, ValueError) as error:
+        raise ValueError("value must be canonical UUID text") from error
+    if str(parsed) != value:
+        raise ValueError("value must be canonical UUID text")
+    return value
+
+
+CanonicalUUIDText = Annotated[
+    str,
+    Field(min_length=36, max_length=36),
+    AfterValidator(_require_canonical_uuid_text),
+]
+NonblankCriterion = Annotated[Criterion, AfterValidator(_require_nonblank)]
+NonblankTaskTitle = Annotated[TaskTitle, AfterValidator(_require_nonblank)]
+NonblankTaskDescription = Annotated[TaskDescription, AfterValidator(_require_nonblank)]
+
+
+class WorkflowOutcome(StrEnum):
+    """The only terminal outcomes the Phase 16 workflow may report."""
+
+    APPROVED = "APPROVED"
+    REVIEW_CYCLES_EXHAUSTED = "REVIEW_CYCLES_EXHAUSTED"
+
+
+class _ImmutableWorkflowModel(BaseModel):
+    """Shared strict, immutable configuration for public workflow contracts."""
+
+    model_config = ConfigDict(
+        frozen=True,
+        extra="forbid",
+        strict=True,
+        hide_input_in_errors=True,
+        revalidate_instances="always",
+    )
+
+
+class DeveloperReviewerWorkflowRequest(_ImmutableWorkflowModel):
+    """One fully scoped Developer–Reviewer workflow invocation."""
+
+    task_id: UUID
+    developer_agent_id: UUID
+    reviewer_agent_id: UUID
+    developer_request: DeveloperRequest
+    reviewer_profile: AgentProfile
+    max_review_cycles: Annotated[int, Field(ge=1, le=10)]
+    timeout_seconds: Annotated[float, Field(gt=0.0, le=3600.0, allow_inf_nan=False)]
+    correlation_id: UUID
+
+
+class WorkflowHandoffContext(_ImmutableWorkflowModel):
+    """Bounded persistent scope used to build one independent Reviewer request."""
+
+    task_id: CanonicalUUIDText
+    project_id: CanonicalUUIDText
+    task_title: NonblankTaskTitle
+    task_description: NonblankTaskDescription
+    acceptance_criteria: Annotated[
+        tuple[NonblankCriterion, ...], Field(min_length=1, max_length=16)
+    ]
+    developer_id: Identifier
+    reviewer_id: Identifier
+    reviewer_profile: AgentProfile
+    required_check_profiles: Annotated[
+        tuple[CommandProfileId, ...], Field(min_length=1, max_length=4)
+    ]
+
+    @field_validator("acceptance_criteria", "required_check_profiles", mode="before")
+    @classmethod
+    def copy_sequences(cls, value: object) -> object:
+        if isinstance(value, (list, tuple)):
+            return tuple(value)
+        return value
+
+    @field_validator("acceptance_criteria")
+    @classmethod
+    def require_unique_acceptance_criteria(cls, value: tuple[str, ...]) -> tuple[str, ...]:
+        if len(set(value)) != len(value):
+            raise ValueError("acceptance criteria must be unique")
+        return value
+
+    @field_validator("required_check_profiles")
+    @classmethod
+    def require_unique_required_check_profiles(
+        cls, value: tuple[CommandProfileId, ...]
+    ) -> tuple[CommandProfileId, ...]:
+        if len(set(value)) != len(value):
+            raise ValueError("required check profiles must be unique")
+        return value
+
+
+class DeveloperReviewerWorkflowResult(_ImmutableWorkflowModel):
+    """Bounded terminal result retaining only final reports and scalar workflow metadata."""
+
+    task_status: TaskStatus
+    outcome: WorkflowOutcome
+    developer_cycles: Annotated[int, Field(ge=1, le=10)]
+    reviewer_cycles: Annotated[int, Field(ge=1, le=10)]
+    developer_report: AgentReport
+    reviewer_result: ReviewerResult
+    correlation_id: UUID
+
+    @model_validator(mode="after")
+    def require_truthful_terminal_result(self) -> Self:
+        valid_pairs = {
+            (TaskStatus.WAITING_QA, WorkflowOutcome.APPROVED),
+            (TaskStatus.WAITING_HUMAN, WorkflowOutcome.REVIEW_CYCLES_EXHAUSTED),
+        }
+        if (self.task_status, self.outcome) not in valid_pairs:
+            raise ValueError("workflow terminal status and outcome are inconsistent")
+        if self.developer_cycles != self.reviewer_cycles:
+            raise ValueError("developer and reviewer cycle counts must match")
+        expected_decision = (
+            ReviewDecision.APPROVED
+            if self.outcome is WorkflowOutcome.APPROVED
+            else ReviewDecision.CHANGES_REQUESTED
+        )
+        if self.reviewer_result.decision is not expected_decision:
+            raise ValueError("workflow outcome and reviewer decision are inconsistent")
+        return self

--- a/core/workflows/validation.py
+++ b/core/workflows/validation.py
@@ -1,0 +1,152 @@
+"""Fail-closed persistent preflight for the Phase 16 workflow."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from pydantic import ValidationError
+from sqlalchemy.exc import SQLAlchemyError
+from sqlalchemy.orm import Session
+
+from core.developer import DeveloperError, validate_developer_request
+from core.enums import AgentStatus, TaskStatus
+from core.workflows.errors import WorkflowError, WorkflowErrorCode
+from core.workflows.types import DeveloperReviewerWorkflowRequest, WorkflowHandoffContext
+from infrastructure.database.models import Agent, Task
+
+_ACTIVE_AGENT_STATUSES = frozenset({AgentStatus.ASSIGNED, AgentStatus.WORKING})
+
+
+@dataclass(frozen=True, slots=True)
+class ValidatedWorkflowScope:
+    """Canonical persistent workflow state accepted before any external work."""
+
+    request: DeveloperReviewerWorkflowRequest
+    task: Task
+    developer: Agent
+    reviewer: Agent
+    handoff_context: WorkflowHandoffContext
+
+
+def validate_workflow_request(
+    session: Session, request: DeveloperReviewerWorkflowRequest
+) -> ValidatedWorkflowScope:
+    """Validate one strict workflow request against its persistent READY scope."""
+    if type(request) is not DeveloperReviewerWorkflowRequest:
+        raise WorkflowError(WorkflowErrorCode.INVALID_INPUT)
+    canonical_request = _canonicalize_request(request)
+    task, developer, reviewer = _load_scope(session, canonical_request)
+    _validate_persistent_scope(canonical_request, task, developer, reviewer)
+    _validate_developer_request(canonical_request)
+    handoff_context = _build_handoff_context(canonical_request, task)
+    _validate_developer_task_content(canonical_request, handoff_context)
+    return ValidatedWorkflowScope(
+        request=canonical_request,
+        task=task,
+        developer=developer,
+        reviewer=reviewer,
+        handoff_context=handoff_context,
+    )
+
+
+def _canonicalize_request(
+    request: DeveloperReviewerWorkflowRequest,
+) -> DeveloperReviewerWorkflowRequest:
+    try:
+        return DeveloperReviewerWorkflowRequest.model_validate(
+            request.model_dump(mode="python", warnings=False)
+        )
+    except (TypeError, ValueError, ValidationError):
+        raise WorkflowError(WorkflowErrorCode.INVALID_INPUT) from None
+
+
+def _validate_developer_request(request: DeveloperReviewerWorkflowRequest) -> None:
+    try:
+        validate_developer_request(request.developer_request)
+    except DeveloperError:
+        raise WorkflowError(WorkflowErrorCode.INVALID_INPUT) from None
+
+
+def _load_scope(
+    session: Session, request: DeveloperReviewerWorkflowRequest
+) -> tuple[Task, Agent, Agent]:
+    try:
+        task = session.get(Task, request.task_id)
+        developer = session.get(Agent, request.developer_agent_id)
+        reviewer = session.get(Agent, request.reviewer_agent_id)
+    except SQLAlchemyError:
+        raise WorkflowError(WorkflowErrorCode.PERSISTENCE_FAILURE) from None
+    if task is None or developer is None or reviewer is None:
+        raise WorkflowError(WorkflowErrorCode.INVALID_SCOPE)
+    return task, developer, reviewer
+
+
+def _validate_persistent_scope(
+    request: DeveloperReviewerWorkflowRequest,
+    task: Task,
+    developer: Agent,
+    reviewer: Agent,
+) -> None:
+    if task.status is not TaskStatus.READY:
+        raise WorkflowError(WorkflowErrorCode.INVALID_STATE)
+    if request.developer_agent_id == request.reviewer_agent_id:
+        raise WorkflowError(WorkflowErrorCode.INVALID_SCOPE)
+    if developer.role != "Developer" or reviewer.role != "Reviewer":
+        raise WorkflowError(WorkflowErrorCode.INVALID_ROLE)
+    if (
+        developer.status not in _ACTIVE_AGENT_STATUSES
+        or reviewer.status not in _ACTIVE_AGENT_STATUSES
+    ):
+        raise WorkflowError(WorkflowErrorCode.INVALID_AGENT)
+    developer_request = request.developer_request
+    context = developer_request.execution_context
+    reviewer_profile = request.reviewer_profile
+    if (
+        developer_request.profile.id != developer.slug
+        or developer_request.profile.role != developer.role
+        or developer_request.profile.status is not developer.status
+        or reviewer_profile.id != reviewer.slug
+        or reviewer_profile.role != reviewer.role
+        or reviewer_profile.status is not reviewer.status
+        or developer.slug == reviewer.slug
+        or developer_request.profile.id == reviewer_profile.id
+        or request.task_id != task.id
+        or developer_request.task.task_id != task.id
+        or context.task_id != task.id
+        or context.project_id != task.project_id
+        or context.agent_id != developer.slug
+        or context.correlation_id != request.correlation_id
+    ):
+        raise WorkflowError(WorkflowErrorCode.INVALID_SCOPE)
+
+
+def _build_handoff_context(
+    request: DeveloperReviewerWorkflowRequest, task: Task
+) -> WorkflowHandoffContext:
+    try:
+        return WorkflowHandoffContext.model_validate(
+            {
+                "task_id": str(task.id),
+                "project_id": str(task.project_id),
+                "task_title": task.title,
+                "task_description": task.description,
+                "acceptance_criteria": task.acceptance_criteria,
+                "developer_id": request.developer_request.profile.id,
+                "reviewer_id": request.reviewer_profile.id,
+                "reviewer_profile": request.reviewer_profile,
+                "required_check_profiles": request.developer_request.required_check_profiles,
+            }
+        )
+    except (TypeError, ValueError, ValidationError):
+        raise WorkflowError(WorkflowErrorCode.INVALID_SCOPE) from None
+
+
+def _validate_developer_task_content(
+    request: DeveloperReviewerWorkflowRequest, handoff_context: WorkflowHandoffContext
+) -> None:
+    runtime_task = request.developer_request.task
+    if (
+        runtime_task.objective != handoff_context.task_description
+        or runtime_task.acceptance_criteria != handoff_context.acceptance_criteria
+    ):
+        raise WorkflowError(WorkflowErrorCode.INVALID_SCOPE)

--- a/core/workflows/validation.py
+++ b/core/workflows/validation.py
@@ -10,7 +10,14 @@ from sqlalchemy.orm import Session
 
 from core.developer import DeveloperError, validate_developer_request
 from core.enums import AgentStatus, TaskStatus
-from core.workflows.errors import WorkflowError, WorkflowErrorCode
+from core.reviewer import ReviewerError, validate_reviewer_profile_authority
+from core.workflows.deadline import _configure_transaction_timeouts, _is_database_timeout
+from core.workflows.errors import (
+    WorkflowError,
+    WorkflowErrorCode,
+    _discard_exception,
+    _raise_workflow_error,
+)
 from core.workflows.types import DeveloperReviewerWorkflowRequest, WorkflowHandoffContext
 from infrastructure.database.models import Agent, Task
 
@@ -32,21 +39,79 @@ def validate_workflow_request(
     session: Session, request: DeveloperReviewerWorkflowRequest
 ) -> ValidatedWorkflowScope:
     """Validate one strict workflow request against its persistent READY scope."""
-    if type(request) is not DeveloperReviewerWorkflowRequest:
-        raise WorkflowError(WorkflowErrorCode.INVALID_INPUT)
-    canonical_request = _canonicalize_request(request)
-    task, developer, reviewer = _load_scope(session, canonical_request)
-    _validate_persistent_scope(canonical_request, task, developer, reviewer)
-    _validate_developer_request(canonical_request)
-    handoff_context = _build_handoff_context(canonical_request, task)
-    _validate_developer_task_content(canonical_request, handoff_context)
-    return ValidatedWorkflowScope(
-        request=canonical_request,
-        task=task,
-        developer=developer,
-        reviewer=reviewer,
-        handoff_context=handoff_context,
-    )
+    result, error_code = _validate_workflow_request_result(session, request)
+    del session
+    del request
+    if error_code is not None:
+        del result
+        _raise_workflow_error(error_code)
+    assert result is not None
+    return result
+
+
+def _validate_workflow_request_result(
+    session: Session,
+    request: DeveloperReviewerWorkflowRequest,
+    *,
+    deadline: float | None = None,
+) -> tuple[ValidatedWorkflowScope | None, WorkflowErrorCode | None]:
+    """Return canonical scope or one detached stable failure without raising publicly."""
+    try:
+        if type(request) is not DeveloperReviewerWorkflowRequest:
+            return None, WorkflowErrorCode.INVALID_INPUT
+        canonical_request = _canonicalize_request(request)
+        if deadline is not None:
+            _configure_transaction_timeouts(session, deadline)
+        task, developer, reviewer = _load_scope(session, canonical_request)
+        _validate_persistent_scope(canonical_request, task, developer, reviewer)
+        _validate_developer_request(canonical_request)
+        _validate_reviewer_authority(canonical_request)
+        handoff_context = _build_handoff_context(canonical_request, task)
+        _validate_developer_task_content(canonical_request, handoff_context)
+        return (
+            ValidatedWorkflowScope(
+                request=canonical_request,
+                task=task,
+                developer=developer,
+                reviewer=reviewer,
+                handoff_context=handoff_context,
+            ),
+            None,
+        )
+    except WorkflowError as error:
+        error_code = error.code
+        _discard_exception(error)
+        del error
+        return _failed_preflight_result(session, deadline, error_code)
+    except SQLAlchemyError as error:
+        error_code = (
+            WorkflowErrorCode.TIMEOUT
+            if _is_database_timeout(error)
+            else WorkflowErrorCode.PERSISTENCE_FAILURE
+        )
+        _discard_exception(error)
+        del error
+        return _failed_preflight_result(session, deadline, error_code)
+    except Exception as error:
+        _discard_exception(error)
+        del error
+        return _failed_preflight_result(session, deadline, WorkflowErrorCode.INTERNAL_FAILURE)
+
+
+def _failed_preflight_result(
+    session: Session,
+    deadline: float | None,
+    error_code: WorkflowErrorCode,
+) -> tuple[None, WorkflowErrorCode]:
+    if deadline is None:
+        return None, error_code
+    try:
+        session.rollback()
+    except BaseException as error:
+        _discard_exception(error)
+        del error
+        return None, WorkflowErrorCode.PERSISTENCE_FAILURE
+    return None, error_code
 
 
 def _canonicalize_request(
@@ -67,6 +132,15 @@ def _validate_developer_request(request: DeveloperReviewerWorkflowRequest) -> No
         raise WorkflowError(WorkflowErrorCode.INVALID_INPUT) from None
 
 
+def _validate_reviewer_authority(request: DeveloperReviewerWorkflowRequest) -> None:
+    try:
+        validate_reviewer_profile_authority(request.reviewer_profile)
+    except ReviewerError as error:
+        _discard_exception(error)
+        del error
+        raise WorkflowError(WorkflowErrorCode.INVALID_AGENT) from None
+
+
 def _load_scope(
     session: Session, request: DeveloperReviewerWorkflowRequest
 ) -> tuple[Task, Agent, Agent]:
@@ -74,8 +148,15 @@ def _load_scope(
         task = session.get(Task, request.task_id)
         developer = session.get(Agent, request.developer_agent_id)
         reviewer = session.get(Agent, request.reviewer_agent_id)
-    except SQLAlchemyError:
-        raise WorkflowError(WorkflowErrorCode.PERSISTENCE_FAILURE) from None
+    except SQLAlchemyError as error:
+        code = (
+            WorkflowErrorCode.TIMEOUT
+            if _is_database_timeout(error)
+            else WorkflowErrorCode.PERSISTENCE_FAILURE
+        )
+        _discard_exception(error)
+        del error
+        raise WorkflowError(code) from None
     if task is None or developer is None or reviewer is None:
         raise WorkflowError(WorkflowErrorCode.INVALID_SCOPE)
     return task, developer, reviewer

--- a/docs/developer-reviewer-workflow.md
+++ b/docs/developer-reviewer-workflow.md
@@ -15,13 +15,14 @@ explicit limits:
 
 Preflight loads the task and both persistent agents from the caller-owned SQLAlchemy session. It
 rejects missing or non-`READY` tasks, missing or inactive agents, incorrect roles, self-review,
-profile or runtime scope mismatches, and inconsistent bounded task criteria before assignment or
-an agent call. The Developer and Reviewer identities must differ both by persistent UUID and by
-profile slug.
+profile or runtime scope mismatches, unsafe Reviewer permissions or tool declarations, and
+inconsistent bounded task criteria before assignment or an agent call. The Developer and Reviewer
+identities must differ both by persistent UUID and by profile slug.
 
 The session is supplied by the caller. The orchestrator commits each durable checkpoint before the
-next external call and never closes, disposes, or reconfigures the session. Injected agents,
-providers, tools, handoff builders, and clients are also caller-owned.
+next external call and never closes or invalidates the Session. PostgreSQL statement and lock
+timeouts are transaction-local and disappear with the checkpoint commit or rollback. Injected
+agents, providers, tools, handoff builders, and clients are also caller-owned.
 
 ## Exact flow
 
@@ -80,7 +81,13 @@ Audit data is an allowlist of stable identifiers, cycle numbers, decisions, scor
 limits. It does not persist prompts, provider responses, conversation history, diffs, findings,
 rationales, command output, paths, environment values, exceptions, credentials, or arbitrary
 provider metadata. Events share the request correlation UUID and use the existing append-only
-audit model.
+audit model. Raw workflow-event staging is private; public callers can record these facts only
+through the state-coupled checkpoint functions that validate the exact legal source state.
+
+Before every checkpoint, the task row is reloaded with `SELECT FOR UPDATE` and
+`populate_existing`. The checkpoint requires the exact expected source status and assigned
+Developer UUID. A concurrent human escalation or cancellation therefore wins; stale workflow
+state raises `INVALID_STATE` without overwriting the task or recording a false workflow event.
 
 ## Result and resource bounds
 
@@ -91,9 +98,14 @@ not retain earlier results, diffs, prompts, responses, runtime histories, or com
 
 Each cycle invokes Developer once, the handoff builder once, and Reviewer once. There is no hidden
 retry, provider fallback, duplicate call, speculative parallel call, or unbounded collection. The
-overall timeout follows the same safe escalation path as a collaborator failure. Cancellation is
-re-raised immediately without another call; the last committed checkpoint remains the durable
-location of interruption. Database failures are rolled back and sanitized without retry.
+overall monotonic deadline starts before persistent preflight. Its remaining budget is installed as
+transaction-local PostgreSQL `statement_timeout` and `lock_timeout` before preflight and each
+checkpoint, so synchronous SQL and row-lock waits cannot escape the workflow limit. Timeout
+follows the same safe escalation path as a collaborator failure. Cancellation is re-raised
+immediately without another call; the last committed checkpoint remains the durable location of
+interruption. After the work deadline expires, safe escalation receives only a separate bounded
+50-millisecond cleanup transaction budget and cannot invoke a collaborator. Database failures are
+rolled back and sanitized without retry.
 
 ## Safe failures
 
@@ -102,6 +114,9 @@ failure, timeout, or persistence failure safely escalates the task to `WAITING_H
 transition is legal, records only a stable error category, and raises a sanitized `WorkflowError`.
 Cancellation is not converted into a normal failure. Raw exception messages and tracebacks never
 reach the public error or audit data. A Reviewer decision is never upgraded by the orchestrator.
+If rollback itself fails, only the poisoned SQLAlchemy connection is invalidated. The caller-owned
+Session is neither closed nor invalidated; the failure is fatal and the caller must discard or
+explicitly recover that Session before reuse.
 
 ## Usage example
 

--- a/docs/developer-reviewer-workflow.md
+++ b/docs/developer-reviewer-workflow.md
@@ -1,0 +1,139 @@
+# Developer–Reviewer Workflow
+
+Phase 16 provides the first concrete SynapseOS multi-agent workflow. It composes one persistent
+`READY` task, one Developer agent, one independent read-only Reviewer agent, and a bounded fresh
+evidence handoff. The public entry point is `core.workflows.WorkflowOrchestrator`.
+
+## Boundary and configuration
+
+`DeveloperReviewerWorkflowRequest` identifies the persistent task UUID, Developer UUID, Reviewer
+UUID, the bounded `DeveloperRequest`, the validated Reviewer profile, a correlation UUID, and two
+explicit limits:
+
+- `max_review_cycles` is an integer from 1 through 10.
+- `timeout_seconds` is greater than zero and no more than 3,600 seconds for the whole workflow.
+
+Preflight loads the task and both persistent agents from the caller-owned SQLAlchemy session. It
+rejects missing or non-`READY` tasks, missing or inactive agents, incorrect roles, self-review,
+profile or runtime scope mismatches, and inconsistent bounded task criteria before assignment or
+an agent call. The Developer and Reviewer identities must differ both by persistent UUID and by
+profile slug.
+
+The session is supplied by the caller. The orchestrator commits each durable checkpoint before the
+next external call and never closes, disposes, or reconfigures the session. Injected agents,
+providers, tools, handoff builders, and clients are also caller-owned.
+
+## Exact flow
+
+The workflow is explicit code with closed states and decisions:
+
+```text
+validate request and persistent scope
+  -> assign Developer; READY -> ASSIGNED
+  -> ASSIGNED -> IN_PROGRESS
+  -> run Developer once
+  -> IN_PROGRESS -> WAITING_REVIEW
+  -> build and validate a fresh Reviewer handoff once
+  -> run Reviewer once
+  -> APPROVED: WAITING_REVIEW -> WAITING_QA; return
+  -> CHANGES_REQUESTED: WAITING_REVIEW -> CHANGES_REQUESTED
+  -> if a cycle remains: CHANGES_REQUESTED -> IN_PROGRESS; repeat
+  -> if the limit is exhausted: CHANGES_REQUESTED -> WAITING_HUMAN; return
+```
+
+Only `TaskStateMachine` changes task status. The orchestrator does not assign `WAITING_SECURITY`,
+`COMPLETED`, or any later-phase state. `WAITING_QA` is the only successful terminal state in this
+phase.
+
+## Handoff contents and freshness
+
+`ReviewerHandoffBuilder` is an asynchronous caller-supplied boundary. It receives the validated
+workflow context, the latest bounded `DeveloperResult`, and the one-based cycle number. It must
+return one strict `ReviewerRequest` containing:
+
+- canonical task and project UUID text;
+- independent Developer and Reviewer profile slugs;
+- the validated title, description, and acceptance criteria;
+- the current bounded diff;
+- the exact latest Developer report;
+- a lossless allowlisted conversion of the latest Developer check metadata; and
+- the Developer request's required check profiles.
+
+The orchestrator revalidates the complete request before running the Reviewer. The builder runs
+once per completed Developer cycle and is never retried. A correction cycle therefore obtains a
+new diff and a new latest Developer result rather than reusing first-cycle evidence.
+
+## Checkpoints and audit
+
+Every task transition is persisted together with its authoritative `TASK_STATUS_CHANGED` event.
+Phase 16 adds these bounded correlated workflow events:
+
+| Event | Recorded fact |
+| --- | --- |
+| `WORKFLOW_STARTED` | Developer/Reviewer slugs and cycle limit after assignment |
+| `DEVELOPER_HANDOFF_CREATED` | one-based cycle after handoff validation |
+| `REVIEW_COMPLETED` | cycle, decision, score, and finding count |
+| `REVIEW_CYCLE_EXHAUSTED` | final cycle and configured limit |
+| `WORKFLOW_COMPLETED` | final approved cycle |
+
+Audit data is an allowlist of stable identifiers, cycle numbers, decisions, scores, counts, and
+limits. It does not persist prompts, provider responses, conversation history, diffs, findings,
+rationales, command output, paths, environment values, exceptions, credentials, or arbitrary
+provider metadata. Events share the request correlation UUID and use the existing append-only
+audit model.
+
+## Result and resource bounds
+
+`DeveloperReviewerWorkflowResult` is immutable and final-only. It contains the terminal task state,
+terminal workflow outcome, equal Developer/Reviewer cycle counts, the final bounded Developer
+report, the final sanitized Reviewer result, the cycle limit, and the correlation UUID. It does
+not retain earlier results, diffs, prompts, responses, runtime histories, or command output.
+
+Each cycle invokes Developer once, the handoff builder once, and Reviewer once. There is no hidden
+retry, provider fallback, duplicate call, speculative parallel call, or unbounded collection. The
+overall timeout follows the same safe escalation path as a collaborator failure. Cancellation is
+re-raised immediately without another call; the last committed checkpoint remains the durable
+location of interruption. Database failures are rolled back and sanitized without retry.
+
+## Safe failures
+
+Validation failures occur before side effects. After assignment, an unsafe handoff, collaborator
+failure, timeout, or persistence failure safely escalates the task to `WAITING_HUMAN` when that
+transition is legal, records only a stable error category, and raises a sanitized `WorkflowError`.
+Cancellation is not converted into a normal failure. Raw exception messages and tracebacks never
+reach the public error or audit data. A Reviewer decision is never upgraded by the orchestrator.
+
+## Usage example
+
+```python
+request = DeveloperReviewerWorkflowRequest(
+    task_id=task.id,
+    developer_agent_id=developer.id,
+    reviewer_agent_id=reviewer.id,
+    developer_request=developer_request,
+    reviewer_profile=reviewer_profile,
+    max_review_cycles=3,
+    timeout_seconds=120.0,
+    correlation_id=developer_request.execution_context.correlation_id,
+)
+
+result = await WorkflowOrchestrator(
+    session,
+    developer=developer_agent,
+    reviewer=reviewer_agent,
+    handoff_builder=handoff_builder,
+).run(request)
+
+assert result.task_status in {TaskStatus.WAITING_QA, TaskStatus.WAITING_HUMAN}
+```
+
+The caller remains responsible for the surrounding session and dependency lifecycle. A concrete
+deployment must supply the existing bounded `DeveloperAgent`, read-only `ReviewerAgent`, and a
+handoff builder that obtains current repository evidence through approved repository boundaries.
+
+## Phase 17 exclusions
+
+Phase 16 does not implement or invoke a QA agent, Security agent, merge or pull-request automation,
+event bus, background worker, scheduler, reputation update, memory write, deployment, or generic
+workflow language. `WAITING_QA` is a handoff boundary only. Phase 17 owns QA validation and any
+future transition out of that state; no Phase 17 behavior is present in this workflow.

--- a/docs/superpowers/plans/2026-08-30-phase-16-developer-reviewer-workflow.md
+++ b/docs/superpowers/plans/2026-08-30-phase-16-developer-reviewer-workflow.md
@@ -1,0 +1,546 @@
+# Phase 16 Developer–Reviewer Workflow Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build the first bounded multi-agent SynapseOS workflow from a persistent `READY` task through Developer correction cycles and independent Reviewer approval to `WAITING_QA`.
+
+**Architecture:** Add a focused `core/workflows` application package that composes the existing `DeveloperAgent`, `ReviewerAgent`, PostgreSQL `Task`, append-only `AuditEvent`, and `TaskStateMachine`. A narrow injected handoff builder supplies a fresh bounded diff after every Developer cycle; the orchestrator owns workflow sequencing and durable checkpoints but never owns injected resources.
+
+**Tech Stack:** Python 3.12+, Pydantic v2 strict immutable models, asyncio timeouts, SQLAlchemy 2 synchronous sessions, PostgreSQL 16, Alembic, pytest, FakeLLMProvider, Ruff, and mypy strict.
+
+**Spec:** `docs/superpowers/specs/2026-08-30-phase-16-developer-reviewer-workflow-design.md`
+
+## Global Constraints
+
+- Implement Phase 16 only; do not add QA, Security, merge, PR automation, event bus, scheduler, memory, reputation, deployment, or a generic workflow language.
+- The only successful terminal state is `WAITING_QA`; cycle exhaustion and safe escalation end in `WAITING_HUMAN`.
+- Developer and Reviewer identities must be distinct at both persistent UUID and profile-slug levels.
+- All task status changes go through `TaskStateMachine`; direct status assignment remains forbidden.
+- `max_review_cycles` is explicit and bounded from 1 through 10; workflow timeout is explicit, positive, and at most 3,600 seconds.
+- There is no implicit retry, fallback, duplicated provider/tool call, or speculative parallel call.
+- Cancellation propagates immediately; injected sessions, agents, providers, builders, tools, and clients are never closed.
+- Prompts, responses, diffs, findings, command output, paths, arbitrary metadata, raw exceptions, and sensitive values are never persisted in workflow audit data.
+- Tests use real PostgreSQL through Alembic; never call `metadata.create_all()`.
+- Write tests first, observe the expected RED failure, implement the minimum GREEN behavior, refactor only while green, and commit each independently reviewable task.
+
+---
+
+### Task 1: Define immutable workflow contracts and safe errors
+
+**Files:**
+- Create: `core/workflows/__init__.py`
+- Create: `core/workflows/errors.py`
+- Create: `core/workflows/types.py`
+- Test: `tests/workflows/__init__.py`
+- Test: `tests/workflows/factories.py`
+- Test: `tests/workflows/test_types.py`
+
+**Interfaces:**
+- Consumes: `DeveloperRequest`, `DeveloperResult`, `AgentProfile`, `AgentReport`, `ReviewerRequest`, `ReviewerResult`, `TaskStatus`, and UUID.
+- Produces: `WorkflowOutcome`, `DeveloperReviewerWorkflowRequest`, `DeveloperReviewerWorkflowResult`, `WorkflowHandoffContext`, `WorkflowErrorCode`, and `WorkflowError`.
+
+- [ ] **Step 1: Write strict contract tests**
+
+  Add tests proving that a valid request contains persistent task/Developer/Reviewer UUIDs,
+  `DeveloperRequest`, Reviewer profile, `max_review_cycles`, timeout, and correlation UUID. Assert
+  frozen instances, `extra="forbid"`, strict cycle/timeout bounds, copied immutable collections,
+  type-confused `model_copy()` rejection through public validation, and result cardinality:
+
+  ```python
+  request = DeveloperReviewerWorkflowRequest(
+      task_id=task.id,
+      developer_agent_id=developer.id,
+      reviewer_agent_id=reviewer.id,
+      developer_request=developer_request,
+      reviewer_profile=reviewer_profile,
+      max_review_cycles=2,
+      timeout_seconds=30.0,
+      correlation_id=developer_request.execution_context.correlation_id,
+  )
+  assert request.max_review_cycles == 2
+  with pytest.raises(ValidationError):
+      request.max_review_cycles = 3
+  ```
+
+  Test `DeveloperReviewerWorkflowResult` accepts only `WAITING_QA` with `APPROVED` and
+  `WAITING_HUMAN` with `REVIEW_CYCLES_EXHAUSTED`, requires equal non-zero Developer/Reviewer cycle
+  counts, and retains only final `AgentReport`/`ReviewerResult` plus scalar metadata.
+
+- [ ] **Step 2: Run the focused tests and verify RED**
+
+  Run: `.venv/bin/pytest tests/workflows/test_types.py -q`
+
+  Expected: collection fails because `core.workflows` does not exist.
+
+- [ ] **Step 3: Implement the minimum contracts**
+
+  Define strict frozen Pydantic models with `extra="forbid"` and `hide_input_in_errors=True`.
+  Define:
+
+  ```python
+  class WorkflowOutcome(StrEnum):
+      APPROVED = "APPROVED"
+      REVIEW_CYCLES_EXHAUSTED = "REVIEW_CYCLES_EXHAUSTED"
+
+  class DeveloperReviewerWorkflowRequest(_ImmutableWorkflowModel):
+      task_id: UUID
+      developer_agent_id: UUID
+      reviewer_agent_id: UUID
+      developer_request: DeveloperRequest
+      reviewer_profile: AgentProfile
+      max_review_cycles: Annotated[int, Field(ge=1, le=10)]
+      timeout_seconds: Annotated[float, Field(gt=0.0, le=3600.0, allow_inf_nan=False)]
+      correlation_id: UUID
+  ```
+
+  Add a bounded immutable `WorkflowHandoffContext` containing canonical task/project UUID text,
+  title, description, criteria, Developer/Reviewer slugs, Reviewer profile, and required profiles.
+  Add a result model validator enforcing truthful outcome/status pairs and cycle counts.
+
+  `WorkflowError` accepts only an enum code and maps it to an application-owned safe message. Codes
+  cover invalid input/scope/state/role/agent, unsafe handoff, timeout, collaborator failure,
+  persistence failure, and internal failure. Caller-provided messages are not accepted.
+
+- [ ] **Step 4: Run focused tests and quality checks**
+
+  Run:
+
+  ```bash
+  .venv/bin/pytest tests/workflows/test_types.py -q
+  .venv/bin/ruff check core/workflows tests/workflows
+  .venv/bin/mypy core/workflows tests/workflows
+  ```
+
+  Expected: all pass without warnings.
+
+- [ ] **Step 5: Commit Task 1**
+
+  ```bash
+  git add core/workflows tests/workflows
+  git commit -m "feat(workflow): define bounded orchestration contracts"
+  ```
+
+---
+
+### Task 2: Add fail-closed persistent workflow preflight
+
+**Files:**
+- Create: `core/workflows/validation.py`
+- Modify: `core/workflows/__init__.py`
+- Modify: `tests/workflows/factories.py`
+- Create: `tests/workflows/test_validation.py`
+
+**Interfaces:**
+- Consumes: `DeveloperReviewerWorkflowRequest`, SQLAlchemy `Session`, `Task`, `Agent`, existing Developer/Reviewer validation rules, and canonical workflow bounds.
+- Produces: `ValidatedWorkflowScope` and `validate_workflow_request(session, request) -> ValidatedWorkflowScope`.
+
+- [ ] **Step 1: Write PostgreSQL preflight tests**
+
+  Build Project, READY Task, Developer Agent, and Reviewer Agent through the existing PostgreSQL
+  fixture. Test a valid scope and parameterize rejection before collaborators for:
+
+  - non-exact or type-confused request;
+  - missing task or agent;
+  - task not `READY`;
+  - equal persistent UUIDs or equal profile slugs;
+  - wrong roles and `OFFLINE`/`BLOCKED` status;
+  - mismatched Developer slug, runtime task UUID, execution task/project/agent/correlation IDs;
+  - Developer objective/criteria inconsistent with the persistent task;
+  - absent, blank, non-string, duplicated, or over-bounds persistent criteria/title/description;
+  - Reviewer profile inconsistent with persistent Reviewer slug/role/status.
+
+  Assert task status, assignment, audit row count, Developer calls, Reviewer calls, and handoff calls
+  remain unchanged after every rejected preflight.
+
+- [ ] **Step 2: Run validation tests and verify RED**
+
+  Run: `.venv/bin/pytest tests/workflows/test_validation.py -q`
+
+  Expected: import or assertion failure because workflow validation is absent.
+
+- [ ] **Step 3: Implement strict canonical preflight**
+
+  First reject `type(request) is not DeveloperReviewerWorkflowRequest`; then dump and strictly
+  revalidate before reading nested fields. Load persistent records with the injected session and
+  validate all cross-scope equality. Do not interpolate rejected values into errors.
+
+  Return a frozen slots dataclass:
+
+  ```python
+  @dataclass(frozen=True, slots=True)
+  class ValidatedWorkflowScope:
+      request: DeveloperReviewerWorkflowRequest
+      task: Task
+      developer: Agent
+      reviewer: Agent
+      handoff_context: WorkflowHandoffContext
+  ```
+
+  Canonicalize persistent criteria to a unique tuple of nonblank strings and construct the bounded
+  handoff context. Keep ORM objects internal; never place them in public Pydantic results.
+
+- [ ] **Step 4: Run validation and regression tests**
+
+  Run:
+
+  ```bash
+  .venv/bin/pytest tests/workflows/test_validation.py tests/developer/test_validation.py tests/reviewer/test_validation.py -q
+  .venv/bin/ruff check core/workflows tests/workflows
+  .venv/bin/mypy core/workflows tests/workflows
+  ```
+
+  Expected: all pass.
+
+- [ ] **Step 5: Commit Task 2**
+
+  ```bash
+  git add core/workflows/validation.py core/workflows/__init__.py tests/workflows
+  git commit -m "feat(workflow): validate persistent agent scope"
+  ```
+
+---
+
+### Task 3: Define and enforce the fresh Reviewer handoff boundary
+
+**Files:**
+- Create: `core/workflows/ports.py`
+- Create: `core/workflows/handoff.py`
+- Modify: `core/workflows/__init__.py`
+- Create: `tests/workflows/fakes.py`
+- Create: `tests/workflows/test_handoff.py`
+
+**Interfaces:**
+- Consumes: `WorkflowHandoffContext`, latest `DeveloperResult`, one-based cycle, and existing Developer/Reviewer contracts.
+- Produces: `DeveloperRunner`, `ReviewerRunner`, `ReviewerHandoffBuilder` protocols and `validate_reviewer_handoff(context, developer_result, request) -> ReviewerRequest`.
+
+- [ ] **Step 1: Write handoff protocol and validation tests**
+
+  Define deterministic recording fakes in tests. Test that one valid handoff preserves only:
+
+  - canonical task/project and independent agent identifiers;
+  - task title, description, criteria, and current bounded diff;
+  - exact latest Developer report;
+  - exact required check profiles;
+  - lossless conversion of latest `DeveloperCheckResult` values into `ReviewCheck` values;
+  - exact Reviewer profile from the validated persistent scope.
+
+  Parameterize rejection of stale Developer report/checks, missing/extra/reordered check evidence,
+  stale identifiers, wrong profile, write/command permissions or tools, malformed diff, and
+  type-confused `ReviewerRequest`. Verify rejected values never appear in exception strings or repr.
+
+- [ ] **Step 2: Run handoff tests and verify RED**
+
+  Run: `.venv/bin/pytest tests/workflows/test_handoff.py -q`
+
+  Expected: import failure because ports and handoff validation are absent.
+
+- [ ] **Step 3: Implement structural ports and exact handoff revalidation**
+
+  Define runtime-checkable protocols with exact asynchronous signatures:
+
+  ```python
+  class DeveloperRunner(Protocol):
+      async def run(self, request: DeveloperRequest) -> DeveloperResult: ...
+
+  class ReviewerRunner(Protocol):
+      async def run(self, request: ReviewerRequest) -> ReviewerResult: ...
+
+  class ReviewerHandoffBuilder(Protocol):
+      async def build(
+          self,
+          context: WorkflowHandoffContext,
+          developer_result: DeveloperResult,
+          cycle: int,
+      ) -> ReviewerRequest: ...
+  ```
+
+  Canonicalize both `DeveloperResult` and returned `ReviewerRequest` before equality checks. Convert
+  Developer checks through explicit field copying; compare values, never object identity. Invoke
+  existing `validate_reviewer_request` after workflow-specific checks.
+
+- [ ] **Step 4: Run handoff and agent regression tests**
+
+  Run:
+
+  ```bash
+  .venv/bin/pytest tests/workflows/test_handoff.py tests/developer tests/reviewer -q
+  .venv/bin/ruff check core/workflows tests/workflows
+  .venv/bin/mypy core/workflows tests/workflows
+  ```
+
+  Expected: all pass with no hidden calls.
+
+- [ ] **Step 5: Commit Task 3**
+
+  ```bash
+  git add core/workflows tests/workflows
+  git commit -m "feat(workflow): enforce fresh review handoff"
+  ```
+
+---
+
+### Task 4: Add bounded append-only workflow audit checkpoints
+
+**Files:**
+- Create: `core/workflows/audit.py`
+- Modify: `core/workflows/errors.py`
+- Modify: `core/workflows/__init__.py`
+- Create: `tests/workflows/test_audit.py`
+
+**Interfaces:**
+- Consumes: `Session`, validated persistent scope, cycle, Reviewer decision/score/finding count, `TaskStateMachine`, and existing append-only `AuditEvent`.
+- Produces: `WorkflowEventType`, `append_workflow_event(...)`, and checkpoint helpers that atomically commit a status transition plus bounded workflow events.
+
+- [ ] **Step 1: Write real-PostgreSQL audit tests**
+
+  Test each event type and assert exact allowlisted JSON data. Test shared correlation UUID,
+  Developer/Reviewer actor attribution, project/task linkage, append-only behavior, chronological
+  status events, and absence of source markers placed in task text, diff, findings, reports,
+  exception strings, and workspace paths.
+
+  Add transaction tests proving assignment plus `READY -> ASSIGNED` plus `WORKFLOW_STARTED` commit
+  atomically, a transition failure rolls back its pending workflow event, and no helper closes the
+  injected session.
+
+- [ ] **Step 2: Run audit tests and verify RED**
+
+  Run: `.venv/bin/pytest tests/workflows/test_audit.py -q`
+
+  Expected: import failure because workflow audit helpers are absent.
+
+- [ ] **Step 3: Implement the allowlisted audit/checkpoint layer**
+
+  Define closed event values and explicit constructors. Never accept arbitrary metadata mappings.
+  Use `AuditEvent` plus `TaskStateMachine`, add all rows/status mutations, and call `session.commit()`
+  once per checkpoint. On SQLAlchemy failure call `session.rollback()` and raise only
+  `WorkflowError(WorkflowErrorCode.PERSISTENCE_FAILURE)` from `None`.
+
+  Assignment checkpoint sets `task.assigned_agent_id` before the audited READY transition. Later
+  helpers accept only stable scalar values (`cycle`, `decision`, `review_score`, `finding_count`,
+  `max_review_cycles`).
+
+- [ ] **Step 4: Run audit and state-machine regression tests**
+
+  Run:
+
+  ```bash
+  .venv/bin/pytest tests/workflows/test_audit.py tests/database/test_task_state_machine.py tests/database/test_append_only.py -q
+  .venv/bin/ruff check core/workflows tests/workflows
+  .venv/bin/mypy core/workflows tests/workflows
+  ```
+
+  Expected: all pass.
+
+- [ ] **Step 5: Commit Task 4**
+
+  ```bash
+  git add core/workflows tests/workflows
+  git commit -m "feat(workflow): add audited durable checkpoints"
+  ```
+
+---
+
+### Task 5: Implement the bounded Developer–Reviewer correction loop
+
+**Files:**
+- Create: `core/workflows/orchestrator.py`
+- Modify: `core/workflows/__init__.py`
+- Modify: `tests/workflows/fakes.py`
+- Create: `tests/workflows/test_orchestrator.py`
+- Create: `tests/workflows/test_safety.py`
+
+**Interfaces:**
+- Consumes: validated request/scope, `DeveloperRunner`, `ReviewerRunner`, `ReviewerHandoffBuilder`, workflow audit/checkpoint helpers, and `asyncio.timeout`.
+- Produces: `WorkflowOrchestrator.run(request) -> DeveloperReviewerWorkflowResult`.
+
+- [ ] **Step 1: Write one-cycle approval RED test**
+
+  Use recording Developer, handoff, and Reviewer fakes. Start with a persistent READY task. Assert
+  exact status sequence, Developer assignment, one call to each collaborator, final `WAITING_QA`,
+  truthful counts, final bounded reports, expected audit sequence, no QA/Security calls, and no
+  collaborator closure.
+
+- [ ] **Step 2: Run the approval test and verify RED**
+
+  Run: `.venv/bin/pytest tests/workflows/test_orchestrator.py -q -k one_cycle`
+
+  Expected: import failure because `WorkflowOrchestrator` is absent.
+
+- [ ] **Step 3: Implement minimum one-cycle orchestration**
+
+  Constructor:
+
+  ```python
+  class WorkflowOrchestrator:
+      def __init__(
+          self,
+          session: Session,
+          developer: DeveloperRunner,
+          reviewer: ReviewerRunner,
+          handoff_builder: ReviewerHandoffBuilder,
+      ) -> None: ...
+
+      async def run(
+          self,
+          request: DeveloperReviewerWorkflowRequest,
+      ) -> DeveloperReviewerWorkflowResult: ...
+  ```
+
+  Validate before calls, enter one overall `asyncio.timeout`, commit assignment and IN_PROGRESS,
+  call Developer, checkpoint WAITING_REVIEW, build/revalidate handoff, call Reviewer, then checkpoint
+  WAITING_QA only for final `APPROVED`.
+
+- [ ] **Step 4: Write correction and exhaustion RED tests**
+
+  Add tests for one rejection then approval and repeated rejection at limits 1 and 3. Assert fresh
+  handoff cycle numbers and diff markers, exact call counts, no retained earlier results, transition
+  chronology, and exhaustion at `WAITING_HUMAN` without an extra Developer/Reviewer call.
+
+- [ ] **Step 5: Run correction tests and verify RED**
+
+  Run: `.venv/bin/pytest tests/workflows/test_orchestrator.py -q -k 'correction or exhausted'`
+
+  Expected: assertions fail because the minimum implementation has no correction loop.
+
+- [ ] **Step 6: Implement the explicit bounded correction loop**
+
+  Iterate `range(1, max_review_cycles + 1)`. Never use recursion. A requested change commits
+  `CHANGES_REQUESTED`; continue through an audited `IN_PROGRESS` transition only when another cycle
+  remains. Otherwise commit `WAITING_HUMAN` plus exhaustion audit and return the exhausted result.
+
+- [ ] **Step 7: Write failure, timeout, cancellation, and sanitization RED tests**
+
+  Test Developer error, handoff error, Reviewer error, unexpected exception with secret marker,
+  global timeout, and cancellation during each collaborator. Assert:
+
+  - ordinary failures become stable `WorkflowError` values and durable `WAITING_HUMAN` when legal;
+  - raw exception context, traceback frames, source markers, and absolute paths are absent;
+  - timeout causes no retry or extra call;
+  - `CancelledError` is re-raised and causes no subsequent transition, audit, model, tool, or handoff
+    call;
+  - injected collaborators/session remain open;
+  - orchestrator instance retains only injected collaborators/session, not requests or results.
+
+- [ ] **Step 8: Run safety tests and verify RED**
+
+  Run: `.venv/bin/pytest tests/workflows/test_safety.py -q`
+
+  Expected: failure until safe normalization and cancellation behavior exist.
+
+- [ ] **Step 9: Implement fail-closed normalization without retries**
+
+  Catch `asyncio.CancelledError` separately and re-raise. Convert timeout and ordinary exceptions to
+  application-owned codes, clear raw traceback frames/references, perform one legal safe escalation
+  checkpoint, then raise from `None`. Never catch `BaseException`; never invoke a collaborator from
+  error handling.
+
+- [ ] **Step 10: Run focused orchestration and full regression tests**
+
+  Run:
+
+  ```bash
+  .venv/bin/pytest tests/workflows -q
+  .venv/bin/pytest tests/tasks tests/database/test_task_state_machine.py tests/developer tests/reviewer -q
+  .venv/bin/ruff check core/workflows tests/workflows
+  .venv/bin/mypy core/workflows tests/workflows
+  ```
+
+  Expected: all pass.
+
+- [ ] **Step 11: Commit Task 5**
+
+  ```bash
+  git add core/workflows tests/workflows
+  git commit -m "feat(workflow): orchestrate bounded review cycles"
+  ```
+
+---
+
+### Task 6: Add real-provider-contract end-to-end tests and documentation
+
+**Files:**
+- Create: `tests/workflows/test_integration.py`
+- Create: `docs/developer-reviewer-workflow.md`
+- Modify: `README.md`
+- Modify: `AGENTS.md`
+- Modify: `SYNAPSEOS_DEVELOPMENT_CHECKLIST.md`
+
+**Interfaces:**
+- Consumes: concrete `DeveloperAgent`, concrete `ReviewerAgent`, deterministic
+  `FakeLLMProvider`, real PostgreSQL schema from Alembic, recording tool/audit fakes, and the public
+  `core.workflows` API.
+- Produces: documented and verified Phase 16 behavior with only completed Phase 16 boxes checked.
+
+- [ ] **Step 1: Write end-to-end RED tests with concrete agents**
+
+  Build deterministic provider scripts for:
+
+  - Developer succeeds and Reviewer approves in one cycle;
+  - first Reviewer requests changes, second Developer cycle produces fresh evidence, and second
+    Reviewer approves;
+  - all Reviewer cycles request changes and exhaust the limit.
+
+  Use real PostgreSQL records and schema, concrete bounded agents, real task transitions/audit, and
+  a deterministic handoff builder that supplies a different bounded diff per cycle. Assert exact
+  provider-call counts, terminal states, audit chronology, result bounds, and no Phase 17 behavior.
+
+- [ ] **Step 2: Run integration tests and verify RED**
+
+  Run: `.venv/bin/pytest tests/workflows/test_integration.py -q`
+
+  Expected: fail on any missing composition behavior discovered by the concrete contracts.
+
+- [ ] **Step 3: Make only focused integration corrections**
+
+  Correct mismatches in workflow composition without weakening Developer, Reviewer, task-state,
+  audit, timeout, or security contracts. Do not add QA/Security placeholders or abstractions.
+
+- [ ] **Step 4: Document the completed Phase 16 boundary**
+
+  Document exact flow, configuration, handoff contents, checkpoint/audit behavior, timeout and
+  cancellation semantics, resource ownership, safe failures, usage example, and explicit Phase 17
+  exclusions in `docs/developer-reviewer-workflow.md`.
+
+  Update README status/roadmap and AGENTS architecture/commands. Change only the seven Phase 16
+  checklist boxes after corresponding tests pass. Leave Phase 17 and later boxes untouched.
+
+- [ ] **Step 5: Run the fresh final verification gate**
+
+  Run:
+
+  ```bash
+  .venv/bin/pytest -q
+  .venv/bin/pytest --collect-only -q
+  .venv/bin/ruff check .
+  .venv/bin/ruff format --check .
+  .venv/bin/mypy .
+  git diff --check
+  docker compose build api
+  docker compose up -d api
+  docker compose ps
+  docker compose exec -T api alembic current
+  curl --fail --silent http://localhost:8000/health
+  ```
+
+  Expected: full suite passes, clean Ruff/format/mypy output, Docker services healthy, Alembic at
+  head, and health JSON `{"status":"ok"}`.
+
+- [ ] **Step 6: Perform final scope and security review**
+
+  Compare the branch against `phase-15/reviewer-agent`. Verify only Phase 16 checklist changes,
+  no prompt/diff/output persistence, no hidden retry, no unbounded collection or loop, no injected
+  resource closure, no direct task status mutation, no raw exception leakage, no Phase 17 code, and
+  no staged `CLAUDE.local.md`.
+
+- [ ] **Step 7: Commit Task 6**
+
+  ```bash
+  git add core/workflows tests/workflows docs/developer-reviewer-workflow.md README.md AGENTS.md SYNAPSEOS_DEVELOPMENT_CHECKLIST.md
+  git commit -m "docs(workflow): complete Phase 16 delivery"
+  ```
+
+- [ ] **Step 8: Push and open the stacked pull request**
+
+  Push `phase-16/developer-reviewer-workflow` and open a pull request with base
+  `phase-15/reviewer-agent`. Include test count, static checks, Docker/PostgreSQL/Alembic/API
+  evidence, security-review outcome, Phase 16 scope, and explicit Phase 17 exclusion.

--- a/docs/superpowers/plans/2026-08-30-phase-16-developer-reviewer-workflow.md
+++ b/docs/superpowers/plans/2026-08-30-phase-16-developer-reviewer-workflow.md
@@ -82,6 +82,7 @@
       APPROVED = "APPROVED"
       REVIEW_CYCLES_EXHAUSTED = "REVIEW_CYCLES_EXHAUSTED"
 
+
   class DeveloperReviewerWorkflowRequest(_ImmutableWorkflowModel):
       task_id: UUID
       developer_agent_id: UUID
@@ -242,8 +243,10 @@
   class DeveloperRunner(Protocol):
       async def run(self, request: DeveloperRequest) -> DeveloperResult: ...
 
+
   class ReviewerRunner(Protocol):
       async def run(self, request: ReviewerRequest) -> ReviewerResult: ...
+
 
   class ReviewerHandoffBuilder(Protocol):
       async def build(

--- a/docs/superpowers/specs/2026-08-30-phase-16-developer-reviewer-workflow-design.md
+++ b/docs/superpowers/specs/2026-08-30-phase-16-developer-reviewer-workflow-design.md
@@ -1,0 +1,211 @@
+# Phase 16 Developer–Reviewer Workflow Design
+
+## Scope
+
+Phase 16 introduces the first real SynapseOS multi-agent workflow. A minimal
+`WorkflowOrchestrator` assigns one persistent `READY` task to one Developer, runs the bounded
+`DeveloperAgent`, hands only validated evidence to an independent `ReviewerAgent`, and repeats the
+correction cycle until the review is approved or the configured cycle limit is reached.
+
+The successful terminal state for this phase is `WAITING_QA`. Phase 16 does not implement a QA
+agent, Security agent, merge, pull-request automation, event bus, background worker, scheduler,
+reputation update, memory write, deployment, or generic workflow language.
+
+## Architectural choice
+
+Create a focused `core/workflows/` application package. The orchestrator composes existing
+Developer, Reviewer, `TaskStateMachine`, and append-only audit behavior; it does not duplicate
+their internal rules. Agent calls are represented by narrow protocols so deterministic fakes can
+test orchestration without weakening the concrete agents' contracts.
+
+The workflow receives one strict immutable `DeveloperReviewerWorkflowRequest` plus a handoff
+builder. The handoff builder is responsible for obtaining the current bounded Git diff after each
+Developer run and constructing a complete `ReviewerRequest`. This keeps repository reads outside
+the orchestrator and guarantees that a correction cycle reviews fresh evidence rather than a stale
+first-cycle diff.
+
+The orchestrator is intentionally not a reusable graph engine. The Phase 16 flow is explicit code
+with closed states and decisions. A generic event-driven workflow engine is deferred until multiple
+real workflows demonstrate a stable abstraction.
+
+## Persistent identities and assignment
+
+The workflow request identifies:
+
+- one persistent PostgreSQL task UUID;
+- one persistent Developer agent UUID;
+- one persistent Reviewer agent UUID;
+- the bounded `DeveloperRequest` used for each Developer cycle;
+- `max_review_cycles`, from 1 through 10;
+- one workflow timeout, greater than zero and no more than 3,600 seconds;
+- one correlation UUID shared by workflow audit events.
+
+Preflight loads the task and both agents in the injected SQLAlchemy session and fails before any
+agent call when:
+
+- the task does not exist or is not `READY`;
+- either agent does not exist;
+- Developer and Reviewer persistent UUIDs are equal;
+- the Developer role or Reviewer role is incorrect;
+- either agent is `OFFLINE` or `BLOCKED`;
+- `DeveloperRequest.profile.id` does not match the persistent Developer slug;
+- the runtime task ID, execution-context task ID, project ID, agent ID, or correlation ID does not
+  match persistent workflow scope;
+- Developer and Reviewer profile identities are not independent;
+- task criteria or descriptions cannot be represented by the bounded agent contracts.
+
+Assignment sets `task.assigned_agent_id` to the Developer's persistent UUID and then applies
+`READY -> ASSIGNED` through `TaskStateMachine`. The Reviewer is never assigned as the author.
+
+## Workflow state machine
+
+The exact Phase 16 sequence is:
+
+1. validate the complete request and persistent scope;
+2. assign the Developer and transition `READY -> ASSIGNED`;
+3. transition `ASSIGNED -> IN_PROGRESS`;
+4. run the Developer exactly once for the current review cycle;
+5. transition `IN_PROGRESS -> WAITING_REVIEW`;
+6. build a fresh bounded handoff from the Developer result and current diff;
+7. run the Reviewer exactly once for the current review cycle;
+8. if approved, transition `WAITING_REVIEW -> WAITING_QA` and return;
+9. if changes are requested, transition `WAITING_REVIEW -> CHANGES_REQUESTED`;
+10. when another cycle is available, transition `CHANGES_REQUESTED -> IN_PROGRESS` and repeat;
+11. when the limit is exhausted, transition `CHANGES_REQUESTED -> WAITING_HUMAN` and return a
+    fail-closed exhausted result.
+
+Only `TaskStateMachine` may modify task status. The orchestrator never assigns `WAITING_SECURITY`,
+`COMPLETED`, or any later-phase state.
+
+## Transaction and checkpoint policy
+
+The injected SQLAlchemy session remains caller-owned and is never closed. The orchestrator commits
+each state transition and its associated append-only audit event before invoking the next external
+agent operation. This avoids holding a database transaction open during LLM or tool execution and
+leaves a durable, truthful checkpoint if the process stops.
+
+Assignment and `READY -> ASSIGNED` are committed atomically. Every later status transition and its
+workflow event are committed atomically. A database failure is rolled back and converted to a safe
+workflow error; it never causes an agent retry. Already committed checkpoints remain historical
+truth and are not rewritten.
+
+The orchestrator does not own the surrounding session lifecycle and never closes, disposes, or
+reconfigures it.
+
+## Handoff contract
+
+`ReviewerHandoffBuilder` is an asynchronous injected protocol with one method that receives the
+validated workflow scope, the latest `DeveloperResult`, and the one-based review cycle. It returns
+one strict `ReviewerRequest`.
+
+The orchestrator revalidates the returned request and requires:
+
+- persistent task and project identifiers encoded in their canonical lowercase UUID text;
+- Developer and Reviewer IDs equal to their validated profile slugs;
+- the exact latest Developer report;
+- checks equal to a lossless, allowlisted conversion of the latest Developer checks;
+- required check profiles equal to the Developer request;
+- title, description, criteria, and diff within Reviewer bounds;
+- no self-review and no write-capable Reviewer profile.
+
+The handoff includes no Developer conversation, runtime history, tool output, prompts, model
+responses, absolute paths, environment values, secrets, or earlier-cycle diff. The builder is
+called once per completed Developer cycle and is never retried implicitly.
+
+## Workflow result
+
+`DeveloperReviewerWorkflowResult` is immutable and bounded. It contains:
+
+- terminal task status (`WAITING_QA` or `WAITING_HUMAN` only);
+- terminal workflow outcome (`APPROVED` or `REVIEW_CYCLES_EXHAUSTED`);
+- number of completed Developer cycles;
+- number of completed Reviewer cycles;
+- the final sanitized `ReviewerResult`;
+- the final bounded Developer report;
+- correlation UUID.
+
+It does not retain complete `DeveloperResult` instances, runtime histories, diffs, prompts, raw
+provider responses, command output, or all previous review results.
+
+## Audit contract
+
+Existing `TASK_STATUS_CHANGED` events remain authoritative for every state transition. Phase 16
+adds bounded append-only events for workflow facts that are not represented by status alone:
+
+- `WORKFLOW_STARTED` after validated assignment;
+- `DEVELOPER_HANDOFF_CREATED` after a safe Reviewer request is built;
+- `REVIEW_COMPLETED` after each Reviewer decision;
+- `REVIEW_CYCLE_EXHAUSTED` when the configured limit is reached;
+- `WORKFLOW_COMPLETED` when the task reaches `WAITING_QA`.
+
+Events use the request correlation UUID. Data is allowlisted to stable identifiers, one-based cycle
+number, decision, score, finding count, and configured cycle limit. Audit data never contains task
+text, acceptance criteria, diff, findings, rationale, prompts, responses, command output, paths,
+exceptions, credentials, or arbitrary provider metadata.
+
+Audit insertion uses the existing append-only model. Normal application code exposes no update or
+delete operation. No PostgreSQL trigger, RLS policy, or new permission scheme is introduced.
+
+## Fail-closed behavior
+
+Validation failures occur before assignment and before agent calls. After workflow start:
+
+- an invalid or unsafe handoff moves the task from `WAITING_REVIEW` to `WAITING_HUMAN` and raises a
+  stable sanitized workflow error;
+- a Developer or Reviewer application error moves the current task to `WAITING_HUMAN` when that
+  transition is legal, records only its stable error category, and raises a sanitized workflow
+  error;
+- an overall workflow timeout follows the same safe escalation path and performs no retry;
+- cancellation is never converted into a normal failure and is re-raised immediately; the last
+  committed task checkpoint identifies where execution stopped;
+- database failures are rolled back, sanitized, and never retried implicitly;
+- a Reviewer decision can never be upgraded by the orchestrator.
+
+No exception message includes user content, diff content, provider content, command output,
+filesystem locations, database statements, credentials, or raw traceback data.
+
+## Resource bounds and ownership
+
+- `max_review_cycles` is explicit and bounded from 1 through 10.
+- One overall timeout bounds the full workflow; existing per-agent limits remain in force.
+- Each cycle invokes Developer once, handoff builder once, and Reviewer once.
+- There is no implicit retry, provider fallback, duplicated call, or speculative parallel call.
+- Cancellation propagates without another model or tool call.
+- The result retains only the final bounded reports and scalar counters.
+- The orchestrator stores no prompt, response, diff, command output, or conversation history.
+- Injected agents, providers, tools, handoff builders, sessions, and network clients remain
+  caller-owned and are never closed.
+
+## TDD and acceptance scenarios
+
+Tests must observe RED before production implementation and cover:
+
+1. strict immutable and bounded workflow request/result contracts;
+2. rejection before side effects for missing task/agent, non-`READY` state, wrong role, offline or
+   blocked agent, self-review, mismatched task/project/agent/correlation scope, and type-confused
+   model copies;
+3. atomic assignment and audited `READY -> ASSIGNED -> IN_PROGRESS` transitions;
+4. one-cycle approval ending in `WAITING_QA` with one Developer and one Reviewer call;
+5. one requested correction followed by approval, with fresh handoff evidence and exactly two calls
+   to each agent;
+6. repeated requested changes exhausting the configured limit and ending in `WAITING_HUMAN`;
+7. handoff revalidation rejects stale reports, checks, identities, scope, write-capable Reviewer, and
+   oversized or malformed evidence;
+8. append-only transition and workflow audit chronology, shared correlation ID, and allowlisted
+   non-sensitive data;
+9. Developer, Reviewer, handoff, timeout, database, and cancellation failure behavior without
+   hidden retries or duplicate calls;
+10. result/history bounds and caller-owned resource lifecycle;
+11. end-to-end execution against real PostgreSQL created through Alembic and deterministic
+    `FakeLLMProvider` instances;
+12. no QA/Security execution and no transition beyond `WAITING_QA`.
+
+The complete gate remains the full pytest suite, Ruff, Ruff format check, strict mypy, diff
+integrity, Docker build, PostgreSQL health, Alembic head, API health, and an independent final
+review.
+
+## Documentation and checklist
+
+Add `docs/developer-reviewer-workflow.md`, update `README.md` and `AGENTS.md`, and mark only genuinely
+verified Phase 16 checklist items in `SYNAPSEOS_DEVELOPMENT_CHECKLIST.md`. Phase 17 and all later
+checkboxes remain unchanged.

--- a/infrastructure/database/task_status_guard.py
+++ b/infrastructure/database/task_status_guard.py
@@ -125,7 +125,8 @@ def _reject_unauthorized_task_status_changes(
             )
 
 
-def _clear_task_status_authorizations(session: Session, *_args: Any) -> None:
+def clear_task_status_authorizations(session: Session, *_args: Any) -> None:
+    """Discard all pending state-machine authorizations for one session."""
     session.info.pop(_AUTHORIZATIONS_KEY, None)
 
 
@@ -133,9 +134,9 @@ def register_task_status_guard() -> None:
     """Register the process-wide task-status guard exactly once."""
     listeners = (
         ("before_flush", _reject_unauthorized_task_status_changes),
-        ("after_flush", _clear_task_status_authorizations),
-        ("after_rollback", _clear_task_status_authorizations),
-        ("after_soft_rollback", _clear_task_status_authorizations),
+        ("after_flush", clear_task_status_authorizations),
+        ("after_rollback", clear_task_status_authorizations),
+        ("after_soft_rollback", clear_task_status_authorizations),
     )
     for event_name, listener in listeners:
         if not event.contains(Session, event_name, listener):

--- a/tests/reviewer/test_validation.py
+++ b/tests/reviewer/test_validation.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import warnings
 from dataclasses import FrozenInstanceError
+from types import TracebackType
 
 import pytest
 
@@ -29,6 +30,24 @@ def _request(**overrides: object) -> ReviewerRequest:
     values = request_values()
     values.update(overrides)
     return ReviewerRequest.model_validate(values)
+
+
+def _assert_authority_validation_traceback_is_profile_free(
+    traceback: TracebackType | None, marker: str
+) -> None:
+    """Reject Reviewer validation frames that retain a confidential profile."""
+    forbidden_locals = frozenset({"profile", "canonical_profile"})
+    while traceback is not None:
+        frame = traceback.tb_frame
+        if frame.f_code.co_filename.endswith("core/reviewer/validation.py"):
+            retained = sorted(
+                name
+                for name in forbidden_locals.intersection(frame.f_locals)
+                if frame.f_locals[name] is not None
+            )
+            assert retained == [], (frame.f_code.co_name, retained)
+            assert all(marker not in repr(value) for value in frame.f_locals.values())
+        traceback = traceback.tb_next
 
 
 def test_validation_rejects_self_review() -> None:
@@ -258,3 +277,22 @@ def test_profile_authority_validator_reuses_reviewer_read_only_rules(
         validate_reviewer_profile_authority(reviewer_profile(**profile_overrides))
 
     assert raised.value.code is expected_code
+
+
+def test_profile_authority_failure_traceback_does_not_retain_the_reviewer_profile() -> None:
+    """Prevent direct authority errors from retaining a confidential system prompt."""
+    marker = "reviewer-authority-profile-secret-marker-79c2"
+    profile = reviewer_profile(
+        system_prompt=marker,
+        permission_ids=frozenset(
+            {Permission.FILESYSTEM_READ.value, Permission.FILESYSTEM_WRITE.value}
+        ),
+    )
+
+    with pytest.raises(ReviewerError) as raised:
+        validate_reviewer_profile_authority(profile)
+
+    assert raised.value.code is ReviewerErrorCode.INVALID_PERMISSION
+    assert raised.value.__cause__ is None
+    assert raised.value.__context__ is None
+    _assert_authority_validation_traceback_is_profile_free(raised.value.__traceback__, marker)

--- a/tests/reviewer/test_validation.py
+++ b/tests/reviewer/test_validation.py
@@ -12,6 +12,7 @@ from core.reviewer import (
     ReviewerError,
     ReviewerErrorCode,
     ReviewerRequest,
+    validate_reviewer_profile_authority,
     validate_reviewer_request,
 )
 from tests.reviewer.factories import request_values, reviewer_profile
@@ -230,3 +231,30 @@ def test_valid_active_reviewer_returns_immutable_canonical_authority(
     assert validated.permissions == expected_permissions
     with pytest.raises(FrozenInstanceError):
         validated.permissions = frozenset()  # type: ignore[misc]
+
+
+@pytest.mark.parametrize(
+    ("profile_overrides", "expected_code"),
+    [
+        (
+            {
+                "permission_ids": frozenset(
+                    {Permission.FILESYSTEM_READ.value, Permission.FILESYSTEM_WRITE.value}
+                )
+            },
+            ReviewerErrorCode.INVALID_PERMISSION,
+        ),
+        (
+            {"tool_ids": frozenset({"read_file", "run_command_profile"})},
+            ReviewerErrorCode.INVALID_TOOLS,
+        ),
+    ],
+)
+def test_profile_authority_validator_reuses_reviewer_read_only_rules(
+    profile_overrides: dict[str, object], expected_code: ReviewerErrorCode
+) -> None:
+    """Prevent workflow preflight from inventing weaker Reviewer authority rules."""
+    with pytest.raises(ReviewerError) as raised:
+        validate_reviewer_profile_authority(reviewer_profile(**profile_overrides))
+
+    assert raised.value.code is expected_code

--- a/tests/workflows/__init__.py
+++ b/tests/workflows/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the Phase 16 Developer–Reviewer workflow boundary."""

--- a/tests/workflows/factories.py
+++ b/tests/workflows/factories.py
@@ -1,0 +1,74 @@
+"""Hand-checked fixtures for Phase 16 workflow contracts."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from uuid import UUID, uuid4
+
+from core.agents import AgentReport, AgentReportOutcome
+from core.commands import CommandProfileId
+from core.developer import DeveloperRequest
+from core.reviewer import ReviewDecision, ReviewerResult
+from tests.developer.factories import request_values
+from tests.reviewer.factories import reviewer_profile
+
+
+def developer_request(tmp_path: Path) -> DeveloperRequest:
+    """Build one fully scoped Developer invocation."""
+    return DeveloperRequest.model_validate(request_values(tmp_path))
+
+
+def completed_developer_report() -> AgentReport:
+    """Build the final bounded report retained by a workflow result."""
+    return AgentReport(
+        summary="Implemented the requested correction.",
+        outcome=AgentReportOutcome.SUCCEEDED,
+        details=("The focused test suite passed.",),
+        next_actions=(),
+    )
+
+
+def approved_reviewer_result() -> ReviewerResult:
+    """Build one final approval that a workflow may retain."""
+    return ReviewerResult(
+        decision=ReviewDecision.APPROVED,
+        findings=(),
+        rationale="The supplied evidence supports approval.",
+        confidence=0.95,
+        review_score=0.95,
+    )
+
+
+def workflow_request_values(tmp_path: Path) -> dict[str, object]:
+    """Build valid workflow request values with persistent UUID identities."""
+    request = developer_request(tmp_path)
+    return {
+        "task_id": uuid4(),
+        "developer_agent_id": uuid4(),
+        "reviewer_agent_id": uuid4(),
+        "developer_request": request,
+        "reviewer_profile": reviewer_profile(),
+        "max_review_cycles": 2,
+        "timeout_seconds": 30.0,
+        "correlation_id": request.execution_context.correlation_id,
+    }
+
+
+def canonical_uuid(value: UUID | None = None) -> str:
+    """Return hand-checked canonical lower-case UUID text."""
+    return str(value or uuid4())
+
+
+def handoff_context_values() -> dict[str, object]:
+    """Build bounded data needed for an independent Reviewer handoff."""
+    return {
+        "task_id": canonical_uuid(),
+        "project_id": canonical_uuid(),
+        "task_title": "Correct addition",
+        "task_description": "Correct the faulty addition implementation.",
+        "acceptance_criteria": ["The existing test suite passes."],
+        "developer_id": "developer-01",
+        "reviewer_id": "reviewer-01",
+        "reviewer_profile": reviewer_profile(),
+        "required_check_profiles": [CommandProfileId.PYTEST],
+    }

--- a/tests/workflows/factories.py
+++ b/tests/workflows/factories.py
@@ -5,11 +5,18 @@ from __future__ import annotations
 from pathlib import Path
 from uuid import UUID, uuid4
 
+from sqlalchemy.orm import Session
+
 from core.agents import AgentReport, AgentReportOutcome
 from core.commands import CommandProfileId
 from core.developer import DeveloperRequest
+from core.enums import AgentSeniority, AgentStatus, ProjectStatus, TaskStatus
 from core.reviewer import ReviewDecision, ReviewerResult
-from tests.developer.factories import request_values
+from core.runtime import RuntimeTask
+from core.tools import ToolExecutionContext
+from core.workflows import DeveloperReviewerWorkflowRequest
+from infrastructure.database.models import Agent, Project, Task
+from tests.developer.factories import developer_profile, request_values
 from tests.reviewer.factories import reviewer_profile
 
 
@@ -72,3 +79,92 @@ def handoff_context_values() -> dict[str, object]:
         "reviewer_profile": reviewer_profile(),
         "required_check_profiles": [CommandProfileId.PYTEST],
     }
+
+
+def persisted_workflow_request(
+    session: Session,
+    tmp_path: Path,
+    *,
+    task_overrides: dict[str, object] | None = None,
+    developer_overrides: dict[str, object] | None = None,
+    reviewer_overrides: dict[str, object] | None = None,
+) -> tuple[Task, Agent, Agent, DeveloperReviewerWorkflowRequest]:
+    """Persist one coherent READY workflow scope and return its strict request."""
+    project = Project(name="Workflow validation project", status=ProjectStatus.IN_PROGRESS)
+    developer_values: dict[str, object] = {
+        "name": "Developer One",
+        "slug": "developer-01",
+        "role": "Developer",
+        "department": "engineering",
+        "seniority": AgentSeniority.ENGINEER,
+        "status": AgentStatus.WORKING,
+        "autonomy_level": 2,
+        "reputation_score": "0.8000",
+        "reliability_score": "0.9000",
+    }
+    reviewer_values: dict[str, object] = {
+        "name": "Reviewer One",
+        "slug": "reviewer-01",
+        "role": "Reviewer",
+        "department": "engineering",
+        "seniority": AgentSeniority.SENIOR,
+        "status": AgentStatus.WORKING,
+        "autonomy_level": 0,
+        "reputation_score": "0.8000",
+        "reliability_score": "0.9000",
+    }
+    developer_values.update(developer_overrides or {})
+    reviewer_values.update(reviewer_overrides or {})
+    developer = Agent(**developer_values)
+    reviewer = Agent(**reviewer_values)
+    session.add_all([project, developer, reviewer])
+    session.flush()
+
+    task_values: dict[str, object] = {
+        "project_id": project.id,
+        "title": "Correct addition",
+        "description": "Correct the faulty addition implementation.",
+        "status": TaskStatus.READY,
+        "acceptance_criteria": ["The existing test suite passes."],
+    }
+    task_values.update(task_overrides or {})
+    task = Task(**task_values)
+    session.add(task)
+    session.flush()
+
+    correlation_id = uuid4()
+    developer_profile_value = developer_profile()
+    runtime_task = RuntimeTask(
+        task_id=task.id,
+        objective="Correct the faulty addition implementation.",
+        acceptance_criteria=("The existing test suite passes.",),
+    )
+    execution_context = ToolExecutionContext(
+        workspace_root=tmp_path,
+        agent_id="developer-01",
+        agent_run_id=uuid4(),
+        project_id=project.id,
+        task_id=task.id,
+        declared_tool_ids=developer_profile_value.tool_ids,
+        correlation_id=correlation_id,
+    )
+    developer_request_value = DeveloperRequest(
+        task=runtime_task,
+        profile=developer_profile_value,
+        execution_context=execution_context,
+        domains=frozenset({"backend"}),
+        technologies=frozenset({"python"}),
+        tags=frozenset({"testing"}),
+        required_check_profiles=(CommandProfileId.PYTEST,),
+    )
+    request = DeveloperReviewerWorkflowRequest(
+        task_id=task.id,
+        developer_agent_id=developer.id,
+        reviewer_agent_id=reviewer.id,
+        developer_request=developer_request_value,
+        reviewer_profile=reviewer_profile(),
+        max_review_cycles=2,
+        timeout_seconds=30.0,
+        correlation_id=correlation_id,
+    )
+    return task, developer, reviewer, request

--- a/tests/workflows/fakes.py
+++ b/tests/workflows/fakes.py
@@ -1,0 +1,51 @@
+"""Deterministic recording collaborators for Phase 16 workflow tests."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from core.developer import DeveloperRequest, DeveloperResult
+from core.reviewer import ReviewerRequest, ReviewerResult
+from core.workflows import WorkflowHandoffContext
+from core.workflows.ports import DeveloperRunner, ReviewerHandoffBuilder, ReviewerRunner
+
+
+@dataclass(slots=True)
+class RecordingDeveloperRunner(DeveloperRunner):
+    """Return one predetermined Developer result and record accepted requests."""
+
+    result: DeveloperResult
+    requests: list[DeveloperRequest] = field(default_factory=list)
+
+    async def run(self, request: DeveloperRequest) -> DeveloperResult:
+        self.requests.append(request)
+        return self.result
+
+
+@dataclass(slots=True)
+class RecordingReviewerRunner(ReviewerRunner):
+    """Return one predetermined Reviewer result and record accepted requests."""
+
+    result: ReviewerResult
+    requests: list[ReviewerRequest] = field(default_factory=list)
+
+    async def run(self, request: ReviewerRequest) -> ReviewerResult:
+        self.requests.append(request)
+        return self.result
+
+
+@dataclass(slots=True)
+class RecordingReviewerHandoffBuilder(ReviewerHandoffBuilder):
+    """Return one predetermined handoff and record each exact build input."""
+
+    request: ReviewerRequest
+    calls: list[tuple[WorkflowHandoffContext, DeveloperResult, int]] = field(default_factory=list)
+
+    async def build(
+        self,
+        context: WorkflowHandoffContext,
+        developer_result: DeveloperResult,
+        cycle: int,
+    ) -> ReviewerRequest:
+        self.calls.append((context, developer_result, cycle))
+        return self.request

--- a/tests/workflows/fakes.py
+++ b/tests/workflows/fakes.py
@@ -166,12 +166,16 @@ class BlockingDeveloperRunner(DeveloperRunner):
     started: Event = field(default_factory=Event)
     release: Event = field(default_factory=Event)
     requests: list[DeveloperRequest] = field(default_factory=list)
+    close_calls: int = 0
 
     async def run(self, request: DeveloperRequest) -> DeveloperResult:
         self.requests.append(request)
         self.started.set()
         await self.release.wait()
         return self.result
+
+    async def close(self) -> None:
+        self.close_calls += 1
 
 
 @dataclass(slots=True)
@@ -182,12 +186,16 @@ class BlockingReviewerRunner(ReviewerRunner):
     started: Event = field(default_factory=Event)
     release: Event = field(default_factory=Event)
     requests: list[ReviewerRequest] = field(default_factory=list)
+    close_calls: int = 0
 
     async def run(self, request: ReviewerRequest) -> ReviewerResult:
         self.requests.append(request)
         self.started.set()
         await self.release.wait()
         return self.result
+
+    async def close(self) -> None:
+        self.close_calls += 1
 
 
 @dataclass(slots=True)
@@ -198,6 +206,7 @@ class BlockingReviewerHandoffBuilder(ReviewerHandoffBuilder):
     started: Event = field(default_factory=Event)
     release: Event = field(default_factory=Event)
     calls: list[tuple[WorkflowHandoffContext, DeveloperResult, int]] = field(default_factory=list)
+    close_calls: int = 0
 
     async def build(
         self,
@@ -209,3 +218,6 @@ class BlockingReviewerHandoffBuilder(ReviewerHandoffBuilder):
         self.started.set()
         await self.release.wait()
         return self.request
+
+    async def close(self) -> None:
+        self.close_calls += 1

--- a/tests/workflows/fakes.py
+++ b/tests/workflows/fakes.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from asyncio import Event
 from dataclasses import dataclass, field
 
 from core.developer import DeveloperRequest, DeveloperResult
@@ -16,10 +17,14 @@ class RecordingDeveloperRunner(DeveloperRunner):
 
     result: DeveloperResult
     requests: list[DeveloperRequest] = field(default_factory=list)
+    close_calls: int = 0
 
     async def run(self, request: DeveloperRequest) -> DeveloperResult:
         self.requests.append(request)
         return self.result
+
+    async def close(self) -> None:
+        self.close_calls += 1
 
 
 @dataclass(slots=True)
@@ -28,10 +33,14 @@ class RecordingReviewerRunner(ReviewerRunner):
 
     result: ReviewerResult
     requests: list[ReviewerRequest] = field(default_factory=list)
+    close_calls: int = 0
 
     async def run(self, request: ReviewerRequest) -> ReviewerResult:
         self.requests.append(request)
         return self.result
+
+    async def close(self) -> None:
+        self.close_calls += 1
 
 
 @dataclass(slots=True)
@@ -39,6 +48,104 @@ class RecordingReviewerHandoffBuilder(ReviewerHandoffBuilder):
     """Return one predetermined handoff and record each exact build input."""
 
     request: ReviewerRequest
+    calls: list[tuple[WorkflowHandoffContext, DeveloperResult, int]] = field(default_factory=list)
+    close_calls: int = 0
+
+    async def build(
+        self,
+        context: WorkflowHandoffContext,
+        developer_result: DeveloperResult,
+        cycle: int,
+    ) -> ReviewerRequest:
+        self.calls.append((context, developer_result, cycle))
+        return self.request
+
+    async def close(self) -> None:
+        self.close_calls += 1
+
+
+@dataclass(slots=True)
+class SequencedRecordingDeveloperRunner(DeveloperRunner):
+    """Return each predetermined Developer result once in call order."""
+
+    results: tuple[DeveloperResult, ...]
+    requests: list[DeveloperRequest] = field(default_factory=list)
+    close_calls: int = 0
+
+    async def run(self, request: DeveloperRequest) -> DeveloperResult:
+        self.requests.append(request)
+        return self.results[len(self.requests) - 1]
+
+    async def close(self) -> None:
+        self.close_calls += 1
+
+
+@dataclass(slots=True)
+class SequencedRecordingReviewerRunner(ReviewerRunner):
+    """Return each predetermined Reviewer result once in call order."""
+
+    results: tuple[ReviewerResult, ...]
+    requests: list[ReviewerRequest] = field(default_factory=list)
+    close_calls: int = 0
+
+    async def run(self, request: ReviewerRequest) -> ReviewerResult:
+        self.requests.append(request)
+        return self.results[len(self.requests) - 1]
+
+    async def close(self) -> None:
+        self.close_calls += 1
+
+
+@dataclass(slots=True)
+class SequencedRecordingReviewerHandoffBuilder(ReviewerHandoffBuilder):
+    """Return each predetermined fresh Reviewer request once in call order."""
+
+    requests: tuple[ReviewerRequest, ...]
+    calls: list[tuple[WorkflowHandoffContext, DeveloperResult, int]] = field(default_factory=list)
+    close_calls: int = 0
+
+    async def build(
+        self,
+        context: WorkflowHandoffContext,
+        developer_result: DeveloperResult,
+        cycle: int,
+    ) -> ReviewerRequest:
+        self.calls.append((context, developer_result, cycle))
+        return self.requests[len(self.calls) - 1]
+
+    async def close(self) -> None:
+        self.close_calls += 1
+
+
+@dataclass(slots=True)
+class FailingDeveloperRunner(DeveloperRunner):
+    """Raise one caller-supplied ordinary error after recording the invocation."""
+
+    error: Exception
+    requests: list[DeveloperRequest] = field(default_factory=list)
+
+    async def run(self, request: DeveloperRequest) -> DeveloperResult:
+        self.requests.append(request)
+        raise self.error
+
+
+@dataclass(slots=True)
+class FailingReviewerRunner(ReviewerRunner):
+    """Raise one caller-supplied ordinary error after recording the invocation."""
+
+    error: Exception
+    requests: list[ReviewerRequest] = field(default_factory=list)
+
+    async def run(self, request: ReviewerRequest) -> ReviewerResult:
+        self.requests.append(request)
+        raise self.error
+
+
+@dataclass(slots=True)
+class FailingReviewerHandoffBuilder(ReviewerHandoffBuilder):
+    """Raise one caller-supplied ordinary error after recording the build input."""
+
+    error: Exception
     calls: list[tuple[WorkflowHandoffContext, DeveloperResult, int]] = field(default_factory=list)
 
     async def build(
@@ -48,4 +155,57 @@ class RecordingReviewerHandoffBuilder(ReviewerHandoffBuilder):
         cycle: int,
     ) -> ReviewerRequest:
         self.calls.append((context, developer_result, cycle))
+        raise self.error
+
+
+@dataclass(slots=True)
+class BlockingDeveloperRunner(DeveloperRunner):
+    """Block a Developer invocation until cancellation or explicit release."""
+
+    result: DeveloperResult
+    started: Event = field(default_factory=Event)
+    release: Event = field(default_factory=Event)
+    requests: list[DeveloperRequest] = field(default_factory=list)
+
+    async def run(self, request: DeveloperRequest) -> DeveloperResult:
+        self.requests.append(request)
+        self.started.set()
+        await self.release.wait()
+        return self.result
+
+
+@dataclass(slots=True)
+class BlockingReviewerRunner(ReviewerRunner):
+    """Block a Reviewer invocation until cancellation or explicit release."""
+
+    result: ReviewerResult
+    started: Event = field(default_factory=Event)
+    release: Event = field(default_factory=Event)
+    requests: list[ReviewerRequest] = field(default_factory=list)
+
+    async def run(self, request: ReviewerRequest) -> ReviewerResult:
+        self.requests.append(request)
+        self.started.set()
+        await self.release.wait()
+        return self.result
+
+
+@dataclass(slots=True)
+class BlockingReviewerHandoffBuilder(ReviewerHandoffBuilder):
+    """Block a handoff build until cancellation or explicit release."""
+
+    request: ReviewerRequest
+    started: Event = field(default_factory=Event)
+    release: Event = field(default_factory=Event)
+    calls: list[tuple[WorkflowHandoffContext, DeveloperResult, int]] = field(default_factory=list)
+
+    async def build(
+        self,
+        context: WorkflowHandoffContext,
+        developer_result: DeveloperResult,
+        cycle: int,
+    ) -> ReviewerRequest:
+        self.calls.append((context, developer_result, cycle))
+        self.started.set()
+        await self.release.wait()
         return self.request

--- a/tests/workflows/test_audit.py
+++ b/tests/workflows/test_audit.py
@@ -2,15 +2,19 @@
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from pathlib import Path
+from types import TracebackType
+from uuid import UUID, uuid4
 
 import pytest
-from sqlalchemy import select
+from sqlalchemy import Engine, select
 from sqlalchemy.exc import SQLAlchemyError
-from sqlalchemy.orm import Session
+from sqlalchemy.orm import Session, sessionmaker
 
 from core.enums import AuditActorType, AuditResult, TaskStatus
 from core.reviewer import ReviewDecision
+from core.tasks.state_machine import InvalidTaskTransitionError
 from core.workflows import (
     ValidatedWorkflowScope,
     WorkflowError,
@@ -38,6 +42,54 @@ def _events(session: Session) -> list[AuditEvent]:
 
 def _workflow_events(session: Session) -> list[AuditEvent]:
     return [event for event in _events(session) if event.event_type != "TASK_STATUS_CHANGED"]
+
+
+def _assert_exception_chain_excludes_markers(error: BaseException, *markers: str) -> None:
+    """Inspect all public exception links and traceback locals for raw failure data."""
+    current: BaseException | None = error
+    while current is not None:
+        assert current.__cause__ is None
+        assert current.__context__ is None
+        assert all(marker not in repr(current) for marker in markers)
+        assert all(marker not in repr(current.args) for marker in markers)
+        assert all(marker not in repr(vars(current)) for marker in markers)
+        _assert_traceback_excludes_markers(current.__traceback__, markers)
+        current = current.__cause__ or current.__context__
+
+
+def _assert_traceback_excludes_markers(
+    traceback: TracebackType | None, markers: tuple[str, ...]
+) -> None:
+    while traceback is not None:
+        for value in traceback.tb_frame.f_locals.values():
+            assert all(marker not in repr(value) for marker in markers)
+        traceback = traceback.tb_next
+
+
+def _capture_workflow_error(operation: Callable[[], None]) -> WorkflowError:
+    """Return one sanitized checkpoint error without retaining caller-local marker data."""
+    try:
+        operation()
+    except WorkflowError as error:
+        return error
+    raise AssertionError("checkpoint should have raised WorkflowError")
+
+
+def _capture_rejected_metadata_error(
+    session: Session, scope: ValidatedWorkflowScope
+) -> tuple[TypeError, str]:
+    marker = "unbounded-metadata-marker-5a5c"
+    try:
+        append_workflow_event(  # type: ignore[call-arg]
+            session,
+            scope,
+            WorkflowEventType.WORKFLOW_STARTED,
+            metadata={"source-marker": marker},
+        )
+    except TypeError as error:
+        del marker
+        return error, "unbounded-metadata-marker-5a5c"
+    raise AssertionError("workflow event constructor should reject arbitrary metadata")
 
 
 @pytest.mark.parametrize(
@@ -126,9 +178,7 @@ def _append_event_for_type(
             finding_count=2,
         )
     if event_type is WorkflowEventType.REVIEW_CYCLE_EXHAUSTED:
-        return append_workflow_event(
-            session, scope, event_type, cycle=2, max_review_cycles=2
-        )
+        return append_workflow_event(session, scope, event_type, cycle=2, max_review_cycles=2)
     return append_workflow_event(session, scope, event_type, cycle=1)
 
 
@@ -159,9 +209,7 @@ def test_assignment_checkpoint_commits_assignment_status_and_start_event_togethe
         "reviewer_agent_id": "reviewer-01",
         "max_review_cycles": 2,
     }
-    assert {event.correlation_id for event in _workflow_events(db_session)} == {
-        request.correlation_id
-    }
+    assert {event.correlation_id for event in events} == {request.correlation_id}
 
 
 def test_checkpoints_preserve_chronological_status_and_workflow_history(
@@ -173,17 +221,38 @@ def test_checkpoints_preserve_chronological_status_and_workflow_history(
 
     scope = validate_workflow_request(db_session, request)
 
-    commit_assignment_checkpoint(db_session, scope)
-    commit_developer_started_checkpoint(db_session, scope, cycle=1)
-    commit_developer_completed_checkpoint(db_session, scope, cycle=1)
+    observed_status_edges: list[tuple[str, str]] = []
+    observed_event_ids: set[UUID] = set()
+
+    def record_checkpoint(operation: Callable[[], None]) -> None:
+        operation()
+        new_status_events = [
+            event
+            for event in _events(db_session)
+            if event.id not in observed_event_ids and event.event_type == "TASK_STATUS_CHANGED"
+        ]
+        observed_event_ids.update(event.id for event in _events(db_session))
+        assert len(new_status_events) == 1
+        observed_status_edges.append(
+            (
+                str(new_status_events[0].data["from_status"]),
+                str(new_status_events[0].data["to_status"]),
+            )
+        )
+
+    record_checkpoint(lambda: commit_assignment_checkpoint(db_session, scope))
+    record_checkpoint(lambda: commit_developer_started_checkpoint(db_session, scope, cycle=1))
+    record_checkpoint(lambda: commit_developer_completed_checkpoint(db_session, scope, cycle=1))
     commit_developer_handoff_checkpoint(db_session, scope, cycle=1)
-    commit_review_completed_checkpoint(
-        db_session,
-        scope,
-        cycle=1,
-        decision=ReviewDecision.APPROVED,
-        review_score=0.95,
-        finding_count=0,
+    record_checkpoint(
+        lambda: commit_review_completed_checkpoint(
+            db_session,
+            scope,
+            cycle=1,
+            decision=ReviewDecision.APPROVED,
+            review_score=0.95,
+            finding_count=0,
+        )
     )
 
     assert task.status is TaskStatus.WAITING_QA
@@ -196,41 +265,27 @@ def test_checkpoints_preserve_chronological_status_and_workflow_history(
         "WORKFLOW_COMPLETED",
     }
     assert len(events) == 8
-    status_edges = {
-        (event.data["from_status"], event.data["to_status"])
-        for event in events
-        if event.event_type == "TASK_STATUS_CHANGED"
-    }
-    assert status_edges == {
+    assert observed_status_edges == [
         ("READY", "ASSIGNED"),
         ("ASSIGNED", "IN_PROGRESS"),
         ("IN_PROGRESS", "WAITING_REVIEW"),
         ("WAITING_REVIEW", "WAITING_QA"),
-    }
-    assert {event.correlation_id for event in _workflow_events(db_session)} == {
-        request.correlation_id
-    }
+    ]
+    assert {event.correlation_id for event in events} == {request.correlation_id}
 
 
-def test_workflow_audit_never_leaks_source_markers(
+def test_workflow_audit_excludes_reachable_task_content_markers(
     db_session: Session, tmp_path: Path
 ) -> None:
     """Prevent task and agent evidence content from becoming append-only workflow data."""
-    markers = {
-        "task_text": "task-text-marker-5ce8",
-        "diff": "diff-marker-e6fc",
-        "finding": "finding-marker-b8f9",
-        "report": "report-marker-c2c1",
-        "exception": "exception-marker-6749",
-        "workspace": "workspace-marker-bf9a",
-    }
+    marker = "task-text-marker-5ce8"
     task, _, _, request = persisted_workflow_request(db_session, tmp_path)
     from core.workflows import validate_workflow_request
 
     scope = validate_workflow_request(db_session, request)
-    task.title = markers["task_text"]
-    task.description = markers["task_text"]
-    task.acceptance_criteria = [markers["task_text"]]
+    task.title = marker
+    task.description = marker
+    task.acceptance_criteria = [marker]
     db_session.commit()
     commit_assignment_checkpoint(db_session, scope)
     commit_developer_started_checkpoint(db_session, scope, cycle=1)
@@ -251,8 +306,7 @@ def test_workflow_audit_never_leaks_source_markers(
             for event in _events(db_session)
         ]
     )
-    for marker in markers.values():
-        assert marker not in serialized_history
+    assert marker not in serialized_history
 
 
 def test_exhausted_review_checkpoint_commits_human_escalation_with_its_event(
@@ -276,9 +330,7 @@ def test_exhausted_review_checkpoint_commits_human_escalation_with_its_event(
         finding_count=3,
     )
 
-    commit_review_cycle_exhausted_checkpoint(
-        db_session, scope, cycle=1, max_review_cycles=1
-    )
+    commit_review_cycle_exhausted_checkpoint(db_session, scope, cycle=1, max_review_cycles=1)
 
     assert task.status is TaskStatus.WAITING_HUMAN
     exhausted_event = next(
@@ -288,6 +340,35 @@ def test_exhausted_review_checkpoint_commits_human_escalation_with_its_event(
     )
     assert exhausted_event.actor_id == "reviewer-01"
     assert exhausted_event.data == {"cycle": 1, "max_review_cycles": 1}
+
+
+def test_exhaustion_rejects_a_cycle_before_the_configured_limit(
+    db_session: Session, tmp_path: Path
+) -> None:
+    """Prevent a first rejected review from being falsely recorded as exhausted."""
+    task, _, _, request = persisted_workflow_request(db_session, tmp_path)
+    from core.workflows import validate_workflow_request
+
+    scope = validate_workflow_request(db_session, request)
+    commit_assignment_checkpoint(db_session, scope)
+    commit_developer_started_checkpoint(db_session, scope, cycle=1)
+    commit_developer_completed_checkpoint(db_session, scope, cycle=1)
+    commit_review_completed_checkpoint(
+        db_session,
+        scope,
+        cycle=1,
+        decision=ReviewDecision.CHANGES_REQUESTED,
+        review_score=0.4,
+        finding_count=3,
+    )
+    event_count = len(_events(db_session))
+
+    with pytest.raises(WorkflowError) as raised:
+        commit_review_cycle_exhausted_checkpoint(db_session, scope, cycle=1, max_review_cycles=2)
+
+    assert raised.value.code is WorkflowErrorCode.INVALID_INPUT
+    assert task.status is TaskStatus.CHANGES_REQUESTED
+    assert len(_events(db_session)) == event_count
 
 
 def test_next_review_cycle_checkpoint_transitions_back_to_developer_work(
@@ -336,13 +417,9 @@ def test_workflow_event_constructor_rejects_arbitrary_metadata(
 
     scope = validate_workflow_request(db_session, request)
 
-    with pytest.raises(TypeError):
-        append_workflow_event(  # type: ignore[call-arg]
-            db_session,
-            scope,
-            WorkflowEventType.WORKFLOW_STARTED,
-            metadata={"source-marker": "unbounded-metadata-marker-5a5c"},
-        )
+    error, marker = _capture_rejected_metadata_error(db_session, scope)
+
+    _assert_exception_chain_excludes_markers(error, marker)
 
 
 def test_invalid_review_scalars_leave_no_pending_transition_or_audit(
@@ -401,6 +478,150 @@ def test_assignment_database_failure_rolls_back_its_pending_status_and_workflow_
     assert restored.status is TaskStatus.READY
     assert restored.assigned_agent_id is None
     assert _events(db_session) == []
+
+
+@pytest.mark.parametrize(
+    ("exception_factory", "expected_code", "marker"),
+    [
+        (
+            lambda: InvalidTaskTransitionError(
+                task_id="invalid-transition-marker-a428",
+                current=TaskStatus.READY,
+                target=TaskStatus.WAITING_QA,
+            ),
+            WorkflowErrorCode.INVALID_STATE,
+            "invalid-transition-marker-a428",
+        ),
+        (
+            lambda: RuntimeError("ordinary-staging-marker-9fac"),
+            WorkflowErrorCode.INTERNAL_FAILURE,
+            "ordinary-staging-marker-9fac",
+        ),
+    ],
+)
+def test_assignment_staging_failures_roll_back_and_detach_raw_exceptions(
+    db_session: Session,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    exception_factory: object,
+    expected_code: WorkflowErrorCode,
+    marker: str,
+) -> None:
+    """Prevent a staging failure from preserving assignment or raw exception state."""
+    task, _, _, request = persisted_workflow_request(db_session, tmp_path)
+    task_id = task.id
+    from core.workflows import validate_workflow_request
+
+    db_session.commit()
+    scope = validate_workflow_request(db_session, request)
+
+    def fail_after_transition(*_args: object, **_kwargs: object) -> AuditEvent:
+        raise exception_factory()  # type: ignore[operator]
+
+    monkeypatch.setattr("core.workflows.audit.append_workflow_event", fail_after_transition)
+
+    error = _capture_workflow_error(lambda: commit_assignment_checkpoint(db_session, scope))
+
+    assert error.code is expected_code
+    _assert_exception_chain_excludes_markers(error, marker)
+    restored = db_session.get(Task, task_id)
+    assert restored is not None
+    assert restored.status is TaskStatus.READY
+    assert restored.assigned_agent_id is None
+    assert _events(db_session) == []
+    db_session.commit()
+    restored_after_commit = db_session.get(Task, task_id)
+    assert restored_after_commit is not None
+    assert restored_after_commit.assigned_agent_id is None
+
+
+def test_rollback_failure_is_detached_and_never_replaces_safe_checkpoint_error(
+    db_session: Session, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Prevent a rollback error from disclosing or replacing the checkpoint failure."""
+    _, _, _, request = persisted_workflow_request(db_session, tmp_path)
+    from core.workflows import validate_workflow_request
+
+    scope = validate_workflow_request(db_session, request)
+    staging_marker = "staging-exception-marker-9cde"
+    rollback_marker = "rollback-exception-marker-12f7"
+
+    def fail_stage(*_args: object, **_kwargs: object) -> AuditEvent:
+        raise RuntimeError(staging_marker)
+
+    def fail_rollback() -> None:
+        raise RuntimeError(rollback_marker)
+
+    monkeypatch.setattr("core.workflows.audit.append_workflow_event", fail_stage)
+    monkeypatch.setattr(db_session, "rollback", fail_rollback)
+
+    error = _capture_workflow_error(lambda: commit_assignment_checkpoint(db_session, scope))
+
+    assert error.code is WorkflowErrorCode.INTERNAL_FAILURE
+    _assert_exception_chain_excludes_markers(error, staging_marker, rollback_marker)
+
+
+def test_assignment_reloads_a_locked_task_and_rejects_a_stale_preflight(
+    database_engine: Engine, tmp_path: Path
+) -> None:
+    """Prevent two READY preflights from both committing a workflow assignment."""
+    factory = sessionmaker(bind=database_engine, expire_on_commit=False)
+    seed_session = factory()
+    first_session = factory()
+    second_session = factory()
+    try:
+        task, developer, reviewer, request = persisted_workflow_request(seed_session, tmp_path)
+        developer_slug = f"developer-{uuid4().hex[:12]}"
+        reviewer_slug = f"reviewer-{uuid4().hex[:12]}"
+        developer.slug = developer_slug
+        reviewer.slug = reviewer_slug
+        developer_request = request.developer_request.model_copy(
+            update={
+                "profile": request.developer_request.profile.model_copy(
+                    update={"id": developer_slug}
+                ),
+                "execution_context": request.developer_request.execution_context.model_copy(
+                    update={"agent_id": developer_slug}
+                ),
+            }
+        )
+        request = request.model_copy(
+            update={
+                "developer_request": developer_request,
+                "reviewer_profile": request.reviewer_profile.model_copy(
+                    update={"id": reviewer_slug}
+                ),
+            }
+        )
+        task_id = task.id
+        seed_session.commit()
+        from core.workflows import validate_workflow_request
+
+        first_scope = validate_workflow_request(first_session, request)
+        second_scope = validate_workflow_request(second_session, request)
+        commit_assignment_checkpoint(first_session, first_scope)
+
+        with pytest.raises(WorkflowError) as raised:
+            commit_assignment_checkpoint(second_session, second_scope)
+
+        assert raised.value.code is WorkflowErrorCode.INVALID_STATE
+        stored = second_session.get(Task, task_id, populate_existing=True)
+        assert stored is not None
+        assert stored.status is TaskStatus.ASSIGNED
+        events = _events(second_session)
+        status_events = [event for event in events if event.event_type == "TASK_STATUS_CHANGED"]
+        assert [(event.event_type, event.data["to_status"]) for event in status_events] == [
+            ("TASK_STATUS_CHANGED", "ASSIGNED")
+        ]
+        assert {event.event_type for event in events} == {
+            "TASK_STATUS_CHANGED",
+            "WORKFLOW_STARTED",
+        }
+        assert {event.correlation_id for event in events} == {request.correlation_id}
+    finally:
+        first_session.close()
+        second_session.close()
+        seed_session.close()
 
 
 def test_checkpoint_never_closes_the_caller_owned_session(

--- a/tests/workflows/test_audit.py
+++ b/tests/workflows/test_audit.py
@@ -28,6 +28,7 @@ from core.workflows import (
     commit_next_review_cycle_checkpoint,
     commit_review_completed_checkpoint,
     commit_review_cycle_exhausted_checkpoint,
+    commit_safe_failure_checkpoint,
 )
 from infrastructure.database.append_only import AppendOnlyViolationError
 from infrastructure.database.models import AuditEvent, Task
@@ -441,6 +442,35 @@ def test_next_review_cycle_checkpoint_transitions_back_to_developer_work(
         "to_status": "IN_PROGRESS",
         "reason": "Workflow correction cycle started.",
         "metadata": {},
+    }
+
+
+def test_safe_failure_checkpoint_escalates_a_started_workflow_with_only_a_stable_code(
+    db_session: Session, tmp_path: Path
+) -> None:
+    """A collaborator failure must use TaskStateMachine to commit its human escalation."""
+    task, _, _, request = persisted_workflow_request(db_session, tmp_path)
+    from core.workflows import validate_workflow_request
+
+    scope = validate_workflow_request(db_session, request)
+    commit_assignment_checkpoint(db_session, scope)
+    commit_developer_started_checkpoint(db_session, scope, cycle=1)
+
+    commit_safe_failure_checkpoint(
+        db_session, scope, error_code=WorkflowErrorCode.COLLABORATOR_FAILURE
+    )
+
+    assert task.status is TaskStatus.WAITING_HUMAN
+    status_event = next(
+        event
+        for event in _events(db_session)
+        if event.event_type == "TASK_STATUS_CHANGED" and event.data["to_status"] == "WAITING_HUMAN"
+    )
+    assert status_event.data == {
+        "from_status": "IN_PROGRESS",
+        "to_status": "WAITING_HUMAN",
+        "reason": "Workflow safely escalated for human attention.",
+        "metadata": {"workflow_error_code": "COLLABORATOR_FAILURE"},
     }
 
 

--- a/tests/workflows/test_audit.py
+++ b/tests/workflows/test_audit.py
@@ -66,6 +66,18 @@ def _assert_traceback_excludes_markers(
         traceback = traceback.tb_next
 
 
+def _assert_checkpoint_implementation_frames_are_clean(error: WorkflowError, *markers: str) -> None:
+    """Inspect only workflow implementation frames, not uncontrollable caller frames."""
+    traceback = error.__traceback__
+    while traceback is not None:
+        frame = traceback.tb_frame
+        if frame.f_code.co_filename.endswith("core/workflows/audit.py"):
+            assert {"scope", "request", "task", "session", "stage"}.isdisjoint(frame.f_locals)
+            for value in frame.f_locals.values():
+                assert all(marker not in repr(value) for marker in markers)
+        traceback = traceback.tb_next
+
+
 def _capture_workflow_error(operation: Callable[[], None]) -> WorkflowError:
     """Return one sanitized checkpoint error without retaining caller-local marker data."""
     try:
@@ -371,6 +383,28 @@ def test_exhaustion_rejects_a_cycle_before_the_configured_limit(
     assert len(_events(db_session)) == event_count
 
 
+def test_direct_exhaustion_event_rejects_a_cycle_before_the_configured_limit(
+    db_session: Session, tmp_path: Path
+) -> None:
+    """Prevent direct workflow-event callers from falsely recording exhaustion."""
+    _, _, _, request = persisted_workflow_request(db_session, tmp_path)
+    from core.workflows import validate_workflow_request
+
+    scope = validate_workflow_request(db_session, request)
+
+    with pytest.raises(WorkflowError) as raised:
+        append_workflow_event(
+            db_session,
+            scope,
+            WorkflowEventType.REVIEW_CYCLE_EXHAUSTED,
+            cycle=1,
+            max_review_cycles=2,
+        )
+
+    assert raised.value.code is WorkflowErrorCode.INVALID_INPUT
+    assert _events(db_session) == []
+
+
 def test_next_review_cycle_checkpoint_transitions_back_to_developer_work(
     db_session: Session, tmp_path: Path
 ) -> None:
@@ -535,30 +569,104 @@ def test_assignment_staging_failures_roll_back_and_detach_raw_exceptions(
     assert restored_after_commit.assigned_agent_id is None
 
 
-def test_rollback_failure_is_detached_and_never_replaces_safe_checkpoint_error(
-    db_session: Session, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+def test_rollback_failure_invalidates_partial_assignment_and_returns_safe_persistence_error(
+    database_engine: Engine, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """Prevent a rollback error from disclosing or replacing the checkpoint failure."""
-    _, _, _, request = persisted_workflow_request(db_session, tmp_path)
+    """Prevent a poisoned checkpoint transaction from later persisting partial state."""
+    factory = sessionmaker(bind=database_engine, expire_on_commit=False)
+    seed_session = factory()
+    poisoned_session = factory()
+    verification_session = factory()
     from core.workflows import validate_workflow_request
 
-    scope = validate_workflow_request(db_session, request)
-    staging_marker = "staging-exception-marker-9cde"
+    task, developer, reviewer, request = persisted_workflow_request(seed_session, tmp_path)
+    developer_slug = f"developer-{uuid4().hex[:12]}"
+    reviewer_slug = f"reviewer-{uuid4().hex[:12]}"
+    developer.slug = developer_slug
+    reviewer.slug = reviewer_slug
+    developer_request = request.developer_request.model_copy(
+        update={
+            "profile": request.developer_request.profile.model_copy(update={"id": developer_slug}),
+            "execution_context": request.developer_request.execution_context.model_copy(
+                update={"agent_id": developer_slug}
+            ),
+        }
+    )
+    request = request.model_copy(
+        update={
+            "developer_request": developer_request,
+            "reviewer_profile": request.reviewer_profile.model_copy(update={"id": reviewer_slug}),
+        }
+    )
+    task_id = task.id
+    seed_session.commit()
+    scope = validate_workflow_request(poisoned_session, request)
+    original_commit = poisoned_session.commit
+    original_rollback = poisoned_session.rollback
+    staging_marker = "commit-exception-marker-9cde"
     rollback_marker = "rollback-exception-marker-12f7"
 
-    def fail_stage(*_args: object, **_kwargs: object) -> AuditEvent:
-        raise RuntimeError(staging_marker)
+    def fail_after_flush() -> None:
+        poisoned_session.flush()
+        raise SQLAlchemyError(staging_marker)
 
     def fail_rollback() -> None:
         raise RuntimeError(rollback_marker)
 
+    monkeypatch.setattr(poisoned_session, "commit", fail_after_flush)
+    monkeypatch.setattr(poisoned_session, "rollback", fail_rollback)
+
+    error = _capture_workflow_error(lambda: commit_assignment_checkpoint(poisoned_session, scope))
+
+    assert error.code is WorkflowErrorCode.PERSISTENCE_FAILURE
+    _assert_exception_chain_excludes_markers(error, staging_marker, rollback_marker)
+    monkeypatch.setattr(poisoned_session, "commit", original_commit)
+    monkeypatch.setattr(poisoned_session, "rollback", original_rollback)
+    poisoned_session.commit()
+
+    restored = verification_session.get(Task, task_id)
+    assert restored is not None
+    assert restored.status is TaskStatus.READY
+    assert restored.assigned_agent_id is None
+    assert _events(verification_session) == []
+    poisoned_session.close()
+    verification_session.close()
+    seed_session.close()
+
+
+def test_safe_checkpoint_error_traceback_does_not_retain_workflow_scope_markers(
+    db_session: Session, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Prevent public checkpoint frames from retaining task or workspace scope data."""
+    task_marker = "task-scope-marker-3efa"
+    workspace_marker = "workspace-scope-marker-940c"
+    workspace_root = tmp_path / workspace_marker
+    workspace_root.mkdir()
+    task, _, _, request = persisted_workflow_request(db_session, tmp_path)
+    task.title = task_marker
+    db_session.commit()
+    from core.workflows import validate_workflow_request
+
+    developer_request = request.developer_request.model_copy(
+        update={
+            "execution_context": request.developer_request.execution_context.model_copy(
+                update={"workspace_root": workspace_root}
+            )
+        }
+    )
+    scope = validate_workflow_request(
+        db_session, request.model_copy(update={"developer_request": developer_request})
+    )
+
+    def fail_stage(*_args: object, **_kwargs: object) -> AuditEvent:
+        raise RuntimeError("staging failure")
+
     monkeypatch.setattr("core.workflows.audit.append_workflow_event", fail_stage)
-    monkeypatch.setattr(db_session, "rollback", fail_rollback)
 
     error = _capture_workflow_error(lambda: commit_assignment_checkpoint(db_session, scope))
 
     assert error.code is WorkflowErrorCode.INTERNAL_FAILURE
-    _assert_exception_chain_excludes_markers(error, staging_marker, rollback_marker)
+    _assert_checkpoint_implementation_frames_are_clean(error, task_marker, workspace_marker)
 
 
 def test_assignment_reloads_a_locked_task_and_rejects_a_stale_preflight(
@@ -608,7 +716,7 @@ def test_assignment_reloads_a_locked_task_and_rejects_a_stale_preflight(
         stored = second_session.get(Task, task_id, populate_existing=True)
         assert stored is not None
         assert stored.status is TaskStatus.ASSIGNED
-        events = _events(second_session)
+        events = [event for event in _events(second_session) if event.task_id == task_id]
         status_events = [event for event in events if event.event_type == "TASK_STATUS_CHANGED"]
         assert [(event.event_type, event.data["to_status"]) for event in status_events] == [
             ("TASK_STATUS_CHANGED", "ASSIGNED")

--- a/tests/workflows/test_audit.py
+++ b/tests/workflows/test_audit.py
@@ -1,0 +1,434 @@
+"""Real-PostgreSQL tests for bounded Phase 16 workflow checkpoints."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.exc import SQLAlchemyError
+from sqlalchemy.orm import Session
+
+from core.enums import AuditActorType, AuditResult, TaskStatus
+from core.reviewer import ReviewDecision
+from core.workflows import (
+    ValidatedWorkflowScope,
+    WorkflowError,
+    WorkflowErrorCode,
+    WorkflowEventType,
+    append_workflow_event,
+    commit_assignment_checkpoint,
+    commit_developer_completed_checkpoint,
+    commit_developer_handoff_checkpoint,
+    commit_developer_started_checkpoint,
+    commit_next_review_cycle_checkpoint,
+    commit_review_completed_checkpoint,
+    commit_review_cycle_exhausted_checkpoint,
+)
+from infrastructure.database.append_only import AppendOnlyViolationError
+from infrastructure.database.models import AuditEvent, Task
+from tests.workflows.factories import persisted_workflow_request
+
+pytest_plugins = ("tests.database.conftest",)
+
+
+def _events(session: Session) -> list[AuditEvent]:
+    return list(session.scalars(select(AuditEvent).order_by(AuditEvent.created_at, AuditEvent.id)))
+
+
+def _workflow_events(session: Session) -> list[AuditEvent]:
+    return [event for event in _events(session) if event.event_type != "TASK_STATUS_CHANGED"]
+
+
+@pytest.mark.parametrize(
+    ("event_type", "expected_actor", "expected_data"),
+    [
+        (
+            WorkflowEventType.WORKFLOW_STARTED,
+            "developer-01",
+            {
+                "developer_agent_id": "developer-01",
+                "reviewer_agent_id": "reviewer-01",
+                "max_review_cycles": 2,
+            },
+        ),
+        (
+            WorkflowEventType.DEVELOPER_HANDOFF_CREATED,
+            "developer-01",
+            {"cycle": 1},
+        ),
+        (
+            WorkflowEventType.REVIEW_COMPLETED,
+            "reviewer-01",
+            {
+                "cycle": 1,
+                "decision": "CHANGES_REQUESTED",
+                "review_score": 0.75,
+                "finding_count": 2,
+            },
+        ),
+        (
+            WorkflowEventType.REVIEW_CYCLE_EXHAUSTED,
+            "reviewer-01",
+            {"cycle": 2, "max_review_cycles": 2},
+        ),
+        (
+            WorkflowEventType.WORKFLOW_COMPLETED,
+            "reviewer-01",
+            {"cycle": 1},
+        ),
+    ],
+)
+def test_append_workflow_event_records_only_its_allowlisted_scalars(
+    db_session: Session,
+    tmp_path: Path,
+    event_type: WorkflowEventType,
+    expected_actor: str,
+    expected_data: dict[str, object],
+) -> None:
+    """Prevent workflow history from retaining unbounded agent input or output."""
+    _, _, _, request = persisted_workflow_request(db_session, tmp_path)
+    from core.workflows import validate_workflow_request
+
+    scope = validate_workflow_request(db_session, request)
+
+    event = _append_event_for_type(db_session, scope, event_type)
+    db_session.commit()
+
+    assert event.event_type == event_type.value
+    assert event.action == "record_workflow_checkpoint"
+    assert event.resource_type == "DEVELOPER_REVIEWER_WORKFLOW"
+    assert event.resource_id == str(scope.task.id)
+    assert event.result is AuditResult.SUCCEEDED
+    assert event.actor_type is AuditActorType.AGENT
+    assert event.actor_id == expected_actor
+    assert event.project_id == scope.task.project_id
+    assert event.task_id == scope.task.id
+    assert event.correlation_id == request.correlation_id
+    assert event.data == expected_data
+
+
+def _append_event_for_type(
+    session: Session, scope: ValidatedWorkflowScope, event_type: WorkflowEventType
+) -> AuditEvent:
+    if event_type is WorkflowEventType.WORKFLOW_STARTED:
+        return append_workflow_event(session, scope, event_type)
+    if event_type is WorkflowEventType.DEVELOPER_HANDOFF_CREATED:
+        return append_workflow_event(session, scope, event_type, cycle=1)
+    if event_type is WorkflowEventType.REVIEW_COMPLETED:
+        return append_workflow_event(
+            session,
+            scope,
+            event_type,
+            cycle=1,
+            decision=ReviewDecision.CHANGES_REQUESTED,
+            review_score=0.75,
+            finding_count=2,
+        )
+    if event_type is WorkflowEventType.REVIEW_CYCLE_EXHAUSTED:
+        return append_workflow_event(
+            session, scope, event_type, cycle=2, max_review_cycles=2
+        )
+    return append_workflow_event(session, scope, event_type, cycle=1)
+
+
+def test_assignment_checkpoint_commits_assignment_status_and_start_event_together(
+    db_session: Session, tmp_path: Path
+) -> None:
+    """Prevent a durable assignment without its authoritative status and workflow facts."""
+    task, developer, _, request = persisted_workflow_request(db_session, tmp_path)
+    from core.workflows import validate_workflow_request
+
+    scope = validate_workflow_request(db_session, request)
+
+    commit_assignment_checkpoint(db_session, scope)
+
+    assert task.assigned_agent_id == developer.id
+    assert task.status is TaskStatus.ASSIGNED
+    events = _events(db_session)
+    assert len(events) == 2
+    events_by_type = {event.event_type: event for event in events}
+    assert events_by_type["TASK_STATUS_CHANGED"].data == {
+        "from_status": "READY",
+        "to_status": "ASSIGNED",
+        "reason": "Workflow developer assignment accepted.",
+        "metadata": {},
+    }
+    assert events_by_type["WORKFLOW_STARTED"].data == {
+        "developer_agent_id": "developer-01",
+        "reviewer_agent_id": "reviewer-01",
+        "max_review_cycles": 2,
+    }
+    assert {event.correlation_id for event in _workflow_events(db_session)} == {
+        request.correlation_id
+    }
+
+
+def test_checkpoints_preserve_chronological_status_and_workflow_history(
+    db_session: Session, tmp_path: Path
+) -> None:
+    """Prevent later checkpoints from overwriting earlier workflow truth."""
+    task, _, _, request = persisted_workflow_request(db_session, tmp_path)
+    from core.workflows import validate_workflow_request
+
+    scope = validate_workflow_request(db_session, request)
+
+    commit_assignment_checkpoint(db_session, scope)
+    commit_developer_started_checkpoint(db_session, scope, cycle=1)
+    commit_developer_completed_checkpoint(db_session, scope, cycle=1)
+    commit_developer_handoff_checkpoint(db_session, scope, cycle=1)
+    commit_review_completed_checkpoint(
+        db_session,
+        scope,
+        cycle=1,
+        decision=ReviewDecision.APPROVED,
+        review_score=0.95,
+        finding_count=0,
+    )
+
+    assert task.status is TaskStatus.WAITING_QA
+    events = _events(db_session)
+    assert {event.event_type for event in events} == {
+        "TASK_STATUS_CHANGED",
+        "WORKFLOW_STARTED",
+        "DEVELOPER_HANDOFF_CREATED",
+        "REVIEW_COMPLETED",
+        "WORKFLOW_COMPLETED",
+    }
+    assert len(events) == 8
+    status_edges = {
+        (event.data["from_status"], event.data["to_status"])
+        for event in events
+        if event.event_type == "TASK_STATUS_CHANGED"
+    }
+    assert status_edges == {
+        ("READY", "ASSIGNED"),
+        ("ASSIGNED", "IN_PROGRESS"),
+        ("IN_PROGRESS", "WAITING_REVIEW"),
+        ("WAITING_REVIEW", "WAITING_QA"),
+    }
+    assert {event.correlation_id for event in _workflow_events(db_session)} == {
+        request.correlation_id
+    }
+
+
+def test_workflow_audit_never_leaks_source_markers(
+    db_session: Session, tmp_path: Path
+) -> None:
+    """Prevent task and agent evidence content from becoming append-only workflow data."""
+    markers = {
+        "task_text": "task-text-marker-5ce8",
+        "diff": "diff-marker-e6fc",
+        "finding": "finding-marker-b8f9",
+        "report": "report-marker-c2c1",
+        "exception": "exception-marker-6749",
+        "workspace": "workspace-marker-bf9a",
+    }
+    task, _, _, request = persisted_workflow_request(db_session, tmp_path)
+    from core.workflows import validate_workflow_request
+
+    scope = validate_workflow_request(db_session, request)
+    task.title = markers["task_text"]
+    task.description = markers["task_text"]
+    task.acceptance_criteria = [markers["task_text"]]
+    db_session.commit()
+    commit_assignment_checkpoint(db_session, scope)
+    commit_developer_started_checkpoint(db_session, scope, cycle=1)
+    commit_developer_completed_checkpoint(db_session, scope, cycle=1)
+    commit_developer_handoff_checkpoint(db_session, scope, cycle=1)
+    commit_review_completed_checkpoint(
+        db_session,
+        scope,
+        cycle=1,
+        decision=ReviewDecision.CHANGES_REQUESTED,
+        review_score=0.4,
+        finding_count=3,
+    )
+
+    serialized_history = repr(
+        [
+            (event.event_type, event.action, event.resource_type, event.resource_id, event.data)
+            for event in _events(db_session)
+        ]
+    )
+    for marker in markers.values():
+        assert marker not in serialized_history
+
+
+def test_exhausted_review_checkpoint_commits_human_escalation_with_its_event(
+    db_session: Session, tmp_path: Path
+) -> None:
+    """Prevent an exhausted review cycle from losing its durable human escalation fact."""
+    task, _, _, request = persisted_workflow_request(db_session, tmp_path)
+    request = request.model_copy(update={"max_review_cycles": 1})
+    from core.workflows import validate_workflow_request
+
+    scope = validate_workflow_request(db_session, request)
+    commit_assignment_checkpoint(db_session, scope)
+    commit_developer_started_checkpoint(db_session, scope, cycle=1)
+    commit_developer_completed_checkpoint(db_session, scope, cycle=1)
+    commit_review_completed_checkpoint(
+        db_session,
+        scope,
+        cycle=1,
+        decision=ReviewDecision.CHANGES_REQUESTED,
+        review_score=0.4,
+        finding_count=3,
+    )
+
+    commit_review_cycle_exhausted_checkpoint(
+        db_session, scope, cycle=1, max_review_cycles=1
+    )
+
+    assert task.status is TaskStatus.WAITING_HUMAN
+    exhausted_event = next(
+        event
+        for event in _workflow_events(db_session)
+        if event.event_type == "REVIEW_CYCLE_EXHAUSTED"
+    )
+    assert exhausted_event.actor_id == "reviewer-01"
+    assert exhausted_event.data == {"cycle": 1, "max_review_cycles": 1}
+
+
+def test_next_review_cycle_checkpoint_transitions_back_to_developer_work(
+    db_session: Session, tmp_path: Path
+) -> None:
+    """Prevent requested changes from starting another Developer cycle without an audit edge."""
+    task, _, _, request = persisted_workflow_request(db_session, tmp_path)
+    from core.workflows import validate_workflow_request
+
+    scope = validate_workflow_request(db_session, request)
+    commit_assignment_checkpoint(db_session, scope)
+    commit_developer_started_checkpoint(db_session, scope, cycle=1)
+    commit_developer_completed_checkpoint(db_session, scope, cycle=1)
+    commit_review_completed_checkpoint(
+        db_session,
+        scope,
+        cycle=1,
+        decision=ReviewDecision.CHANGES_REQUESTED,
+        review_score=0.4,
+        finding_count=3,
+    )
+
+    commit_next_review_cycle_checkpoint(db_session, scope, cycle=2)
+
+    assert task.status is TaskStatus.IN_PROGRESS
+    status_event = next(
+        event
+        for event in _events(db_session)
+        if event.event_type == "TASK_STATUS_CHANGED"
+        and event.data["from_status"] == "CHANGES_REQUESTED"
+    )
+    assert status_event.data == {
+        "from_status": "CHANGES_REQUESTED",
+        "to_status": "IN_PROGRESS",
+        "reason": "Workflow correction cycle started.",
+        "metadata": {},
+    }
+
+
+def test_workflow_event_constructor_rejects_arbitrary_metadata(
+    db_session: Session, tmp_path: Path
+) -> None:
+    """Prevent callers from smuggling unbounded metadata into immutable audit history."""
+    _, _, _, request = persisted_workflow_request(db_session, tmp_path)
+    from core.workflows import validate_workflow_request
+
+    scope = validate_workflow_request(db_session, request)
+
+    with pytest.raises(TypeError):
+        append_workflow_event(  # type: ignore[call-arg]
+            db_session,
+            scope,
+            WorkflowEventType.WORKFLOW_STARTED,
+            metadata={"source-marker": "unbounded-metadata-marker-5a5c"},
+        )
+
+
+def test_invalid_review_scalars_leave_no_pending_transition_or_audit(
+    db_session: Session, tmp_path: Path
+) -> None:
+    """Prevent malformed reviewer data from staging a truthful-looking checkpoint."""
+    task, _, _, request = persisted_workflow_request(db_session, tmp_path)
+    from core.workflows import validate_workflow_request
+
+    scope = validate_workflow_request(db_session, request)
+    commit_assignment_checkpoint(db_session, scope)
+    commit_developer_started_checkpoint(db_session, scope, cycle=1)
+    commit_developer_completed_checkpoint(db_session, scope, cycle=1)
+    audit_count = len(_events(db_session))
+
+    with pytest.raises(WorkflowError) as raised:
+        commit_review_completed_checkpoint(
+            db_session,
+            scope,
+            cycle=1,
+            decision=ReviewDecision.CHANGES_REQUESTED,
+            review_score=1.1,
+            finding_count=1,
+        )
+
+    assert raised.value.code is WorkflowErrorCode.INVALID_INPUT
+    assert task.status is TaskStatus.WAITING_REVIEW
+    assert len(_events(db_session)) == audit_count
+
+
+def test_assignment_database_failure_rolls_back_its_pending_status_and_workflow_event(
+    db_session: Session, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Prevent a failed checkpoint from leaving half-persisted workflow history."""
+    task, _, _, request = persisted_workflow_request(db_session, tmp_path)
+    task_id = task.id
+    from core.workflows import validate_workflow_request
+
+    db_session.commit()
+    scope = validate_workflow_request(db_session, request)
+    original_commit = db_session.commit
+
+    def fail_after_flush() -> None:
+        db_session.flush()
+        raise SQLAlchemyError("database-failure-marker-45ea")
+
+    monkeypatch.setattr(db_session, "commit", fail_after_flush)
+
+    with pytest.raises(WorkflowError) as raised:
+        commit_assignment_checkpoint(db_session, scope)
+
+    assert raised.value.code is WorkflowErrorCode.PERSISTENCE_FAILURE
+    monkeypatch.setattr(db_session, "commit", original_commit)
+    restored = db_session.get(Task, task_id)
+    assert restored is not None
+    assert restored.status is TaskStatus.READY
+    assert restored.assigned_agent_id is None
+    assert _events(db_session) == []
+
+
+def test_checkpoint_never_closes_the_caller_owned_session(
+    db_session: Session, tmp_path: Path
+) -> None:
+    """Prevent a checkpoint from taking ownership of its injected database session."""
+    _, _, _, request = persisted_workflow_request(db_session, tmp_path)
+    from core.workflows import validate_workflow_request
+
+    scope = validate_workflow_request(db_session, request)
+
+    commit_assignment_checkpoint(db_session, scope)
+
+    assert db_session.is_active is True
+    assert db_session.get(Task, scope.task.id) is scope.task
+
+
+def test_workflow_events_remain_append_only_after_a_checkpoint(
+    db_session: Session, tmp_path: Path
+) -> None:
+    """Prevent normal workflow code from rewriting historical checkpoints."""
+    _, _, _, request = persisted_workflow_request(db_session, tmp_path)
+    from core.workflows import validate_workflow_request
+
+    scope = validate_workflow_request(db_session, request)
+    commit_assignment_checkpoint(db_session, scope)
+    event = _workflow_events(db_session)[0]
+    event.action = "rewritten_workflow_checkpoint"
+
+    with pytest.raises(AppendOnlyViolationError, match="append-only"):
+        db_session.flush()

--- a/tests/workflows/test_audit.py
+++ b/tests/workflows/test_audit.py
@@ -72,7 +72,9 @@ def _assert_checkpoint_implementation_frames_are_clean(error: WorkflowError, *ma
     while traceback is not None:
         frame = traceback.tb_frame
         if frame.f_code.co_filename.endswith("core/workflows/audit.py"):
-            assert {"scope", "request", "task", "session", "stage"}.isdisjoint(frame.f_locals)
+            assert {"scope", "request", "task", "session", "stage", "preflight"}.isdisjoint(
+                frame.f_locals
+            )
             for value in frame.f_locals.values():
                 assert all(marker not in repr(value) for marker in markers)
         traceback = traceback.tb_next
@@ -729,6 +731,57 @@ def test_assignment_reloads_a_locked_task_and_rejects_a_stale_preflight(
     finally:
         first_session.close()
         second_session.close()
+        seed_session.close()
+
+
+def test_rejected_stale_assignment_keeps_the_losing_scope_task_at_winning_state(
+    database_engine: Engine, tmp_path: Path
+) -> None:
+    """Prevent rejected assignment recovery from restoring a stale READY task snapshot."""
+    factory = sessionmaker(bind=database_engine, expire_on_commit=False)
+    seed_session = factory()
+    winning_session = factory()
+    losing_session = factory()
+    try:
+        task, developer, reviewer, request = persisted_workflow_request(seed_session, tmp_path)
+        developer_slug = f"developer-{uuid4().hex[:12]}"
+        reviewer_slug = f"reviewer-{uuid4().hex[:12]}"
+        developer.slug = developer_slug
+        reviewer.slug = reviewer_slug
+        developer_request = request.developer_request.model_copy(
+            update={
+                "profile": request.developer_request.profile.model_copy(
+                    update={"id": developer_slug}
+                ),
+                "execution_context": request.developer_request.execution_context.model_copy(
+                    update={"agent_id": developer_slug}
+                ),
+            }
+        )
+        request = request.model_copy(
+            update={
+                "developer_request": developer_request,
+                "reviewer_profile": request.reviewer_profile.model_copy(
+                    update={"id": reviewer_slug}
+                ),
+            }
+        )
+        seed_session.commit()
+        from core.workflows import validate_workflow_request
+
+        winning_scope = validate_workflow_request(winning_session, request)
+        losing_scope = validate_workflow_request(losing_session, request)
+        commit_assignment_checkpoint(winning_session, winning_scope)
+
+        with pytest.raises(WorkflowError) as raised:
+            commit_assignment_checkpoint(losing_session, losing_scope)
+
+        assert raised.value.code is WorkflowErrorCode.INVALID_STATE
+        assert losing_scope.task.status is TaskStatus.ASSIGNED
+        assert losing_scope.task.assigned_agent_id == developer.id
+    finally:
+        winning_session.close()
+        losing_session.close()
         seed_session.close()
 
 

--- a/tests/workflows/test_audit.py
+++ b/tests/workflows/test_audit.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import Callable
+from contextlib import suppress
 from pathlib import Path
 from types import TracebackType
 from uuid import UUID, uuid4
@@ -12,6 +13,7 @@ from sqlalchemy import Engine, select
 from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.orm import Session, sessionmaker
 
+import core.workflows as workflow_api
 from core.enums import AuditActorType, AuditResult, TaskStatus
 from core.reviewer import ReviewDecision
 from core.tasks.state_machine import InvalidTaskTransitionError
@@ -20,7 +22,6 @@ from core.workflows import (
     WorkflowError,
     WorkflowErrorCode,
     WorkflowEventType,
-    append_workflow_event,
     commit_assignment_checkpoint,
     commit_developer_completed_checkpoint,
     commit_developer_handoff_checkpoint,
@@ -35,6 +36,11 @@ from infrastructure.database.models import AuditEvent, Task
 from tests.workflows.factories import persisted_workflow_request
 
 pytest_plugins = ("tests.database.conftest",)
+
+
+def test_raw_workflow_event_staging_is_not_publicly_exposed() -> None:
+    """Prevent callers from recording workflow facts outside legal state checkpoints."""
+    assert not hasattr(workflow_api, "append_workflow_event")
 
 
 def _events(session: Session) -> list[AuditEvent]:
@@ -90,23 +96,6 @@ def _capture_workflow_error(operation: Callable[[], None]) -> WorkflowError:
     raise AssertionError("checkpoint should have raised WorkflowError")
 
 
-def _capture_rejected_metadata_error(
-    session: Session, scope: ValidatedWorkflowScope
-) -> tuple[TypeError, str]:
-    marker = "unbounded-metadata-marker-5a5c"
-    try:
-        append_workflow_event(  # type: ignore[call-arg]
-            session,
-            scope,
-            WorkflowEventType.WORKFLOW_STARTED,
-            metadata={"source-marker": marker},
-        )
-    except TypeError as error:
-        del marker
-        return error, "unbounded-metadata-marker-5a5c"
-    raise AssertionError("workflow event constructor should reject arbitrary metadata")
-
-
 @pytest.mark.parametrize(
     ("event_type", "expected_actor", "expected_data"),
     [
@@ -146,7 +135,7 @@ def _capture_rejected_metadata_error(
         ),
     ],
 )
-def test_append_workflow_event_records_only_its_allowlisted_scalars(
+def test_state_coupled_checkpoint_records_only_its_allowlisted_scalars(
     db_session: Session,
     tmp_path: Path,
     event_type: WorkflowEventType,
@@ -159,8 +148,7 @@ def test_append_workflow_event_records_only_its_allowlisted_scalars(
 
     scope = validate_workflow_request(db_session, request)
 
-    event = _append_event_for_type(db_session, scope, event_type)
-    db_session.commit()
+    event = _commit_checkpoint_for_event(db_session, scope, event_type)
 
     assert event.event_type == event_type.value
     assert event.action == "record_workflow_checkpoint"
@@ -175,26 +163,59 @@ def test_append_workflow_event_records_only_its_allowlisted_scalars(
     assert event.data == expected_data
 
 
-def _append_event_for_type(
+def _commit_checkpoint_for_event(
     session: Session, scope: ValidatedWorkflowScope, event_type: WorkflowEventType
 ) -> AuditEvent:
+    commit_assignment_checkpoint(session, scope)
     if event_type is WorkflowEventType.WORKFLOW_STARTED:
-        return append_workflow_event(session, scope, event_type)
+        return next(
+            event for event in _workflow_events(session) if event.event_type == event_type.value
+        )
+    commit_developer_started_checkpoint(session, scope, cycle=1)
+    commit_developer_completed_checkpoint(session, scope, cycle=1)
     if event_type is WorkflowEventType.DEVELOPER_HANDOFF_CREATED:
-        return append_workflow_event(session, scope, event_type, cycle=1)
-    if event_type is WorkflowEventType.REVIEW_COMPLETED:
-        return append_workflow_event(
+        commit_developer_handoff_checkpoint(session, scope, cycle=1)
+    elif event_type is WorkflowEventType.REVIEW_COMPLETED:
+        commit_review_completed_checkpoint(
             session,
             scope,
-            event_type,
             cycle=1,
             decision=ReviewDecision.CHANGES_REQUESTED,
             review_score=0.75,
             finding_count=2,
         )
-    if event_type is WorkflowEventType.REVIEW_CYCLE_EXHAUSTED:
-        return append_workflow_event(session, scope, event_type, cycle=2, max_review_cycles=2)
-    return append_workflow_event(session, scope, event_type, cycle=1)
+    elif event_type is WorkflowEventType.REVIEW_CYCLE_EXHAUSTED:
+        commit_review_completed_checkpoint(
+            session,
+            scope,
+            cycle=1,
+            decision=ReviewDecision.CHANGES_REQUESTED,
+            review_score=0.75,
+            finding_count=2,
+        )
+        commit_next_review_cycle_checkpoint(session, scope, cycle=2)
+        commit_developer_completed_checkpoint(session, scope, cycle=2)
+        commit_review_completed_checkpoint(
+            session,
+            scope,
+            cycle=2,
+            decision=ReviewDecision.CHANGES_REQUESTED,
+            review_score=0.75,
+            finding_count=2,
+        )
+        commit_review_cycle_exhausted_checkpoint(session, scope, cycle=2, max_review_cycles=2)
+    else:
+        commit_review_completed_checkpoint(
+            session,
+            scope,
+            cycle=1,
+            decision=ReviewDecision.APPROVED,
+            review_score=0.75,
+            finding_count=2,
+        )
+    return next(
+        event for event in _workflow_events(session) if event.event_type == event_type.value
+    )
 
 
 def test_assignment_checkpoint_commits_assignment_status_and_start_event_together(
@@ -386,28 +407,6 @@ def test_exhaustion_rejects_a_cycle_before_the_configured_limit(
     assert len(_events(db_session)) == event_count
 
 
-def test_direct_exhaustion_event_rejects_a_cycle_before_the_configured_limit(
-    db_session: Session, tmp_path: Path
-) -> None:
-    """Prevent direct workflow-event callers from falsely recording exhaustion."""
-    _, _, _, request = persisted_workflow_request(db_session, tmp_path)
-    from core.workflows import validate_workflow_request
-
-    scope = validate_workflow_request(db_session, request)
-
-    with pytest.raises(WorkflowError) as raised:
-        append_workflow_event(
-            db_session,
-            scope,
-            WorkflowEventType.REVIEW_CYCLE_EXHAUSTED,
-            cycle=1,
-            max_review_cycles=2,
-        )
-
-    assert raised.value.code is WorkflowErrorCode.INVALID_INPUT
-    assert _events(db_session) == []
-
-
 def test_next_review_cycle_checkpoint_transitions_back_to_developer_work(
     db_session: Session, tmp_path: Path
 ) -> None:
@@ -457,7 +456,10 @@ def test_safe_failure_checkpoint_escalates_a_started_workflow_with_only_a_stable
     commit_developer_started_checkpoint(db_session, scope, cycle=1)
 
     commit_safe_failure_checkpoint(
-        db_session, scope, error_code=WorkflowErrorCode.COLLABORATOR_FAILURE
+        db_session,
+        scope,
+        error_code=WorkflowErrorCode.COLLABORATOR_FAILURE,
+        expected_status=TaskStatus.IN_PROGRESS,
     )
 
     assert task.status is TaskStatus.WAITING_HUMAN
@@ -472,20 +474,6 @@ def test_safe_failure_checkpoint_escalates_a_started_workflow_with_only_a_stable
         "reason": "Workflow safely escalated for human attention.",
         "metadata": {"workflow_error_code": "COLLABORATOR_FAILURE"},
     }
-
-
-def test_workflow_event_constructor_rejects_arbitrary_metadata(
-    db_session: Session, tmp_path: Path
-) -> None:
-    """Prevent callers from smuggling unbounded metadata into immutable audit history."""
-    _, _, _, request = persisted_workflow_request(db_session, tmp_path)
-    from core.workflows import validate_workflow_request
-
-    scope = validate_workflow_request(db_session, request)
-
-    error, marker = _capture_rejected_metadata_error(db_session, scope)
-
-    _assert_exception_chain_excludes_markers(error, marker)
 
 
 def test_invalid_review_scalars_leave_no_pending_transition_or_audit(
@@ -584,7 +572,7 @@ def test_assignment_staging_failures_roll_back_and_detach_raw_exceptions(
     def fail_after_transition(*_args: object, **_kwargs: object) -> AuditEvent:
         raise exception_factory()  # type: ignore[operator]
 
-    monkeypatch.setattr("core.workflows.audit.append_workflow_event", fail_after_transition)
+    monkeypatch.setattr("core.workflows.audit._stage_workflow_event", fail_after_transition)
 
     error = _capture_workflow_error(lambda: commit_assignment_checkpoint(db_session, scope))
 
@@ -601,10 +589,10 @@ def test_assignment_staging_failures_roll_back_and_detach_raw_exceptions(
     assert restored_after_commit.assigned_agent_id is None
 
 
-def test_rollback_failure_invalidates_partial_assignment_and_returns_safe_persistence_error(
+def test_rollback_failure_invalidates_only_the_poisoned_connection_and_session_cannot_commit(
     database_engine: Engine, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """Prevent a poisoned checkpoint transaction from later persisting partial state."""
+    """Prevent rollback recovery from closing caller Session ownership or preserving writes."""
     factory = sessionmaker(bind=database_engine, expire_on_commit=False)
     seed_session = factory()
     poisoned_session = factory()
@@ -633,10 +621,16 @@ def test_rollback_failure_invalidates_partial_assignment_and_returns_safe_persis
     task_id = task.id
     seed_session.commit()
     scope = validate_workflow_request(poisoned_session, request)
+    poisoned_connection = poisoned_session.connection()
     original_commit = poisoned_session.commit
     original_rollback = poisoned_session.rollback
+    original_close = poisoned_session.close
+    original_connection_invalidate = poisoned_connection.invalidate
     staging_marker = "commit-exception-marker-9cde"
     rollback_marker = "rollback-exception-marker-12f7"
+    session_invalidate_calls = 0
+    session_close_calls = 0
+    connection_invalidate_calls = 0
 
     def fail_after_flush() -> None:
         poisoned_session.flush()
@@ -645,23 +639,44 @@ def test_rollback_failure_invalidates_partial_assignment_and_returns_safe_persis
     def fail_rollback() -> None:
         raise RuntimeError(rollback_marker)
 
+    def record_session_invalidate() -> None:
+        nonlocal session_invalidate_calls
+        session_invalidate_calls += 1
+
+    def record_session_close() -> None:
+        nonlocal session_close_calls
+        session_close_calls += 1
+
+    def record_connection_invalidate(exception: BaseException | None = None) -> None:
+        nonlocal connection_invalidate_calls
+        connection_invalidate_calls += 1
+        original_connection_invalidate(exception)
+
     monkeypatch.setattr(poisoned_session, "commit", fail_after_flush)
     monkeypatch.setattr(poisoned_session, "rollback", fail_rollback)
+    monkeypatch.setattr(poisoned_session, "invalidate", record_session_invalidate)
+    monkeypatch.setattr(poisoned_session, "close", record_session_close)
+    monkeypatch.setattr(poisoned_connection, "invalidate", record_connection_invalidate)
 
     error = _capture_workflow_error(lambda: commit_assignment_checkpoint(poisoned_session, scope))
 
     assert error.code is WorkflowErrorCode.PERSISTENCE_FAILURE
     _assert_exception_chain_excludes_markers(error, staging_marker, rollback_marker)
-    monkeypatch.setattr(poisoned_session, "commit", original_commit)
-    monkeypatch.setattr(poisoned_session, "rollback", original_rollback)
-    poisoned_session.commit()
+    assert session_invalidate_calls == 0
+    assert session_close_calls == 0
+    assert connection_invalidate_calls == 1
+    with pytest.raises(SQLAlchemyError):
+        original_commit()
 
     restored = verification_session.get(Task, task_id)
     assert restored is not None
     assert restored.status is TaskStatus.READY
     assert restored.assigned_agent_id is None
     assert _events(verification_session) == []
-    poisoned_session.close()
+    monkeypatch.setattr(poisoned_session, "rollback", original_rollback)
+    with suppress(SQLAlchemyError):
+        original_rollback()
+    original_close()
     verification_session.close()
     seed_session.close()
 
@@ -693,7 +708,7 @@ def test_safe_checkpoint_error_traceback_does_not_retain_workflow_scope_markers(
     def fail_stage(*_args: object, **_kwargs: object) -> AuditEvent:
         raise RuntimeError("staging failure")
 
-    monkeypatch.setattr("core.workflows.audit.append_workflow_event", fail_stage)
+    monkeypatch.setattr("core.workflows.audit._stage_workflow_event", fail_stage)
 
     error = _capture_workflow_error(lambda: commit_assignment_checkpoint(db_session, scope))
 

--- a/tests/workflows/test_handoff.py
+++ b/tests/workflows/test_handoff.py
@@ -7,21 +7,14 @@ import pytest
 from core.commands import CommandCategory, CommandProfileId, CommandTerminalStatus
 from core.developer import DeveloperCheckResult, DeveloperResult
 from core.enums import Permission
-from core.reviewer import ReviewCheck, ReviewerRequest
+from core.reviewer import ReviewCheck, ReviewerRequest, validate_reviewer_request
 from core.runtime import RuntimeResult, RuntimeTerminalReason, RuntimeTerminalStatus
 from core.workflows import WorkflowError, WorkflowErrorCode, WorkflowHandoffContext
 from core.workflows.handoff import validate_reviewer_handoff
-from core.workflows.ports import DeveloperRunner, ReviewerHandoffBuilder, ReviewerRunner
 from tests.reviewer.factories import reviewer_profile
 from tests.workflows.factories import (
-    approved_reviewer_result,
     completed_developer_report,
     handoff_context_values,
-)
-from tests.workflows.fakes import (
-    RecordingDeveloperRunner,
-    RecordingReviewerHandoffBuilder,
-    RecordingReviewerRunner,
 )
 
 
@@ -147,111 +140,102 @@ def test_handoff_preserves_only_the_current_canonical_evidence() -> None:
     assert validated.profile == context.reviewer_profile
 
 
-def test_recording_fakes_conform_to_the_exact_workflow_protocols() -> None:
-    """Prevent future orchestration tests from using collaborators with widened calls."""
+def test_handoff_rejects_latest_developer_checks_outside_required_profile_scope() -> None:
+    """Prevent a fresh check from being reviewed when it is not an explicitly required check."""
     context = _context()
-    developer_result = _developer_result()
+    developer_result = _developer_result(
+        (
+            DeveloperCheckResult(
+                profile_id=CommandProfileId.RUFF,
+                category=CommandCategory.LINT,
+                status=CommandTerminalStatus.SUCCEEDED,
+                exit_code=0,
+                truncated=False,
+            ),
+        )
+    )
     request = _request(context, developer_result)
 
-    assert isinstance(RecordingDeveloperRunner(developer_result), DeveloperRunner)
-    assert isinstance(RecordingReviewerRunner(approved_reviewer_result()), ReviewerRunner)
-    assert isinstance(RecordingReviewerHandoffBuilder(request), ReviewerHandoffBuilder)
+    with pytest.raises(WorkflowError) as raised:
+        validate_reviewer_handoff(context, developer_result, request)
+
+    assert raised.value.code is WorkflowErrorCode.UNSAFE_HANDOFF
 
 
 @pytest.mark.parametrize(
-    ("case", "request_factory", "rejected_value"),
+    "returned_checks",
     [
         (
-            "stale developer report",
-            lambda context, result, request: request.model_copy(
-                update={
-                    "developer_report": completed_developer_report().model_copy(
-                        update={"summary": "developer-report-must-not-leak"}
-                    )
-                }
+            ReviewCheck(
+                profile_id=CommandProfileId.PYTEST,
+                category=CommandCategory.TEST,
+                status=CommandTerminalStatus.FAILED,
+                exit_code=1,
+                truncated=False,
             ),
-            "developer-report-must-not-leak",
+            ReviewCheck(
+                profile_id=CommandProfileId.RUFF,
+                category=CommandCategory.LINT,
+                status=CommandTerminalStatus.SUCCEEDED,
+                exit_code=0,
+                truncated=False,
+            ),
         ),
         (
-            "missing check evidence",
-            lambda context, result, request: request.model_copy(update={"checks": ()}),
-            "missing-check-must-not-leak",
+            ReviewCheck(
+                profile_id=CommandProfileId.PYTEST,
+                category=CommandCategory.TEST,
+                status=CommandTerminalStatus.SUCCEEDED,
+                exit_code=0,
+                truncated=False,
+            ),
+            ReviewCheck(
+                profile_id=CommandProfileId.RUFF,
+                category=CommandCategory.LINT,
+                status=CommandTerminalStatus.SUCCEEDED,
+                exit_code=0,
+                truncated=False,
+            ),
+            ReviewCheck(
+                profile_id=CommandProfileId.MYPY,
+                category=CommandCategory.LINT,
+                status=CommandTerminalStatus.SUCCEEDED,
+                exit_code=0,
+                truncated=False,
+            ),
         ),
         (
-            "extra check evidence",
-            lambda context, result, request: request.model_copy(
-                update={"checks": request.checks + (request.checks[0],)}
+            ReviewCheck(
+                profile_id=CommandProfileId.PYTEST,
+                category=CommandCategory.TEST,
+                status=CommandTerminalStatus.SUCCEEDED,
+                exit_code=0,
+                truncated=False,
             ),
-            "extra-check-must-not-leak",
         ),
         (
-            "reordered check evidence",
-            lambda context, result, request: request.model_copy(
-                update={"checks": tuple(reversed(request.checks))}
+            ReviewCheck(
+                profile_id=CommandProfileId.RUFF,
+                category=CommandCategory.LINT,
+                status=CommandTerminalStatus.SUCCEEDED,
+                exit_code=0,
+                truncated=False,
             ),
-            "reordered-check-must-not-leak",
-        ),
-        (
-            "stale task identifier",
-            lambda context, result, request: request.model_copy(
-                update={"task_id": "stale-task-must-not-leak"}
+            ReviewCheck(
+                profile_id=CommandProfileId.PYTEST,
+                category=CommandCategory.TEST,
+                status=CommandTerminalStatus.SUCCEEDED,
+                exit_code=0,
+                truncated=False,
             ),
-            "stale-task-must-not-leak",
-        ),
-        (
-            "wrong reviewer profile",
-            lambda context, result, request: request.model_copy(
-                update={"profile": reviewer_profile(id="wrong-profile-must-not-leak")}
-            ),
-            "wrong-profile-must-not-leak",
-        ),
-        (
-            "write permission",
-            lambda context, result, request: request.model_copy(
-                update={
-                    "profile": reviewer_profile(
-                        permission_ids=frozenset(
-                            {
-                                Permission.FILESYSTEM_READ.value,
-                                Permission.FILESYSTEM_WRITE.value,
-                            }
-                        )
-                    )
-                }
-            ),
-            "write-permission-must-not-leak",
-        ),
-        (
-            "command tool",
-            lambda context, result, request: request.model_copy(
-                update={"profile": reviewer_profile(tool_ids=frozenset({"run_command_profile"}))}
-            ),
-            "command-tool-must-not-leak",
-        ),
-        (
-            "malformed diff",
-            lambda context, result, request: request.model_copy(
-                update={"diff": _LeakingValue("malformed-diff-must-not-leak")}
-            ),
-            "malformed-diff-must-not-leak",
-        ),
-        (
-            "type-confused reviewer request",
-            lambda context, result, request: request.model_copy(
-                update={"profile": _LeakingValue("type-confused-request-must-not-leak")}
-            ),
-            "type-confused-request-must-not-leak",
         ),
     ],
-    ids=lambda value: value if isinstance(value, str) else None,
+    ids=("changed-status", "extra-profile", "omitted-source", "reordered"),
 )
-def test_handoff_rejects_non_current_or_unsafe_review_evidence(
-    case: str,
-    request_factory: object,
-    rejected_value: str,
+def test_handoff_rejects_canonical_review_checks_that_differ_from_latest_evidence(
+    returned_checks: tuple[ReviewCheck, ...],
 ) -> None:
-    """Prevent stale scope, altered checks, or authority from crossing the handoff."""
-    context = _context()
+    """Prevent the handoff builder from altering, adding, dropping, or reordering check evidence."""
     developer_result = _developer_result(
         (
             DeveloperCheckResult(
@@ -270,34 +254,78 @@ def test_handoff_rejects_non_current_or_unsafe_review_evidence(
             ),
         )
     )
-    context = context.model_copy(
+    context = _context().model_copy(
         update={"required_check_profiles": (CommandProfileId.PYTEST, CommandProfileId.RUFF)}
     )
-    request = _request(context, developer_result)
-    if case == "missing check evidence":
-        request = request.model_copy(update={"checks": (_LeakingValue(rejected_value),)})
-    elif case == "extra check evidence":
-        request = request.model_copy(
-            update={"checks": request.checks + (_LeakingValue(rejected_value),)}
-        )
-    elif case == "reordered check evidence":
-        request = request.model_copy(
-            update={
-                "checks": (
-                    request.checks[1],
-                    _LeakingValue(rejected_value),
-                )
-            }
-        )
-    else:
-        request = request_factory(context, developer_result, request)  # type: ignore[operator]
+    request = _request(context, developer_result).model_copy(update={"checks": returned_checks})
 
     with pytest.raises(WorkflowError) as raised:
         validate_reviewer_handoff(context, developer_result, request)
 
     assert raised.value.code is WorkflowErrorCode.UNSAFE_HANDOFF
-    assert rejected_value not in str(raised.value)
-    assert rejected_value not in repr(raised.value)
+
+
+def test_handoff_requires_the_exact_context_reviewer_profile() -> None:
+    """Prevent a valid read-only reviewer from substituting a different persistent profile value."""
+    context = _context()
+    developer_result = _developer_result()
+    changed_profile = reviewer_profile(system_prompt="A different but valid Reviewer instruction.")
+    request = _request(context, developer_result).model_copy(update={"profile": changed_profile})
+
+    assert validate_reviewer_request(request).request.profile == changed_profile
+    with pytest.raises(WorkflowError) as raised:
+        validate_reviewer_handoff(context, developer_result, request)
+
+    assert raised.value.code is WorkflowErrorCode.UNSAFE_HANDOFF
+
+
+def test_handoff_rejects_a_stale_developer_report_without_leaking_it() -> None:
+    """Prevent a previous-cycle report from crossing the fresh handoff boundary."""
+    marker = "stale-developer-report-must-not-leak"
+    context = _context()
+    developer_result = _developer_result()
+    stale_report = completed_developer_report().model_copy(update={"summary": marker})
+    request = _request(context, developer_result).model_copy(
+        update={"developer_report": stale_report}
+    )
+
+    with pytest.raises(WorkflowError) as raised:
+        validate_reviewer_handoff(context, developer_result, request)
+
+    assert raised.value.code is WorkflowErrorCode.UNSAFE_HANDOFF
+    assert marker not in str(raised.value)
+    assert marker not in repr(raised.value)
+
+
+def test_handoff_rejects_stale_scope_without_leaking_it() -> None:
+    """Prevent stale task scope from being normalized into a current handoff."""
+    marker = "stale-task-must-not-leak"
+    context = _context()
+    developer_result = _developer_result()
+    request = _request(context, developer_result).model_copy(update={"task_id": marker})
+
+    with pytest.raises(WorkflowError) as raised:
+        validate_reviewer_handoff(context, developer_result, request)
+
+    assert raised.value.code is WorkflowErrorCode.UNSAFE_HANDOFF
+    assert marker not in str(raised.value)
+    assert marker not in repr(raised.value)
+
+
+@pytest.mark.parametrize("field", ["diff", "profile"])
+def test_handoff_sanitizes_type_confused_reviewer_evidence(field: str) -> None:
+    """Prevent malformed Reviewer evidence from escaping the safe workflow boundary."""
+    marker = f"type-confused-{field}-must-not-leak"
+    context = _context()
+    developer_result = _developer_result()
+    request = _request(context, developer_result).model_copy(update={field: _LeakingValue(marker)})
+
+    with pytest.raises(WorkflowError) as raised:
+        validate_reviewer_handoff(context, developer_result, request)
+
+    assert raised.value.code is WorkflowErrorCode.UNSAFE_HANDOFF
+    assert marker not in str(raised.value)
+    assert marker not in repr(raised.value)
 
 
 @pytest.mark.parametrize(

--- a/tests/workflows/test_handoff.py
+++ b/tests/workflows/test_handoff.py
@@ -16,6 +16,7 @@ from tests.workflows.factories import (
     completed_developer_report,
     handoff_context_values,
 )
+from tests.workflows.traceback_assertions import assert_workflow_frames_are_scope_free
 
 
 def _developer_result(
@@ -392,6 +393,39 @@ def test_handoff_canonicalizes_model_copy_nested_evidence_before_comparison() ->
     assert validated.profile == context.reviewer_profile
     assert validated.developer_report == canonical_developer_result.report
     assert validated.checks == canonical_request.checks
+
+
+def test_direct_handoff_failure_traceback_does_not_retain_evidence_scope() -> None:
+    """Prevent direct handoff errors from retaining diff, report, or Reviewer profile data."""
+    diff_marker = "direct-handoff-diff-marker-43d8"
+    report_marker = "direct-handoff-report-marker-5ba1"
+    profile_marker = "direct-handoff-profile-marker-e20c"
+    context = _context()
+    context = context.model_copy(
+        update={
+            "reviewer_profile": context.reviewer_profile.model_copy(
+                update={"system_prompt": profile_marker}
+            )
+        }
+    )
+    developer_result = _developer_result().model_copy(
+        update={"report": _developer_result().report.model_copy(update={"summary": report_marker})}
+    )
+    request = _request(context, developer_result).model_copy(
+        update={"task_id": "stale-task", "diff": diff_marker}
+    )
+
+    with pytest.raises(WorkflowError) as raised:
+        validate_reviewer_handoff(context, developer_result, request)
+
+    assert raised.value.code is WorkflowErrorCode.UNSAFE_HANDOFF
+    assert raised.value.__cause__ is None
+    assert raised.value.__context__ is None
+    assert_workflow_frames_are_scope_free(
+        raised.value.__traceback__,
+        filenames=frozenset({"core/workflows/handoff.py"}),
+        markers=(diff_marker, report_marker, profile_marker),
+    )
 
 
 class _LeakingValue:

--- a/tests/workflows/test_handoff.py
+++ b/tests/workflows/test_handoff.py
@@ -1,0 +1,376 @@
+"""Tests for the fresh, evidence-exact Reviewer handoff boundary."""
+
+from __future__ import annotations
+
+import pytest
+
+from core.commands import CommandCategory, CommandProfileId, CommandTerminalStatus
+from core.developer import DeveloperCheckResult, DeveloperResult
+from core.enums import Permission
+from core.reviewer import ReviewCheck, ReviewerRequest
+from core.runtime import RuntimeResult, RuntimeTerminalReason, RuntimeTerminalStatus
+from core.workflows import WorkflowError, WorkflowErrorCode, WorkflowHandoffContext
+from core.workflows.handoff import validate_reviewer_handoff
+from core.workflows.ports import DeveloperRunner, ReviewerHandoffBuilder, ReviewerRunner
+from tests.reviewer.factories import reviewer_profile
+from tests.workflows.factories import (
+    approved_reviewer_result,
+    completed_developer_report,
+    handoff_context_values,
+)
+from tests.workflows.fakes import (
+    RecordingDeveloperRunner,
+    RecordingReviewerHandoffBuilder,
+    RecordingReviewerRunner,
+)
+
+
+def _developer_result(
+    checks: tuple[DeveloperCheckResult, ...] | None = None,
+) -> DeveloperResult:
+    return DeveloperResult(
+        runtime=RuntimeResult(
+            status=RuntimeTerminalStatus.COMPLETED,
+            reason=RuntimeTerminalReason.TASK_COMPLETED,
+            summary="Developer runtime completed the bounded task.",
+            iterations=1,
+            tool_calls=1,
+            failures=0,
+            reported_tokens=10,
+            usage_available=True,
+            duration_ms=1.0,
+            history=(),
+        ),
+        report=completed_developer_report(),
+        checks=checks
+        or (
+            DeveloperCheckResult(
+                profile_id=CommandProfileId.PYTEST,
+                category=CommandCategory.TEST,
+                status=CommandTerminalStatus.SUCCEEDED,
+                exit_code=0,
+                truncated=False,
+            ),
+        ),
+    )
+
+
+def _context() -> WorkflowHandoffContext:
+    return WorkflowHandoffContext.model_validate(handoff_context_values())
+
+
+def _request(
+    context: WorkflowHandoffContext,
+    developer_result: DeveloperResult,
+) -> ReviewerRequest:
+    checks = tuple(
+        ReviewCheck(
+            profile_id=check.profile_id,
+            category=check.category,
+            status=check.status,
+            exit_code=check.exit_code,
+            truncated=check.truncated,
+        )
+        for check in developer_result.checks
+    )
+    return ReviewerRequest(
+        task_id=context.task_id,
+        project_id=context.project_id,
+        developer_id=context.developer_id,
+        reviewer_id=context.reviewer_id,
+        profile=context.reviewer_profile,
+        task_title=context.task_title,
+        task_description=context.task_description,
+        acceptance_criteria=context.acceptance_criteria,
+        diff="--- a/src/add.py\n+++ b/src/add.py\n@@ -1 +1 @@\n-return 0\n+return a + b\n",
+        required_check_profiles=context.required_check_profiles,
+        checks=checks,
+        developer_report=developer_result.report,
+    )
+
+
+def test_handoff_preserves_only_the_current_canonical_evidence() -> None:
+    """Prevent a valid handoff from changing or retaining unapproved evidence."""
+    context = _context()
+    developer_result = _developer_result(
+        (
+            DeveloperCheckResult(
+                profile_id=CommandProfileId.PYTEST,
+                category=CommandCategory.TEST,
+                status=CommandTerminalStatus.SUCCEEDED,
+                exit_code=0,
+                truncated=False,
+            ),
+            DeveloperCheckResult(
+                profile_id=CommandProfileId.RUFF,
+                category=CommandCategory.LINT,
+                status=CommandTerminalStatus.FAILED,
+                exit_code=1,
+                truncated=True,
+            ),
+        )
+    )
+    context = context.model_copy(
+        update={"required_check_profiles": (CommandProfileId.PYTEST, CommandProfileId.RUFF)}
+    )
+    request = _request(context, developer_result)
+
+    validated = validate_reviewer_handoff(context, developer_result, request)
+
+    assert validated is not request
+    assert validated.task_id == context.task_id
+    assert validated.project_id == context.project_id
+    assert validated.developer_id == context.developer_id
+    assert validated.reviewer_id == context.reviewer_id
+    assert validated.task_title == context.task_title
+    assert validated.task_description == context.task_description
+    assert validated.acceptance_criteria == context.acceptance_criteria
+    assert validated.diff == request.diff
+    assert validated.developer_report == developer_result.report
+    assert validated.required_check_profiles == context.required_check_profiles
+    assert validated.checks == (
+        ReviewCheck(
+            profile_id=CommandProfileId.PYTEST,
+            category=CommandCategory.TEST,
+            status=CommandTerminalStatus.SUCCEEDED,
+            exit_code=0,
+            truncated=False,
+        ),
+        ReviewCheck(
+            profile_id=CommandProfileId.RUFF,
+            category=CommandCategory.LINT,
+            status=CommandTerminalStatus.FAILED,
+            exit_code=1,
+            truncated=True,
+        ),
+    )
+    assert validated.profile == context.reviewer_profile
+
+
+def test_recording_fakes_conform_to_the_exact_workflow_protocols() -> None:
+    """Prevent future orchestration tests from using collaborators with widened calls."""
+    context = _context()
+    developer_result = _developer_result()
+    request = _request(context, developer_result)
+
+    assert isinstance(RecordingDeveloperRunner(developer_result), DeveloperRunner)
+    assert isinstance(RecordingReviewerRunner(approved_reviewer_result()), ReviewerRunner)
+    assert isinstance(RecordingReviewerHandoffBuilder(request), ReviewerHandoffBuilder)
+
+
+@pytest.mark.parametrize(
+    ("case", "request_factory", "rejected_value"),
+    [
+        (
+            "stale developer report",
+            lambda context, result, request: request.model_copy(
+                update={
+                    "developer_report": completed_developer_report().model_copy(
+                        update={"summary": "developer-report-must-not-leak"}
+                    )
+                }
+            ),
+            "developer-report-must-not-leak",
+        ),
+        (
+            "missing check evidence",
+            lambda context, result, request: request.model_copy(update={"checks": ()}),
+            "missing-check-must-not-leak",
+        ),
+        (
+            "extra check evidence",
+            lambda context, result, request: request.model_copy(
+                update={"checks": request.checks + (request.checks[0],)}
+            ),
+            "extra-check-must-not-leak",
+        ),
+        (
+            "reordered check evidence",
+            lambda context, result, request: request.model_copy(
+                update={"checks": tuple(reversed(request.checks))}
+            ),
+            "reordered-check-must-not-leak",
+        ),
+        (
+            "stale task identifier",
+            lambda context, result, request: request.model_copy(
+                update={"task_id": "stale-task-must-not-leak"}
+            ),
+            "stale-task-must-not-leak",
+        ),
+        (
+            "wrong reviewer profile",
+            lambda context, result, request: request.model_copy(
+                update={"profile": reviewer_profile(id="wrong-profile-must-not-leak")}
+            ),
+            "wrong-profile-must-not-leak",
+        ),
+        (
+            "write permission",
+            lambda context, result, request: request.model_copy(
+                update={
+                    "profile": reviewer_profile(
+                        permission_ids=frozenset(
+                            {
+                                Permission.FILESYSTEM_READ.value,
+                                Permission.FILESYSTEM_WRITE.value,
+                            }
+                        )
+                    )
+                }
+            ),
+            "write-permission-must-not-leak",
+        ),
+        (
+            "command tool",
+            lambda context, result, request: request.model_copy(
+                update={"profile": reviewer_profile(tool_ids=frozenset({"run_command_profile"}))}
+            ),
+            "command-tool-must-not-leak",
+        ),
+        (
+            "malformed diff",
+            lambda context, result, request: request.model_copy(
+                update={"diff": _LeakingValue("malformed-diff-must-not-leak")}
+            ),
+            "malformed-diff-must-not-leak",
+        ),
+        (
+            "type-confused reviewer request",
+            lambda context, result, request: request.model_copy(
+                update={"profile": _LeakingValue("type-confused-request-must-not-leak")}
+            ),
+            "type-confused-request-must-not-leak",
+        ),
+    ],
+    ids=lambda value: value if isinstance(value, str) else None,
+)
+def test_handoff_rejects_non_current_or_unsafe_review_evidence(
+    case: str,
+    request_factory: object,
+    rejected_value: str,
+) -> None:
+    """Prevent stale scope, altered checks, or authority from crossing the handoff."""
+    context = _context()
+    developer_result = _developer_result(
+        (
+            DeveloperCheckResult(
+                profile_id=CommandProfileId.PYTEST,
+                category=CommandCategory.TEST,
+                status=CommandTerminalStatus.SUCCEEDED,
+                exit_code=0,
+                truncated=False,
+            ),
+            DeveloperCheckResult(
+                profile_id=CommandProfileId.RUFF,
+                category=CommandCategory.LINT,
+                status=CommandTerminalStatus.SUCCEEDED,
+                exit_code=0,
+                truncated=False,
+            ),
+        )
+    )
+    context = context.model_copy(
+        update={"required_check_profiles": (CommandProfileId.PYTEST, CommandProfileId.RUFF)}
+    )
+    request = _request(context, developer_result)
+    if case == "missing check evidence":
+        request = request.model_copy(update={"checks": (_LeakingValue(rejected_value),)})
+    elif case == "extra check evidence":
+        request = request.model_copy(
+            update={"checks": request.checks + (_LeakingValue(rejected_value),)}
+        )
+    elif case == "reordered check evidence":
+        request = request.model_copy(
+            update={
+                "checks": (
+                    request.checks[1],
+                    _LeakingValue(rejected_value),
+                )
+            }
+        )
+    else:
+        request = request_factory(context, developer_result, request)  # type: ignore[operator]
+
+    with pytest.raises(WorkflowError) as raised:
+        validate_reviewer_handoff(context, developer_result, request)
+
+    assert raised.value.code is WorkflowErrorCode.UNSAFE_HANDOFF
+    assert rejected_value not in str(raised.value)
+    assert rejected_value not in repr(raised.value)
+
+
+@pytest.mark.parametrize(
+    "unsafe_profile",
+    [
+        reviewer_profile(
+            permission_ids=frozenset(
+                {
+                    Permission.FILESYSTEM_READ.value,
+                    Permission.FILESYSTEM_WRITE.value,
+                }
+            )
+        ),
+        reviewer_profile(tool_ids=frozenset({"read_file", "run_command_profile"})),
+    ],
+)
+def test_handoff_rejects_an_exact_profile_with_write_or_command_authority(
+    unsafe_profile: object,
+) -> None:
+    """Prevent matching transient profile data from bypassing Reviewer authority validation."""
+    context = _context().model_copy(update={"reviewer_profile": unsafe_profile})
+    developer_result = _developer_result()
+    request = _request(context, developer_result)
+
+    with pytest.raises(WorkflowError) as raised:
+        validate_reviewer_handoff(context, developer_result, request)
+
+    assert raised.value.code is WorkflowErrorCode.UNSAFE_HANDOFF
+
+
+def test_handoff_sanitizes_a_type_confused_latest_developer_result() -> None:
+    """Prevent model-copy corruption of latest evidence from reaching the Reviewer."""
+    marker = "developer-result-must-not-leak"
+    context = _context()
+    developer_result = _developer_result().model_copy(update={"report": _LeakingValue(marker)})
+    request = _request(context, _developer_result())
+
+    with pytest.raises(WorkflowError) as raised:
+        validate_reviewer_handoff(context, developer_result, request)
+
+    assert raised.value.code is WorkflowErrorCode.UNSAFE_HANDOFF
+    assert marker not in str(raised.value)
+    assert marker not in repr(raised.value)
+
+
+def test_handoff_canonicalizes_model_copy_nested_evidence_before_comparison() -> None:
+    """Prevent raw nested mappings from making truthful current evidence appear stale."""
+    context = _context()
+    canonical_developer_result = _developer_result()
+    developer_result = canonical_developer_result.model_copy(
+        update={"report": canonical_developer_result.report.model_dump(mode="python")}
+    )
+    canonical_request = _request(context, canonical_developer_result)
+    request = canonical_request.model_copy(
+        update={
+            "profile": context.reviewer_profile.model_dump(mode="python"),
+            "checks": tuple(check.model_dump(mode="python") for check in canonical_request.checks),
+            "developer_report": canonical_developer_result.report.model_dump(mode="python"),
+        }
+    )
+
+    validated = validate_reviewer_handoff(context, developer_result, request)
+
+    assert validated.profile == context.reviewer_profile
+    assert validated.developer_report == canonical_developer_result.report
+    assert validated.checks == canonical_request.checks
+
+
+class _LeakingValue:
+    """Hostile value whose representation must not cross a safe exception boundary."""
+
+    def __init__(self, marker: str) -> None:
+        self.marker = marker
+
+    def __repr__(self) -> str:
+        return self.marker

--- a/tests/workflows/test_integration.py
+++ b/tests/workflows/test_integration.py
@@ -13,7 +13,7 @@ from sqlalchemy import event, select
 from sqlalchemy.orm import Session
 
 from core.agents import AgentReportOutcome
-from core.commands import CommandCategory
+from core.commands import CommandCategory, CommandTerminalStatus
 from core.developer import DeveloperAgent, DeveloperResult
 from core.enums import TaskStatus
 from core.llm import LLMModelMetadata, LLMResponse, LLMUsage
@@ -104,8 +104,9 @@ def _reviewer_response(decision: ReviewDecision) -> LLMResponse:
 
 @dataclass(slots=True)
 class RecordingCommandExecutor:
-    """Return one bounded successful check and record every concrete tool call."""
+    """Return one scripted bounded check and record every concrete tool call."""
 
+    terminal_statuses: tuple[CommandTerminalStatus, ...]
     calls: list[tuple[str, Mapping[str, object], ToolExecutionContext]] = field(
         default_factory=list
     )
@@ -116,6 +117,7 @@ class RecordingCommandExecutor:
         arguments: Mapping[str, object],
         context: ToolExecutionContext,
     ) -> ToolResult:
+        terminal_status = self.terminal_statuses[len(self.calls)]
         self.calls.append((tool_name, dict(arguments), context))
         assert tool_name == "run_command_profile"
         assert arguments == {"profile_id": "pytest"}
@@ -125,8 +127,8 @@ class RecordingCommandExecutor:
             output={
                 "profile_id": "pytest",
                 "category": CommandCategory.TEST.value,
-                "terminal_status": "SUCCEEDED",
-                "exit_code": 0,
+                "terminal_status": terminal_status.value,
+                "exit_code": 0 if terminal_status is CommandTerminalStatus.SUCCEEDED else 1,
                 "truncated": False,
             },
             duration_ms=1.0,
@@ -137,9 +139,7 @@ class RecordingCommandExecutor:
 
 @dataclass(slots=True)
 class FreshHandoffBuilder(ReviewerHandoffBuilder):
-    """Build a complete Reviewer request with a distinct diff for each cycle."""
-
-    calls: list[tuple[int, DeveloperResult]] = field(default_factory=list)
+    """Build a complete Reviewer request from the latest bounded Developer evidence."""
 
     async def build(
         self,
@@ -147,7 +147,7 @@ class FreshHandoffBuilder(ReviewerHandoffBuilder):
         developer_result: DeveloperResult,
         cycle: int,
     ) -> ReviewerRequest:
-        self.calls.append((cycle, developer_result))
+        del cycle
         checks = tuple(
             ReviewCheck(
                 profile_id=check.profile_id,
@@ -158,6 +158,11 @@ class FreshHandoffBuilder(ReviewerHandoffBuilder):
             )
             for check in developer_result.checks
         )
+        latest_check = developer_result.checks[-1]
+        evidence_marker = (
+            f"developer-evidence-{developer_result.report.outcome.value.lower()}-"
+            f"{latest_check.status.value.lower()}"
+        )
         return ReviewerRequest(
             task_id=context.task_id,
             project_id=context.project_id,
@@ -167,7 +172,13 @@ class FreshHandoffBuilder(ReviewerHandoffBuilder):
             task_title=context.task_title,
             task_description=context.task_description,
             acceptance_criteria=context.acceptance_criteria,
-            diff=f"cycle-{cycle}-fresh-bounded-diff",
+            diff=(
+                "--- a/src/add.py\n"
+                "+++ b/src/add.py\n"
+                "@@ -1 +1 @@\n"
+                "-unverified\n"
+                f"+{evidence_marker}\n"
+            ),
             required_check_profiles=context.required_check_profiles,
             checks=checks,
             developer_report=developer_result.report,
@@ -209,16 +220,17 @@ def _run_workflow(
     tmp_path: Path,
     *,
     max_review_cycles: int,
+    developer_check_statuses: tuple[CommandTerminalStatus, ...],
     reviewer_decisions: tuple[ReviewDecision, ...],
 ) -> tuple[
     DeveloperReviewerWorkflowRequest,
     DeveloperReviewerWorkflowResult,
     RecordingCommandExecutor,
-    FreshHandoffBuilder,
     FakeLLMProvider,
     FakeLLMProvider,
     list[AuditEvent],
 ]:
+    assert len(developer_check_statuses) == max_review_cycles
     task, _, _, request = persisted_workflow_request(session, tmp_path)
     request = _workflow_request(request, max_review_cycles=max_review_cycles)
     developer_provider = FakeLLMProvider(
@@ -231,7 +243,7 @@ def _run_workflow(
     reviewer_provider = FakeLLMProvider(
         responses=[_reviewer_response(decision) for decision in reviewer_decisions]
     )
-    tool_executor = RecordingCommandExecutor()
+    tool_executor = RecordingCommandExecutor(developer_check_statuses)
     handoff_builder = FreshHandoffBuilder()
     ordered_events: list[AuditEvent] = []
 
@@ -260,7 +272,6 @@ def _run_workflow(
         request,
         result,
         tool_executor,
-        handoff_builder,
         developer_provider,
         reviewer_provider,
         ordered_events,
@@ -290,7 +301,7 @@ def _assert_common_audit_safety(events: list[AuditEvent], correlation_id: UUID) 
     assert events
     assert all(event.correlation_id == correlation_id for event in events)
     serialized = json.dumps([event.data for event in events], sort_keys=True)
-    assert "fresh-bounded-diff" not in serialized
+    assert "developer-evidence-" not in serialized
     assert "fresh-report" not in serialized
     assert all("QA" not in event.event_type for event in events)
     assert all("SECURITY" not in event.event_type for event in events)
@@ -303,7 +314,6 @@ def test_concrete_agents_approve_one_cycle_against_alembic_postgres(
         request,
         result,
         tool_executor,
-        handoff_builder,
         developer_provider,
         reviewer_provider,
         events,
@@ -311,6 +321,7 @@ def test_concrete_agents_approve_one_cycle_against_alembic_postgres(
         db_session,
         tmp_path,
         max_review_cycles=1,
+        developer_check_statuses=(CommandTerminalStatus.SUCCEEDED,),
         reviewer_decisions=(ReviewDecision.APPROVED,),
     )
 
@@ -320,7 +331,6 @@ def test_concrete_agents_approve_one_cycle_against_alembic_postgres(
     assert result.developer_report.outcome is AgentReportOutcome.SUCCEEDED
     assert result.reviewer_result.decision is ReviewDecision.APPROVED
     assert len(tool_executor.calls) == 1
-    assert len(handoff_builder.calls) == 1
     _assert_provider_operations(developer_provider, cycles=1)
     assert len(reviewer_provider.requests) == 1
     assert reviewer_provider.requests[0].max_tokens == 512
@@ -354,7 +364,6 @@ def test_concrete_agents_use_fresh_evidence_for_correction_then_approve(
         request,
         result,
         tool_executor,
-        handoff_builder,
         developer_provider,
         reviewer_provider,
         events,
@@ -362,6 +371,10 @@ def test_concrete_agents_use_fresh_evidence_for_correction_then_approve(
         db_session,
         tmp_path,
         max_review_cycles=2,
+        developer_check_statuses=(
+            CommandTerminalStatus.FAILED,
+            CommandTerminalStatus.SUCCEEDED,
+        ),
         reviewer_decisions=(ReviewDecision.CHANGES_REQUESTED, ReviewDecision.APPROVED),
     )
 
@@ -369,21 +382,31 @@ def test_concrete_agents_use_fresh_evidence_for_correction_then_approve(
     assert result.outcome is WorkflowOutcome.APPROVED
     assert result.developer_cycles == result.reviewer_cycles == 2
     assert result.developer_report.outcome is AgentReportOutcome.SUCCEEDED
-    assert "developer-cycle-1-fresh-report" not in repr(result)
-    assert "cycle-1-fresh-bounded-diff" not in repr(result)
+    assert result.developer_report.details == ("All required checks passed.",)
+    assert "developer-evidence-failed-failed" not in repr(result)
     assert len(tool_executor.calls) == 2
-    assert [cycle for cycle, _ in handoff_builder.calls] == [1, 2]
-    assert all(
-        developer_result.report.outcome is AgentReportOutcome.SUCCEEDED
-        for _, developer_result in handoff_builder.calls
-    )
     _assert_provider_operations(developer_provider, cycles=2)
     assert len(reviewer_provider.requests) == 2
-    assert "cycle-1-fresh-bounded-diff" in reviewer_provider.requests[0].messages[0].content
-    assert "cycle-2-fresh-bounded-diff" in reviewer_provider.requests[1].messages[0].content
-    assert [event.event_type for event in events].count(
-        WorkflowEventType.REVIEW_COMPLETED.value
-    ) == 2
+    assert "developer-evidence-failed-failed" in reviewer_provider.requests[0].messages[0].content
+    assert (
+        "developer-evidence-succeeded-succeeded"
+        in reviewer_provider.requests[1].messages[0].content
+    )
+    assert [event.event_type for event in events] == [
+        "TASK_STATUS_CHANGED",
+        WorkflowEventType.WORKFLOW_STARTED.value,
+        "TASK_STATUS_CHANGED",
+        "TASK_STATUS_CHANGED",
+        WorkflowEventType.DEVELOPER_HANDOFF_CREATED.value,
+        "TASK_STATUS_CHANGED",
+        WorkflowEventType.REVIEW_COMPLETED.value,
+        "TASK_STATUS_CHANGED",
+        "TASK_STATUS_CHANGED",
+        WorkflowEventType.DEVELOPER_HANDOFF_CREATED.value,
+        "TASK_STATUS_CHANGED",
+        WorkflowEventType.REVIEW_COMPLETED.value,
+        WorkflowEventType.WORKFLOW_COMPLETED.value,
+    ]
     assert [
         (event.data["from_status"], event.data["to_status"])
         for event in events
@@ -407,7 +430,6 @@ def test_concrete_agents_exhaust_review_cycles_without_phase17_execution(
         request,
         result,
         tool_executor,
-        handoff_builder,
         developer_provider,
         reviewer_provider,
         events,
@@ -415,6 +437,10 @@ def test_concrete_agents_exhaust_review_cycles_without_phase17_execution(
         db_session,
         tmp_path,
         max_review_cycles=2,
+        developer_check_statuses=(
+            CommandTerminalStatus.SUCCEEDED,
+            CommandTerminalStatus.SUCCEEDED,
+        ),
         reviewer_decisions=(ReviewDecision.CHANGES_REQUESTED, ReviewDecision.CHANGES_REQUESTED),
     )
 
@@ -423,14 +449,24 @@ def test_concrete_agents_exhaust_review_cycles_without_phase17_execution(
     assert result.developer_cycles == result.reviewer_cycles == 2
     assert result.reviewer_result.decision is ReviewDecision.CHANGES_REQUESTED
     assert len(tool_executor.calls) == 2
-    assert len(handoff_builder.calls) == 2
     _assert_provider_operations(developer_provider, cycles=2)
     assert len(reviewer_provider.requests) == 2
-    assert [event.event_type for event in events][-2:] == [
+    assert [event.event_type for event in events] == [
+        "TASK_STATUS_CHANGED",
+        WorkflowEventType.WORKFLOW_STARTED.value,
+        "TASK_STATUS_CHANGED",
+        "TASK_STATUS_CHANGED",
+        WorkflowEventType.DEVELOPER_HANDOFF_CREATED.value,
+        "TASK_STATUS_CHANGED",
+        WorkflowEventType.REVIEW_COMPLETED.value,
+        "TASK_STATUS_CHANGED",
+        "TASK_STATUS_CHANGED",
+        WorkflowEventType.DEVELOPER_HANDOFF_CREATED.value,
+        "TASK_STATUS_CHANGED",
+        WorkflowEventType.REVIEW_COMPLETED.value,
         "TASK_STATUS_CHANGED",
         WorkflowEventType.REVIEW_CYCLE_EXHAUSTED.value,
     ]
-    assert all(event.event_type != WorkflowEventType.WORKFLOW_COMPLETED.value for event in events)
     assert [
         (event.data["from_status"], event.data["to_status"])
         for event in events

--- a/tests/workflows/test_integration.py
+++ b/tests/workflows/test_integration.py
@@ -141,12 +141,15 @@ class RecordingCommandExecutor:
 class FreshHandoffBuilder(ReviewerHandoffBuilder):
     """Build a complete Reviewer request from the latest bounded Developer evidence."""
 
+    invocation_count: int = field(default=0, init=False)
+
     async def build(
         self,
         context: WorkflowHandoffContext,
         developer_result: DeveloperResult,
         cycle: int,
     ) -> ReviewerRequest:
+        self.invocation_count += 1
         del cycle
         checks = tuple(
             ReviewCheck(
@@ -226,6 +229,7 @@ def _run_workflow(
     DeveloperReviewerWorkflowRequest,
     DeveloperReviewerWorkflowResult,
     RecordingCommandExecutor,
+    int,
     FakeLLMProvider,
     FakeLLMProvider,
     list[AuditEvent],
@@ -272,6 +276,7 @@ def _run_workflow(
         request,
         result,
         tool_executor,
+        handoff_builder.invocation_count,
         developer_provider,
         reviewer_provider,
         ordered_events,
@@ -314,6 +319,7 @@ def test_concrete_agents_approve_one_cycle_against_alembic_postgres(
         request,
         result,
         tool_executor,
+        handoff_invocations,
         developer_provider,
         reviewer_provider,
         events,
@@ -331,6 +337,7 @@ def test_concrete_agents_approve_one_cycle_against_alembic_postgres(
     assert result.developer_report.outcome is AgentReportOutcome.SUCCEEDED
     assert result.reviewer_result.decision is ReviewDecision.APPROVED
     assert len(tool_executor.calls) == 1
+    assert handoff_invocations == 1
     _assert_provider_operations(developer_provider, cycles=1)
     assert len(reviewer_provider.requests) == 1
     assert reviewer_provider.requests[0].max_tokens == 512
@@ -364,6 +371,7 @@ def test_concrete_agents_use_fresh_evidence_for_correction_then_approve(
         request,
         result,
         tool_executor,
+        handoff_invocations,
         developer_provider,
         reviewer_provider,
         events,
@@ -385,6 +393,7 @@ def test_concrete_agents_use_fresh_evidence_for_correction_then_approve(
     assert result.developer_report.details == ("All required checks passed.",)
     assert "developer-evidence-failed-failed" not in repr(result)
     assert len(tool_executor.calls) == 2
+    assert handoff_invocations == 2
     _assert_provider_operations(developer_provider, cycles=2)
     assert len(reviewer_provider.requests) == 2
     assert "developer-evidence-failed-failed" in reviewer_provider.requests[0].messages[0].content
@@ -430,6 +439,7 @@ def test_concrete_agents_exhaust_review_cycles_without_phase17_execution(
         request,
         result,
         tool_executor,
+        handoff_invocations,
         developer_provider,
         reviewer_provider,
         events,
@@ -449,6 +459,7 @@ def test_concrete_agents_exhaust_review_cycles_without_phase17_execution(
     assert result.developer_cycles == result.reviewer_cycles == 2
     assert result.reviewer_result.decision is ReviewDecision.CHANGES_REQUESTED
     assert len(tool_executor.calls) == 2
+    assert handoff_invocations == 2
     _assert_provider_operations(developer_provider, cycles=2)
     assert len(reviewer_provider.requests) == 2
     assert [event.event_type for event in events] == [

--- a/tests/workflows/test_integration.py
+++ b/tests/workflows/test_integration.py
@@ -1,0 +1,441 @@
+"""Real PostgreSQL end-to-end coverage for the concrete Phase 16 workflow."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from collections.abc import Mapping
+from dataclasses import dataclass, field
+from pathlib import Path
+from uuid import UUID, uuid4
+
+from sqlalchemy import event, select
+from sqlalchemy.orm import Session
+
+from core.agents import AgentReportOutcome
+from core.commands import CommandCategory
+from core.developer import DeveloperAgent, DeveloperResult
+from core.enums import TaskStatus
+from core.llm import LLMModelMetadata, LLMResponse, LLMUsage
+from core.reviewer import (
+    ReviewCheck,
+    ReviewDecision,
+    ReviewerAgent,
+    ReviewerRequest,
+)
+from core.runtime import RuntimeLimits, RuntimeTerminalReason
+from core.skills import SkillRegistry
+from core.tools import ToolExecutionContext, ToolResult, ToolResultStatus
+from core.workflows import (
+    DeveloperReviewerWorkflowRequest,
+    DeveloperReviewerWorkflowResult,
+    ReviewerHandoffBuilder,
+    WorkflowEventType,
+    WorkflowHandoffContext,
+    WorkflowOrchestrator,
+    WorkflowOutcome,
+)
+from infrastructure.database.models import AuditEvent
+from infrastructure.llm import FakeLLMProvider
+from tests.runtime.fakes import RecordingRuntimeAudit
+from tests.workflows.factories import persisted_workflow_request
+
+pytest_plugins = ("tests.database.conftest",)
+
+
+def _response(content: str, *, model: str) -> LLMResponse:
+    return LLMResponse(
+        content=content,
+        finish_reason="stop",
+        usage=LLMUsage(prompt_tokens=1, completion_tokens=1, total_tokens=2),
+        model=LLMModelMetadata(provider="fake", model=model),
+    )
+
+
+def _developer_cycle_script(cycle: int) -> tuple[LLMResponse, ...]:
+    return (
+        _response(
+            '{"summary":"Repository inspected","facts":[],"uncertainties":[]}',
+            model="developer-v1",
+        ),
+        _response(
+            '{"objective":"Complete the task","steps":["Run verification"],'
+            '"success_criteria":["The required check succeeds"]}',
+            model="developer-v1",
+        ),
+        _response(
+            '{"action":"TOOL_CALL","tool_name":"run_command_profile",'
+            '"arguments":{"profile_id":"pytest"},"rationale":"Run the required check",'
+            '"confidence":0.9}',
+            model="developer-v1",
+        ),
+        _response(
+            '{"outcome":"COMPLETE","summary":"Verification completed","progress_made":true}',
+            model="developer-v1",
+        ),
+        _response(
+            json.dumps(
+                {
+                    "summary": f"developer-cycle-{cycle}-fresh-report",
+                    "details": ["The required check succeeded."],
+                    "next_actions": [],
+                },
+                separators=(",", ":"),
+            ),
+            model="developer-v1",
+        ),
+    )
+
+
+def _reviewer_response(decision: ReviewDecision) -> LLMResponse:
+    return _response(
+        json.dumps(
+            {
+                "decision": decision.value,
+                "findings": [],
+                "rationale": "The supplied bounded evidence was reviewed.",
+                "confidence": 0.95,
+            },
+            separators=(",", ":"),
+        ),
+        model="reviewer-v1",
+    )
+
+
+@dataclass(slots=True)
+class RecordingCommandExecutor:
+    """Return one bounded successful check and record every concrete tool call."""
+
+    calls: list[tuple[str, Mapping[str, object], ToolExecutionContext]] = field(
+        default_factory=list
+    )
+
+    async def execute(
+        self,
+        tool_name: str,
+        arguments: Mapping[str, object],
+        context: ToolExecutionContext,
+    ) -> ToolResult:
+        self.calls.append((tool_name, dict(arguments), context))
+        assert tool_name == "run_command_profile"
+        assert arguments == {"profile_id": "pytest"}
+        return ToolResult(
+            tool_name=tool_name,
+            status=ToolResultStatus.SUCCEEDED,
+            output={
+                "profile_id": "pytest",
+                "category": CommandCategory.TEST.value,
+                "terminal_status": "SUCCEEDED",
+                "exit_code": 0,
+                "truncated": False,
+            },
+            duration_ms=1.0,
+            truncated=False,
+            tool_call_id=uuid4(),
+        )
+
+
+@dataclass(slots=True)
+class FreshHandoffBuilder(ReviewerHandoffBuilder):
+    """Build a complete Reviewer request with a distinct diff for each cycle."""
+
+    calls: list[tuple[int, DeveloperResult]] = field(default_factory=list)
+
+    async def build(
+        self,
+        context: WorkflowHandoffContext,
+        developer_result: DeveloperResult,
+        cycle: int,
+    ) -> ReviewerRequest:
+        self.calls.append((cycle, developer_result))
+        checks = tuple(
+            ReviewCheck(
+                profile_id=check.profile_id,
+                category=check.category,
+                status=check.status,
+                exit_code=check.exit_code,
+                truncated=check.truncated,
+            )
+            for check in developer_result.checks
+        )
+        return ReviewerRequest(
+            task_id=context.task_id,
+            project_id=context.project_id,
+            developer_id=context.developer_id,
+            reviewer_id=context.reviewer_id,
+            profile=context.reviewer_profile,
+            task_title=context.task_title,
+            task_description=context.task_description,
+            acceptance_criteria=context.acceptance_criteria,
+            diff=f"cycle-{cycle}-fresh-bounded-diff",
+            required_check_profiles=context.required_check_profiles,
+            checks=checks,
+            developer_report=developer_result.report,
+        )
+
+
+def _developer_agent(
+    provider: FakeLLMProvider,
+    tool_executor: RecordingCommandExecutor,
+) -> DeveloperAgent:
+    return DeveloperAgent(
+        provider,
+        tool_executor,
+        RecordingRuntimeAudit(),
+        SkillRegistry([]),
+        RuntimeLimits(
+            max_iterations=1,
+            timeout_seconds=10.0,
+            max_tool_calls=1,
+            max_failures=1,
+            max_tokens=1_000,
+            max_history_entries=8,
+            stagnation_window=2,
+            max_step_tokens=64,
+        ),
+    )
+
+
+def _workflow_request(
+    request: DeveloperReviewerWorkflowRequest,
+    *,
+    max_review_cycles: int,
+) -> DeveloperReviewerWorkflowRequest:
+    return request.model_copy(update={"max_review_cycles": max_review_cycles})
+
+
+def _run_workflow(
+    session: Session,
+    tmp_path: Path,
+    *,
+    max_review_cycles: int,
+    reviewer_decisions: tuple[ReviewDecision, ...],
+) -> tuple[
+    DeveloperReviewerWorkflowRequest,
+    DeveloperReviewerWorkflowResult,
+    RecordingCommandExecutor,
+    FreshHandoffBuilder,
+    FakeLLMProvider,
+    FakeLLMProvider,
+    list[AuditEvent],
+]:
+    task, _, _, request = persisted_workflow_request(session, tmp_path)
+    request = _workflow_request(request, max_review_cycles=max_review_cycles)
+    developer_provider = FakeLLMProvider(
+        responses=[
+            response
+            for cycle in range(1, max_review_cycles + 1)
+            for response in _developer_cycle_script(cycle)
+        ]
+    )
+    reviewer_provider = FakeLLMProvider(
+        responses=[_reviewer_response(decision) for decision in reviewer_decisions]
+    )
+    tool_executor = RecordingCommandExecutor()
+    handoff_builder = FreshHandoffBuilder()
+    ordered_events: list[AuditEvent] = []
+
+    def capture_flushed_events(current_session: Session, _flush_context: object) -> None:
+        ordered_events.extend(item for item in current_session.new if isinstance(item, AuditEvent))
+
+    event.listen(session, "after_flush", capture_flushed_events)
+    try:
+        result = asyncio.run(
+            WorkflowOrchestrator(
+                session,
+                developer=_developer_agent(developer_provider, tool_executor),
+                reviewer=ReviewerAgent(reviewer_provider, max_tokens=512),
+                handoff_builder=handoff_builder,
+            ).run(request)
+        )
+    finally:
+        event.remove(session, "after_flush", capture_flushed_events)
+    persisted_events = list(
+        session.scalars(select(AuditEvent).where(AuditEvent.task_id == task.id))
+    )
+    assert {item.id for item in ordered_events} == {item.id for item in persisted_events}
+    persisted_by_id = {item.id: item for item in persisted_events}
+    ordered_events = [persisted_by_id[item.id] for item in ordered_events]
+    return (
+        request,
+        result,
+        tool_executor,
+        handoff_builder,
+        developer_provider,
+        reviewer_provider,
+        ordered_events,
+    )
+
+
+def _assert_provider_operations(provider: FakeLLMProvider, cycles: int) -> None:
+    expected = (
+        "Observe the task. Return exactly one JSON object",
+        "Plan one bounded iteration. Return exactly one JSON object",
+        "Choose one action. Return exactly one JSON object",
+        "Verify the tool observation. Return exactly one JSON object",
+        "Report the terminal run. Return exactly one JSON object",
+    ) * cycles
+    assert len(provider.requests) == 5 * cycles
+    assert (
+        tuple(
+            request.messages[0].content.split("\n", 1)[0].split(" with only:", 1)[0]
+            for request in provider.requests
+        )
+        == expected
+    )
+    assert all(request.max_tokens == 64 for request in provider.requests)
+
+
+def _assert_common_audit_safety(events: list[AuditEvent], correlation_id: UUID) -> None:
+    assert events
+    assert all(event.correlation_id == correlation_id for event in events)
+    serialized = json.dumps([event.data for event in events], sort_keys=True)
+    assert "fresh-bounded-diff" not in serialized
+    assert "fresh-report" not in serialized
+    assert all("QA" not in event.event_type for event in events)
+    assert all("SECURITY" not in event.event_type for event in events)
+
+
+def test_concrete_agents_approve_one_cycle_against_alembic_postgres(
+    db_session: Session, tmp_path: Path
+) -> None:
+    (
+        request,
+        result,
+        tool_executor,
+        handoff_builder,
+        developer_provider,
+        reviewer_provider,
+        events,
+    ) = _run_workflow(
+        db_session,
+        tmp_path,
+        max_review_cycles=1,
+        reviewer_decisions=(ReviewDecision.APPROVED,),
+    )
+
+    assert result.task_status is TaskStatus.WAITING_QA
+    assert result.outcome is WorkflowOutcome.APPROVED
+    assert result.developer_cycles == result.reviewer_cycles == 1
+    assert result.developer_report.outcome is AgentReportOutcome.SUCCEEDED
+    assert result.reviewer_result.decision is ReviewDecision.APPROVED
+    assert len(tool_executor.calls) == 1
+    assert len(handoff_builder.calls) == 1
+    _assert_provider_operations(developer_provider, cycles=1)
+    assert len(reviewer_provider.requests) == 1
+    assert reviewer_provider.requests[0].max_tokens == 512
+    assert [event.event_type for event in events] == [
+        "TASK_STATUS_CHANGED",
+        WorkflowEventType.WORKFLOW_STARTED.value,
+        "TASK_STATUS_CHANGED",
+        "TASK_STATUS_CHANGED",
+        WorkflowEventType.DEVELOPER_HANDOFF_CREATED.value,
+        "TASK_STATUS_CHANGED",
+        WorkflowEventType.REVIEW_COMPLETED.value,
+        WorkflowEventType.WORKFLOW_COMPLETED.value,
+    ]
+    assert [
+        (event.data["from_status"], event.data["to_status"])
+        for event in events
+        if event.event_type == "TASK_STATUS_CHANGED"
+    ] == [
+        ("READY", "ASSIGNED"),
+        ("ASSIGNED", "IN_PROGRESS"),
+        ("IN_PROGRESS", "WAITING_REVIEW"),
+        ("WAITING_REVIEW", "WAITING_QA"),
+    ]
+    _assert_common_audit_safety(events, request.correlation_id)
+
+
+def test_concrete_agents_use_fresh_evidence_for_correction_then_approve(
+    db_session: Session, tmp_path: Path
+) -> None:
+    (
+        request,
+        result,
+        tool_executor,
+        handoff_builder,
+        developer_provider,
+        reviewer_provider,
+        events,
+    ) = _run_workflow(
+        db_session,
+        tmp_path,
+        max_review_cycles=2,
+        reviewer_decisions=(ReviewDecision.CHANGES_REQUESTED, ReviewDecision.APPROVED),
+    )
+
+    assert result.task_status is TaskStatus.WAITING_QA
+    assert result.outcome is WorkflowOutcome.APPROVED
+    assert result.developer_cycles == result.reviewer_cycles == 2
+    assert result.developer_report.outcome is AgentReportOutcome.SUCCEEDED
+    assert "developer-cycle-1-fresh-report" not in repr(result)
+    assert "cycle-1-fresh-bounded-diff" not in repr(result)
+    assert len(tool_executor.calls) == 2
+    assert [cycle for cycle, _ in handoff_builder.calls] == [1, 2]
+    assert all(
+        developer_result.report.outcome is AgentReportOutcome.SUCCEEDED
+        for _, developer_result in handoff_builder.calls
+    )
+    _assert_provider_operations(developer_provider, cycles=2)
+    assert len(reviewer_provider.requests) == 2
+    assert "cycle-1-fresh-bounded-diff" in reviewer_provider.requests[0].messages[0].content
+    assert "cycle-2-fresh-bounded-diff" in reviewer_provider.requests[1].messages[0].content
+    assert [event.event_type for event in events].count(
+        WorkflowEventType.REVIEW_COMPLETED.value
+    ) == 2
+    assert [
+        (event.data["from_status"], event.data["to_status"])
+        for event in events
+        if event.event_type == "TASK_STATUS_CHANGED"
+    ] == [
+        ("READY", "ASSIGNED"),
+        ("ASSIGNED", "IN_PROGRESS"),
+        ("IN_PROGRESS", "WAITING_REVIEW"),
+        ("WAITING_REVIEW", "CHANGES_REQUESTED"),
+        ("CHANGES_REQUESTED", "IN_PROGRESS"),
+        ("IN_PROGRESS", "WAITING_REVIEW"),
+        ("WAITING_REVIEW", "WAITING_QA"),
+    ]
+    _assert_common_audit_safety(events, request.correlation_id)
+
+
+def test_concrete_agents_exhaust_review_cycles_without_phase17_execution(
+    db_session: Session, tmp_path: Path
+) -> None:
+    (
+        request,
+        result,
+        tool_executor,
+        handoff_builder,
+        developer_provider,
+        reviewer_provider,
+        events,
+    ) = _run_workflow(
+        db_session,
+        tmp_path,
+        max_review_cycles=2,
+        reviewer_decisions=(ReviewDecision.CHANGES_REQUESTED, ReviewDecision.CHANGES_REQUESTED),
+    )
+
+    assert result.task_status is TaskStatus.WAITING_HUMAN
+    assert result.outcome is WorkflowOutcome.REVIEW_CYCLES_EXHAUSTED
+    assert result.developer_cycles == result.reviewer_cycles == 2
+    assert result.reviewer_result.decision is ReviewDecision.CHANGES_REQUESTED
+    assert len(tool_executor.calls) == 2
+    assert len(handoff_builder.calls) == 2
+    _assert_provider_operations(developer_provider, cycles=2)
+    assert len(reviewer_provider.requests) == 2
+    assert [event.event_type for event in events][-2:] == [
+        "TASK_STATUS_CHANGED",
+        WorkflowEventType.REVIEW_CYCLE_EXHAUSTED.value,
+    ]
+    assert all(event.event_type != WorkflowEventType.WORKFLOW_COMPLETED.value for event in events)
+    assert [
+        (event.data["from_status"], event.data["to_status"])
+        for event in events
+        if event.event_type == "TASK_STATUS_CHANGED"
+    ][-1] == ("CHANGES_REQUESTED", "WAITING_HUMAN")
+    _assert_common_audit_safety(events, request.correlation_id)
+    assert all(event.data.get("to_status") != TaskStatus.WAITING_SECURITY.value for event in events)
+    assert RuntimeTerminalReason.GLOBAL_TIMEOUT.value not in repr(result)

--- a/tests/workflows/test_orchestrator.py
+++ b/tests/workflows/test_orchestrator.py
@@ -1,0 +1,307 @@
+"""Real-PostgreSQL behavioral tests for the bounded Phase 16 orchestrator."""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+import pytest
+from sqlalchemy import event
+from sqlalchemy.orm import Session
+
+from core.commands import CommandCategory, CommandProfileId, CommandTerminalStatus
+from core.developer import DeveloperCheckResult, DeveloperResult
+from core.enums import TaskStatus
+from core.reviewer import ReviewCheck, ReviewDecision, ReviewerRequest
+from core.runtime import RuntimeResult, RuntimeTerminalReason, RuntimeTerminalStatus
+from core.workflows import (
+    DeveloperReviewerWorkflowRequest,
+    WorkflowEventType,
+    WorkflowOrchestrator,
+    WorkflowOutcome,
+)
+from infrastructure.database.models import AuditEvent
+from tests.workflows.factories import (
+    approved_reviewer_result,
+    completed_developer_report,
+    persisted_workflow_request,
+)
+from tests.workflows.fakes import (
+    RecordingDeveloperRunner,
+    RecordingReviewerHandoffBuilder,
+    RecordingReviewerRunner,
+    SequencedRecordingDeveloperRunner,
+    SequencedRecordingReviewerHandoffBuilder,
+    SequencedRecordingReviewerRunner,
+)
+
+pytest_plugins = ("tests.database.conftest",)
+
+
+def _developer_result(
+    report_summary: str = "Implemented the requested correction.",
+) -> DeveloperResult:
+    return DeveloperResult(
+        runtime=RuntimeResult(
+            status=RuntimeTerminalStatus.COMPLETED,
+            reason=RuntimeTerminalReason.TASK_COMPLETED,
+            summary="Developer runtime completed the bounded task.",
+            iterations=1,
+            tool_calls=1,
+            failures=0,
+            reported_tokens=10,
+            usage_available=True,
+            duration_ms=1.0,
+            history=(),
+        ),
+        report=completed_developer_report().model_copy(update={"summary": report_summary}),
+        checks=(
+            DeveloperCheckResult(
+                profile_id=CommandProfileId.PYTEST,
+                category=CommandCategory.TEST,
+                status=CommandTerminalStatus.SUCCEEDED,
+                exit_code=0,
+                truncated=False,
+            ),
+        ),
+    )
+
+
+def _handoff_request(
+    task_id: str,
+    project_id: str,
+    developer_result: DeveloperResult,
+    request: DeveloperReviewerWorkflowRequest,
+    *,
+    diff: str = "--- a/src/add.py\n+++ b/src/add.py\n@@ -1 +1 @@\n-return 0\n+return a + b\n",
+) -> ReviewerRequest:
+    return ReviewerRequest(
+        task_id=task_id,
+        project_id=project_id,
+        developer_id=request.developer_request.profile.id,
+        reviewer_id=request.reviewer_profile.id,
+        profile=request.reviewer_profile,
+        task_title="Correct addition",
+        task_description="Correct the faulty addition implementation.",
+        acceptance_criteria=("The existing test suite passes.",),
+        diff=diff,
+        required_check_profiles=(CommandProfileId.PYTEST,),
+        checks=(
+            ReviewCheck(
+                profile_id=CommandProfileId.PYTEST,
+                category=CommandCategory.TEST,
+                status=CommandTerminalStatus.SUCCEEDED,
+                exit_code=0,
+                truncated=False,
+            ),
+        ),
+        developer_report=developer_result.report,
+    )
+
+
+def test_one_cycle_approval_persists_the_bounded_developer_reviewer_workflow(
+    db_session: Session, tmp_path: Path
+) -> None:
+    """A missing approval checkpoint must leave the task short of WAITING_QA."""
+    task, developer_agent, _, request = persisted_workflow_request(db_session, tmp_path)
+    developer_result = _developer_result()
+    handoff_request = _handoff_request(
+        str(task.id), str(task.project_id), developer_result, request
+    )
+    developer = RecordingDeveloperRunner(developer_result)
+    handoff_builder = RecordingReviewerHandoffBuilder(handoff_request)
+    reviewer = RecordingReviewerRunner(approved_reviewer_result())
+    flushed_events: list[AuditEvent] = []
+
+    def record_checkpoint_events(session: Session, _flush_context: object) -> None:
+        flushed_events.extend(item for item in session.new if isinstance(item, AuditEvent))
+
+    event.listen(db_session, "after_flush", record_checkpoint_events)
+
+    try:
+        result = asyncio.run(
+            WorkflowOrchestrator(
+                db_session,
+                developer=developer,
+                reviewer=reviewer,
+                handoff_builder=handoff_builder,
+            ).run(request)
+        )
+    finally:
+        event.remove(db_session, "after_flush", record_checkpoint_events)
+
+    assert result.task_status is TaskStatus.WAITING_QA
+    assert result.outcome is WorkflowOutcome.APPROVED
+    assert result.developer_cycles == 1
+    assert result.reviewer_cycles == 1
+    assert result.developer_report == developer_result.report
+    assert result.reviewer_result == approved_reviewer_result()
+    assert result.correlation_id == request.correlation_id
+    assert task.assigned_agent_id == developer_agent.id
+    assert task.status is TaskStatus.WAITING_QA
+    assert developer.requests == [request.developer_request]
+    assert len(handoff_builder.calls) == 1
+    handoff_context, handed_off_result, handoff_cycle = handoff_builder.calls[0]
+    assert handoff_context.task_id == str(task.id)
+    assert handoff_context.project_id == str(task.project_id)
+    assert handed_off_result == developer_result
+    assert handoff_cycle == 1
+    assert reviewer.requests == [handoff_request]
+    assert developer.close_calls == 0
+    assert handoff_builder.close_calls == 0
+    assert reviewer.close_calls == 0
+
+    status_edges = [
+        (event.data["from_status"], event.data["to_status"])
+        for event in flushed_events
+        if event.event_type == "TASK_STATUS_CHANGED"
+    ]
+    workflow_events = [
+        event.event_type for event in flushed_events if event.event_type != "TASK_STATUS_CHANGED"
+    ]
+    assert status_edges == [
+        ("READY", "ASSIGNED"),
+        ("ASSIGNED", "IN_PROGRESS"),
+        ("IN_PROGRESS", "WAITING_REVIEW"),
+        ("WAITING_REVIEW", "WAITING_QA"),
+    ]
+    assert workflow_events == [
+        WorkflowEventType.WORKFLOW_STARTED.value,
+        WorkflowEventType.DEVELOPER_HANDOFF_CREATED.value,
+        WorkflowEventType.REVIEW_COMPLETED.value,
+        WorkflowEventType.WORKFLOW_COMPLETED.value,
+    ]
+    assert all("QA" not in event and "SECURITY" not in event for event in workflow_events)
+
+
+def test_correction_runs_a_fresh_second_cycle_before_approval(
+    db_session: Session, tmp_path: Path
+) -> None:
+    """Skipping the correction checkpoint must prevent a second fresh review from approving."""
+    task, _, _, request = persisted_workflow_request(db_session, tmp_path)
+    request = request.model_copy(update={"max_review_cycles": 2})
+    first_developer_result = _developer_result("first developer report marker")
+    final_developer_result = _developer_result("final developer report marker")
+    first_handoff = _handoff_request(
+        str(task.id),
+        str(task.project_id),
+        first_developer_result,
+        request,
+        diff="first-cycle-diff-marker",
+    )
+    final_handoff = _handoff_request(
+        str(task.id),
+        str(task.project_id),
+        final_developer_result,
+        request,
+        diff="final-cycle-diff-marker",
+    )
+    changes_requested = approved_reviewer_result().model_copy(
+        update={
+            "decision": ReviewDecision.CHANGES_REQUESTED,
+            "rationale": "A correction is required.",
+        }
+    )
+    developer = SequencedRecordingDeveloperRunner((first_developer_result, final_developer_result))
+    handoff_builder = SequencedRecordingReviewerHandoffBuilder((first_handoff, final_handoff))
+    reviewer = SequencedRecordingReviewerRunner((changes_requested, approved_reviewer_result()))
+    flushed_events: list[AuditEvent] = []
+
+    def record_checkpoint_events(session: Session, _flush_context: object) -> None:
+        flushed_events.extend(item for item in session.new if isinstance(item, AuditEvent))
+
+    event.listen(db_session, "after_flush", record_checkpoint_events)
+    try:
+        result = asyncio.run(
+            WorkflowOrchestrator(
+                db_session,
+                developer=developer,
+                reviewer=reviewer,
+                handoff_builder=handoff_builder,
+            ).run(request)
+        )
+    finally:
+        event.remove(db_session, "after_flush", record_checkpoint_events)
+
+    assert task.status is TaskStatus.WAITING_QA
+    assert result.outcome is WorkflowOutcome.APPROVED
+    assert result.developer_cycles == 2
+    assert result.reviewer_cycles == 2
+    assert result.developer_report == final_developer_result.report
+    assert result.reviewer_result == approved_reviewer_result()
+    assert "first developer report marker" not in repr(result)
+    assert "first-cycle-diff-marker" not in repr(result)
+    assert developer.requests == [request.developer_request, request.developer_request]
+    assert reviewer.requests == [first_handoff, final_handoff]
+    assert [call[2] for call in handoff_builder.calls] == [1, 2]
+    assert [call[1] for call in handoff_builder.calls] == [
+        first_developer_result,
+        final_developer_result,
+    ]
+    assert [review_request.diff for review_request in reviewer.requests] == [
+        "first-cycle-diff-marker",
+        "final-cycle-diff-marker",
+    ]
+    assert [
+        (event.data["from_status"], event.data["to_status"])
+        for event in flushed_events
+        if event.event_type == "TASK_STATUS_CHANGED"
+    ] == [
+        ("READY", "ASSIGNED"),
+        ("ASSIGNED", "IN_PROGRESS"),
+        ("IN_PROGRESS", "WAITING_REVIEW"),
+        ("WAITING_REVIEW", "CHANGES_REQUESTED"),
+        ("CHANGES_REQUESTED", "IN_PROGRESS"),
+        ("IN_PROGRESS", "WAITING_REVIEW"),
+        ("WAITING_REVIEW", "WAITING_QA"),
+    ]
+
+
+@pytest.mark.parametrize("max_review_cycles", [1, 3])
+def test_exhausted_review_cycles_escalate_without_an_extra_collaborator_call(
+    db_session: Session, tmp_path: Path, max_review_cycles: int
+) -> None:
+    """An exhausted requested-change cycle must stop before another agent invocation."""
+    task, _, _, request = persisted_workflow_request(db_session, tmp_path)
+    request = request.model_copy(update={"max_review_cycles": max_review_cycles})
+    developer_results = tuple(
+        _developer_result(f"developer cycle {cycle} report")
+        for cycle in range(1, max_review_cycles + 1)
+    )
+    handoffs = tuple(
+        _handoff_request(
+            str(task.id),
+            str(task.project_id),
+            developer_results[cycle - 1],
+            request,
+            diff=f"exhaustion-cycle-{cycle}-diff-marker",
+        )
+        for cycle in range(1, max_review_cycles + 1)
+    )
+    changes_requested = approved_reviewer_result().model_copy(
+        update={
+            "decision": ReviewDecision.CHANGES_REQUESTED,
+            "rationale": "A correction is required.",
+        }
+    )
+    developer = SequencedRecordingDeveloperRunner(developer_results)
+    handoff_builder = SequencedRecordingReviewerHandoffBuilder(handoffs)
+    reviewer = SequencedRecordingReviewerRunner((changes_requested,) * max_review_cycles)
+
+    result = asyncio.run(
+        WorkflowOrchestrator(
+            db_session,
+            developer=developer,
+            reviewer=reviewer,
+            handoff_builder=handoff_builder,
+        ).run(request)
+    )
+
+    assert task.status is TaskStatus.WAITING_HUMAN
+    assert result.task_status is TaskStatus.WAITING_HUMAN
+    assert result.outcome is WorkflowOutcome.REVIEW_CYCLES_EXHAUSTED
+    assert result.developer_cycles == max_review_cycles
+    assert result.reviewer_cycles == max_review_cycles
+    assert len(developer.requests) == max_review_cycles
+    assert len(handoff_builder.calls) == max_review_cycles
+    assert len(reviewer.requests) == max_review_cycles

--- a/tests/workflows/test_safety.py
+++ b/tests/workflows/test_safety.py
@@ -1,0 +1,185 @@
+"""Real-PostgreSQL safety tests for the Phase 16 workflow boundary."""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from core.enums import TaskStatus
+from core.workflows import WorkflowError, WorkflowErrorCode, WorkflowOrchestrator
+from infrastructure.database.models import AuditEvent, Task
+from tests.workflows.factories import approved_reviewer_result, persisted_workflow_request
+from tests.workflows.fakes import (
+    BlockingDeveloperRunner,
+    BlockingReviewerHandoffBuilder,
+    BlockingReviewerRunner,
+    FailingDeveloperRunner,
+    FailingReviewerHandoffBuilder,
+    FailingReviewerRunner,
+    RecordingDeveloperRunner,
+    RecordingReviewerHandoffBuilder,
+    RecordingReviewerRunner,
+)
+from tests.workflows.test_orchestrator import _developer_result, _handoff_request
+
+pytest_plugins = ("tests.database.conftest",)
+
+
+def _assert_workflow_error_excludes_markers(error: WorkflowError, *markers: str) -> None:
+    """Inspect public workflow frames without retaining raw collaborator failures."""
+    assert error.__cause__ is None
+    assert error.__context__ is None
+    assert all(marker not in repr(error) for marker in markers)
+    traceback = error.__traceback__
+    while traceback is not None:
+        frame = traceback.tb_frame
+        if frame.f_code.co_filename.endswith("core/workflows/orchestrator.py"):
+            for value in frame.f_locals.values():
+                assert all(marker not in repr(value) for marker in markers)
+        traceback = traceback.tb_next
+
+
+def _status_edges(session: Session) -> set[tuple[str, str]]:
+    return {
+        (str(event.data["from_status"]), str(event.data["to_status"]))
+        for event in session.scalars(select(AuditEvent))
+        if event.event_type == "TASK_STATUS_CHANGED"
+    }
+
+
+@pytest.mark.parametrize("failure_site", ["developer", "handoff", "reviewer"])
+def test_collaborator_failures_escalate_once_without_retaining_raw_failure_data(
+    db_session: Session, tmp_path: Path, failure_site: str
+) -> None:
+    """A collaborator exception must fail closed rather than escape or trigger another call."""
+    task, _, _, request = persisted_workflow_request(db_session, tmp_path)
+    developer_result = _developer_result()
+    handoff = _handoff_request(str(task.id), str(task.project_id), developer_result, request)
+    marker = f"workflow-secret-marker-{failure_site}-{tmp_path}"
+    error = RuntimeError(marker)
+    developer: RecordingDeveloperRunner | FailingDeveloperRunner = RecordingDeveloperRunner(
+        developer_result
+    )
+    handoff_builder: RecordingReviewerHandoffBuilder | FailingReviewerHandoffBuilder = (
+        RecordingReviewerHandoffBuilder(handoff)
+    )
+    reviewer: RecordingReviewerRunner | FailingReviewerRunner = RecordingReviewerRunner(
+        approved_reviewer_result()
+    )
+    if failure_site == "developer":
+        developer = FailingDeveloperRunner(error)
+    elif failure_site == "handoff":
+        handoff_builder = FailingReviewerHandoffBuilder(error)
+    else:
+        reviewer = FailingReviewerRunner(error)
+    orchestrator = WorkflowOrchestrator(
+        db_session,
+        developer=developer,
+        reviewer=reviewer,
+        handoff_builder=handoff_builder,
+    )
+
+    with pytest.raises(WorkflowError) as raised:
+        asyncio.run(orchestrator.run(request))
+
+    assert raised.value.code is WorkflowErrorCode.COLLABORATOR_FAILURE
+    assert task.status is TaskStatus.WAITING_HUMAN
+    assert all(target != "WAITING_QA" for _, target in _status_edges(db_session))
+    expected_calls = {
+        "developer": (1, 0, 0),
+        "handoff": (1, 1, 0),
+        "reviewer": (1, 1, 1),
+    }[failure_site]
+    assert len(developer.requests) == expected_calls[0]
+    assert len(handoff_builder.calls) == expected_calls[1]
+    assert len(reviewer.requests) == expected_calls[2]
+    assert db_session.get(Task, task.id) is task
+    assert not hasattr(orchestrator, "__dict__")
+    _assert_workflow_error_excludes_markers(raised.value, marker, str(tmp_path))
+
+
+def test_timeout_escalates_without_retrying_the_developer(
+    db_session: Session, tmp_path: Path
+) -> None:
+    """An overall timeout must leave one durable human escalation and no retry."""
+    task, _, _, request = persisted_workflow_request(db_session, tmp_path)
+    request = request.model_copy(update={"timeout_seconds": 0.01})
+    developer = BlockingDeveloperRunner(_developer_result())
+    handoff = _handoff_request(str(task.id), str(task.project_id), _developer_result(), request)
+    handoff_builder = RecordingReviewerHandoffBuilder(handoff)
+    reviewer = RecordingReviewerRunner(approved_reviewer_result())
+
+    with pytest.raises(WorkflowError) as raised:
+        asyncio.run(
+            WorkflowOrchestrator(db_session, developer, reviewer, handoff_builder).run(request)
+        )
+
+    assert raised.value.code is WorkflowErrorCode.TIMEOUT
+    assert task.status is TaskStatus.WAITING_HUMAN
+    assert len(developer.requests) == 1
+    assert handoff_builder.calls == []
+    assert reviewer.requests == []
+
+
+@pytest.mark.parametrize("cancel_site", ["developer", "handoff", "reviewer"])
+def test_cancellation_propagates_without_any_subsequent_checkpoint_or_call(
+    db_session: Session, tmp_path: Path, cancel_site: str
+) -> None:
+    """Cancellation must preserve the last completed checkpoint without normalizing it."""
+    task, _, _, request = persisted_workflow_request(db_session, tmp_path)
+    developer_result = _developer_result()
+    handoff = _handoff_request(str(task.id), str(task.project_id), developer_result, request)
+    developer: RecordingDeveloperRunner | BlockingDeveloperRunner = RecordingDeveloperRunner(
+        developer_result
+    )
+    handoff_builder: RecordingReviewerHandoffBuilder | BlockingReviewerHandoffBuilder = (
+        RecordingReviewerHandoffBuilder(handoff)
+    )
+    reviewer: RecordingReviewerRunner | BlockingReviewerRunner = RecordingReviewerRunner(
+        approved_reviewer_result()
+    )
+    if cancel_site == "developer":
+        developer = BlockingDeveloperRunner(developer_result)
+        started = developer.started
+        expected_status = TaskStatus.IN_PROGRESS
+    elif cancel_site == "handoff":
+        handoff_builder = BlockingReviewerHandoffBuilder(handoff)
+        started = handoff_builder.started
+        expected_status = TaskStatus.WAITING_REVIEW
+    else:
+        reviewer = BlockingReviewerRunner(approved_reviewer_result())
+        started = reviewer.started
+        expected_status = TaskStatus.WAITING_REVIEW
+    orchestrator = WorkflowOrchestrator(
+        db_session,
+        developer=developer,
+        reviewer=reviewer,
+        handoff_builder=handoff_builder,
+    )
+
+    async def cancel_running_workflow() -> None:
+        operation = asyncio.create_task(orchestrator.run(request))
+        await started.wait()
+        operation.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await operation
+
+    asyncio.run(cancel_running_workflow())
+
+    assert task.status is expected_status
+    assert task.status is not TaskStatus.WAITING_HUMAN
+    assert all(
+        target not in {"WAITING_QA", "WAITING_HUMAN"} for _, target in _status_edges(db_session)
+    )
+    expected_calls = {
+        "developer": (1, 0, 0),
+        "handoff": (1, 1, 0),
+        "reviewer": (1, 1, 1),
+    }[cancel_site]
+    assert len(developer.requests) == expected_calls[0]
+    assert len(handoff_builder.calls) == expected_calls[1]
+    assert len(reviewer.requests) == expected_calls[2]

--- a/tests/workflows/test_safety.py
+++ b/tests/workflows/test_safety.py
@@ -3,9 +3,12 @@
 from __future__ import annotations
 
 import asyncio
+from collections.abc import Iterator
+from contextlib import contextmanager
 from pathlib import Path
 
 import pytest
+from sqlalchemy import event as sqlalchemy_event
 from sqlalchemy import select
 from sqlalchemy.orm import Session
 
@@ -49,6 +52,109 @@ def _status_edges(session: Session) -> set[tuple[str, str]]:
         for event in session.scalars(select(AuditEvent))
         if event.event_type == "TASK_STATUS_CHANGED"
     }
+
+
+@contextmanager
+def _capture_audit_stream(session: Session) -> Iterator[list[AuditEvent]]:
+    stream: list[AuditEvent] = []
+
+    def record_flushed_events(flushed_session: Session, _flush_context: object) -> None:
+        stream.extend(item for item in flushed_session.new if isinstance(item, AuditEvent))
+
+    sqlalchemy_event.listen(session, "after_flush", record_flushed_events)
+    try:
+        yield stream
+    finally:
+        sqlalchemy_event.remove(session, "after_flush", record_flushed_events)
+
+
+def _audit_stream_labels(stream: list[AuditEvent]) -> list[str]:
+    labels: list[str] = []
+    for audit_event in stream:
+        if audit_event.event_type == "TASK_STATUS_CHANGED":
+            labels.append(f"TASK_STATUS_CHANGED:{audit_event.data['to_status']}")
+        elif audit_event.event_type == "DEVELOPER_HANDOFF_CREATED":
+            labels.append(f"DEVELOPER_HANDOFF_CREATED:{audit_event.data['cycle']}")
+        else:
+            labels.append(audit_event.event_type)
+    return labels
+
+
+class _SensitiveValue:
+    """Malformed collaborator output carrying data that must not escape."""
+
+    def __init__(self, marker: str) -> None:
+        self.marker = marker
+
+    def __repr__(self) -> str:
+        return self.marker
+
+
+def test_malformed_reviewer_result_is_rejected_before_approval_checkpoint(
+    db_session: Session, tmp_path: Path
+) -> None:
+    """Removing Reviewer canonicalization must permit a false WAITING_QA checkpoint."""
+    task, _, _, request = persisted_workflow_request(db_session, tmp_path)
+    developer_result = _developer_result()
+    handoff = _handoff_request(str(task.id), str(task.project_id), developer_result, request)
+    marker = f"malformed-reviewer-result-marker-{tmp_path}"
+    malformed_result = approved_reviewer_result().model_copy(
+        update={"rationale": _SensitiveValue(marker)}
+    )
+    developer = RecordingDeveloperRunner(developer_result)
+    handoff_builder = RecordingReviewerHandoffBuilder(handoff)
+    reviewer = RecordingReviewerRunner(malformed_result)
+
+    with pytest.raises(WorkflowError) as raised:
+        asyncio.run(
+            WorkflowOrchestrator(db_session, developer, reviewer, handoff_builder).run(request)
+        )
+
+    assert raised.value.code is WorkflowErrorCode.COLLABORATOR_FAILURE
+    assert task.status is TaskStatus.WAITING_HUMAN
+    assert all(target != "WAITING_QA" for _, target in _status_edges(db_session))
+    assert len(developer.requests) == 1
+    assert len(handoff_builder.calls) == 1
+    assert len(reviewer.requests) == 1
+    _assert_workflow_error_excludes_markers(raised.value, marker, str(tmp_path))
+
+
+def test_unexpected_orchestration_exception_is_not_labeled_as_collaborator_failure(
+    db_session: Session, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A broad outer catch must not misclassify an internal checkpoint defect."""
+    task, _, _, request = persisted_workflow_request(db_session, tmp_path)
+    developer_result = _developer_result()
+    handoff = _handoff_request(str(task.id), str(task.project_id), developer_result, request)
+    developer = RecordingDeveloperRunner(developer_result)
+    handoff_builder = RecordingReviewerHandoffBuilder(handoff)
+    reviewer = RecordingReviewerRunner(approved_reviewer_result())
+    marker = f"internal-orchestration-marker-{tmp_path}"
+
+    def fail_internal_checkpoint(*_args: object, **_kwargs: object) -> None:
+        raise RuntimeError(marker)
+
+    monkeypatch.setattr(
+        "core.workflows.orchestrator.commit_developer_completed_checkpoint",
+        fail_internal_checkpoint,
+    )
+
+    with pytest.raises(WorkflowError) as raised:
+        asyncio.run(
+            WorkflowOrchestrator(db_session, developer, reviewer, handoff_builder).run(request)
+        )
+
+    assert raised.value.code is WorkflowErrorCode.INTERNAL_FAILURE
+    assert task.status is TaskStatus.WAITING_HUMAN
+    assert _status_edges(db_session) == {
+        ("READY", "ASSIGNED"),
+        ("ASSIGNED", "IN_PROGRESS"),
+        ("IN_PROGRESS", "WAITING_HUMAN"),
+    }
+    assert len(developer.requests) == 1
+    assert handoff_builder.calls == []
+    assert reviewer.requests == []
+    _assert_workflow_error_excludes_markers(raised.value, marker, str(tmp_path))
 
 
 @pytest.mark.parametrize("failure_site", ["developer", "handoff", "reviewer"])
@@ -127,7 +233,10 @@ def test_timeout_escalates_without_retrying_the_developer(
 
 @pytest.mark.parametrize("cancel_site", ["developer", "handoff", "reviewer"])
 def test_cancellation_propagates_without_any_subsequent_checkpoint_or_call(
-    db_session: Session, tmp_path: Path, cancel_site: str
+    db_session: Session,
+    tmp_path: Path,
+    cancel_site: str,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Cancellation must preserve the last completed checkpoint without normalizing it."""
     task, _, _, request = persisted_workflow_request(db_session, tmp_path)
@@ -160,6 +269,13 @@ def test_cancellation_propagates_without_any_subsequent_checkpoint_or_call(
         reviewer=reviewer,
         handoff_builder=handoff_builder,
     )
+    session_close_calls = 0
+
+    def record_session_close() -> None:
+        nonlocal session_close_calls
+        session_close_calls += 1
+
+    monkeypatch.setattr(db_session, "close", record_session_close)
 
     async def cancel_running_workflow() -> None:
         operation = asyncio.create_task(orchestrator.run(request))
@@ -168,13 +284,33 @@ def test_cancellation_propagates_without_any_subsequent_checkpoint_or_call(
         with pytest.raises(asyncio.CancelledError):
             await operation
 
-    asyncio.run(cancel_running_workflow())
+    with _capture_audit_stream(db_session) as audit_stream:
+        asyncio.run(cancel_running_workflow())
 
     assert task.status is expected_status
     assert task.status is not TaskStatus.WAITING_HUMAN
-    assert all(
-        target not in {"WAITING_QA", "WAITING_HUMAN"} for _, target in _status_edges(db_session)
-    )
+    expected_audit_stream = {
+        "developer": [
+            "TASK_STATUS_CHANGED:ASSIGNED",
+            "WORKFLOW_STARTED",
+            "TASK_STATUS_CHANGED:IN_PROGRESS",
+        ],
+        "handoff": [
+            "TASK_STATUS_CHANGED:ASSIGNED",
+            "WORKFLOW_STARTED",
+            "TASK_STATUS_CHANGED:IN_PROGRESS",
+            "TASK_STATUS_CHANGED:WAITING_REVIEW",
+        ],
+        "reviewer": [
+            "TASK_STATUS_CHANGED:ASSIGNED",
+            "WORKFLOW_STARTED",
+            "TASK_STATUS_CHANGED:IN_PROGRESS",
+            "TASK_STATUS_CHANGED:WAITING_REVIEW",
+            "DEVELOPER_HANDOFF_CREATED:1",
+        ],
+    }[cancel_site]
+    assert _audit_stream_labels(audit_stream) == expected_audit_stream
+    assert len(audit_stream) == len(expected_audit_stream)
     expected_calls = {
         "developer": (1, 0, 0),
         "handoff": (1, 1, 0),
@@ -183,3 +319,8 @@ def test_cancellation_propagates_without_any_subsequent_checkpoint_or_call(
     assert len(developer.requests) == expected_calls[0]
     assert len(handoff_builder.calls) == expected_calls[1]
     assert len(reviewer.requests) == expected_calls[2]
+    assert developer.close_calls == 0
+    assert handoff_builder.close_calls == 0
+    assert reviewer.close_calls == 0
+    assert session_close_calls == 0
+    assert db_session.get(Task, task.id) is task

--- a/tests/workflows/test_safety.py
+++ b/tests/workflows/test_safety.py
@@ -6,15 +6,27 @@ import asyncio
 from collections.abc import Iterator
 from contextlib import contextmanager
 from pathlib import Path
+from threading import Event as ThreadEvent
+from threading import Thread, Timer
+from time import monotonic
+from uuid import uuid4
 
 import pytest
+from sqlalchemy import Engine, select, text
 from sqlalchemy import event as sqlalchemy_event
-from sqlalchemy import select
-from sqlalchemy.orm import Session
+from sqlalchemy.orm import Session, sessionmaker
 
-from core.enums import TaskStatus
-from core.workflows import WorkflowError, WorkflowErrorCode, WorkflowOrchestrator
-from infrastructure.database.models import AuditEvent, Task
+from core.developer import DeveloperRequest, DeveloperResult
+from core.enums import AuditActorType, Permission, TaskStatus
+from core.reviewer import ReviewerRequest, ReviewerResult
+from core.tasks.state_machine import TaskStateMachine
+from core.workflows import (
+    DeveloperReviewerWorkflowRequest,
+    WorkflowError,
+    WorkflowErrorCode,
+    WorkflowOrchestrator,
+)
+from infrastructure.database.models import Agent, AuditEvent, Task
 from tests.workflows.factories import approved_reviewer_result, persisted_workflow_request
 from tests.workflows.fakes import (
     BlockingDeveloperRunner,
@@ -28,6 +40,7 @@ from tests.workflows.fakes import (
     RecordingReviewerRunner,
 )
 from tests.workflows.test_orchestrator import _developer_result, _handoff_request
+from tests.workflows.traceback_assertions import assert_workflow_frames_are_scope_free
 
 pytest_plugins = ("tests.database.conftest",)
 
@@ -90,6 +103,35 @@ class _SensitiveValue:
         return self.marker
 
 
+def _commit_unique_workflow_scope(
+    session: Session, tmp_path: Path
+) -> tuple[Task, Agent, Agent, DeveloperReviewerWorkflowRequest]:
+    task, developer_agent, reviewer_agent, request = persisted_workflow_request(session, tmp_path)
+    developer_slug = f"developer-{uuid4().hex[:12]}"
+    reviewer_slug = f"reviewer-{uuid4().hex[:12]}"
+    developer_agent.slug = developer_slug
+    reviewer_agent.slug = reviewer_slug
+    request = request.model_copy(
+        update={
+            "developer_request": request.developer_request.model_copy(
+                update={
+                    "profile": request.developer_request.profile.model_copy(
+                        update={"id": developer_slug}
+                    ),
+                    "execution_context": (
+                        request.developer_request.execution_context.model_copy(
+                            update={"agent_id": developer_slug}
+                        )
+                    ),
+                }
+            ),
+            "reviewer_profile": request.reviewer_profile.model_copy(update={"id": reviewer_slug}),
+        }
+    )
+    session.commit()
+    return task, developer_agent, reviewer_agent, request
+
+
 def test_malformed_reviewer_result_is_rejected_before_approval_checkpoint(
     db_session: Session, tmp_path: Path
 ) -> None:
@@ -117,6 +159,157 @@ def test_malformed_reviewer_result_is_rejected_before_approval_checkpoint(
     assert len(handoff_builder.calls) == 1
     assert len(reviewer.requests) == 1
     _assert_workflow_error_excludes_markers(raised.value, marker, str(tmp_path))
+
+
+def test_malformed_developer_result_is_rejected_before_waiting_review_or_handoff(
+    db_session: Session, tmp_path: Path
+) -> None:
+    """Prevent type-confused Developer evidence from becoming a review checkpoint."""
+    task, _, _, request = persisted_workflow_request(db_session, tmp_path)
+    canonical_result = _developer_result()
+    marker = f"malformed-developer-result-marker-{tmp_path}"
+    malformed_result = canonical_result.model_copy(update={"report": _SensitiveValue(marker)})
+    handoff = _handoff_request(str(task.id), str(task.project_id), canonical_result, request)
+    developer = RecordingDeveloperRunner(malformed_result)
+    handoff_builder = RecordingReviewerHandoffBuilder(handoff)
+    reviewer = RecordingReviewerRunner(approved_reviewer_result())
+
+    with pytest.raises(WorkflowError) as raised:
+        asyncio.run(
+            WorkflowOrchestrator(
+                db_session,
+                developer,
+                reviewer,
+                handoff_builder,
+            ).run(request)
+        )
+
+    assert raised.value.code is WorkflowErrorCode.COLLABORATOR_FAILURE
+    assert task.status is TaskStatus.WAITING_HUMAN
+    assert ("IN_PROGRESS", "WAITING_REVIEW") not in _status_edges(db_session)
+    assert len(developer.requests) == 1
+    assert handoff_builder.calls == []
+    assert reviewer.requests == []
+    _assert_workflow_error_excludes_markers(raised.value, marker, str(tmp_path))
+
+
+def test_orchestrator_preflight_failure_traceback_does_not_retain_workflow_scope(
+    db_session: Session, tmp_path: Path
+) -> None:
+    """Prevent the async public wrapper from retaining a rejected preflight request or session."""
+    task_marker = "orchestrator-preflight-task-marker-a4c1"
+    profile_marker = "orchestrator-preflight-profile-marker-f93b"
+    workspace_marker = "orchestrator-preflight-workspace-marker-2d65"
+    workspace_root = tmp_path / workspace_marker
+    workspace_root.mkdir()
+    task, _, _, request = persisted_workflow_request(db_session, tmp_path)
+    task.title = task_marker
+    task.description = task_marker
+    db_session.commit()
+    unsafe_request = request.model_copy(
+        update={
+            "developer_request": request.developer_request.model_copy(
+                update={
+                    "task": request.developer_request.task.model_copy(
+                        update={"objective": task_marker}
+                    ),
+                    "execution_context": (
+                        request.developer_request.execution_context.model_copy(
+                            update={"workspace_root": workspace_root}
+                        )
+                    ),
+                }
+            ),
+            "reviewer_profile": request.reviewer_profile.model_copy(
+                update={
+                    "id": "other-reviewer",
+                    "system_prompt": profile_marker,
+                }
+            ),
+        }
+    )
+    developer = RecordingDeveloperRunner(_developer_result())
+    reviewer = RecordingReviewerRunner(approved_reviewer_result())
+    handoff_builder = RecordingReviewerHandoffBuilder(
+        _handoff_request(str(task.id), str(task.project_id), _developer_result(), request)
+    )
+
+    with pytest.raises(WorkflowError) as raised:
+        asyncio.run(
+            WorkflowOrchestrator(
+                db_session,
+                developer,
+                reviewer,
+                handoff_builder,
+            ).run(unsafe_request)
+        )
+
+    assert raised.value.code is WorkflowErrorCode.INVALID_SCOPE
+    assert developer.requests == []
+    assert handoff_builder.calls == []
+    assert reviewer.requests == []
+    assert_workflow_frames_are_scope_free(
+        raised.value.__traceback__,
+        filenames=frozenset(
+            {
+                "core/workflows/orchestrator.py",
+                "core/workflows/validation.py",
+            }
+        ),
+        markers=(task_marker, profile_marker, workspace_marker),
+    )
+
+
+@pytest.mark.parametrize(
+    "reviewer_profile_overrides",
+    [
+        {
+            "permission_ids": frozenset(
+                {Permission.FILESYSTEM_READ.value, Permission.FILESYSTEM_WRITE.value}
+            )
+        },
+        {"tool_ids": frozenset({"read_file", "run_command_profile"})},
+    ],
+    ids=("write-permission", "command-tool"),
+)
+def test_reviewer_authority_is_rejected_before_workflow_side_effects(
+    db_session: Session,
+    tmp_path: Path,
+    reviewer_profile_overrides: dict[str, object],
+) -> None:
+    """Prevent an unsafe Reviewer profile from reaching assignment or Developer work."""
+    task, _, _, request = persisted_workflow_request(db_session, tmp_path)
+    unsafe_request = request.model_copy(
+        update={
+            "reviewer_profile": request.reviewer_profile.model_copy(
+                update=reviewer_profile_overrides
+            )
+        }
+    )
+    developer_result = _developer_result()
+    developer = RecordingDeveloperRunner(developer_result)
+    handoff_builder = RecordingReviewerHandoffBuilder(
+        _handoff_request(str(task.id), str(task.project_id), developer_result, request)
+    )
+    reviewer = RecordingReviewerRunner(approved_reviewer_result())
+
+    with pytest.raises(WorkflowError) as raised:
+        asyncio.run(
+            WorkflowOrchestrator(
+                db_session,
+                developer,
+                reviewer,
+                handoff_builder,
+            ).run(unsafe_request)
+        )
+
+    assert raised.value.code is WorkflowErrorCode.INVALID_AGENT
+    assert task.status is TaskStatus.READY
+    assert task.assigned_agent_id is None
+    assert list(db_session.scalars(select(AuditEvent).where(AuditEvent.task_id == task.id))) == []
+    assert developer.requests == []
+    assert handoff_builder.calls == []
+    assert reviewer.requests == []
 
 
 def test_unexpected_orchestration_exception_is_not_labeled_as_collaborator_failure(
@@ -229,6 +422,281 @@ def test_timeout_escalates_without_retrying_the_developer(
     assert len(developer.requests) == 1
     assert handoff_builder.calls == []
     assert reviewer.requests == []
+
+
+def test_global_deadline_times_out_blocked_preflight_sql_before_assignment(
+    database_engine: Engine,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Prevent synchronous preflight SQL from running outside the workflow deadline."""
+    factory = sessionmaker(bind=database_engine, expire_on_commit=False)
+    seed_session = factory()
+    workflow_session = factory()
+    verification_session = factory()
+    try:
+        task, _, _, request_object = _commit_unique_workflow_scope(seed_session, tmp_path)
+        request = request_object.model_copy(update={"timeout_seconds": 0.03})
+        task_id = task.id
+        from core.workflows import validation as workflow_validation
+
+        original_load_scope = workflow_validation._load_scope
+
+        def load_scope_after_blocked_sql(
+            session: Session, current_request: DeveloperReviewerWorkflowRequest
+        ) -> tuple[Task, Agent, Agent]:
+            session.execute(text("SELECT pg_sleep(0.2)"))
+            return original_load_scope(session, current_request)
+
+        monkeypatch.setattr(workflow_validation, "_load_scope", load_scope_after_blocked_sql)
+        developer_result = _developer_result()
+        developer = RecordingDeveloperRunner(developer_result)
+        handoff_builder = RecordingReviewerHandoffBuilder(
+            _handoff_request(str(task.id), str(task.project_id), developer_result, request)
+        )
+        reviewer = RecordingReviewerRunner(approved_reviewer_result())
+        started_at = monotonic()
+
+        with pytest.raises(WorkflowError) as raised:
+            asyncio.run(
+                WorkflowOrchestrator(
+                    workflow_session,
+                    developer,
+                    reviewer,
+                    handoff_builder,
+                ).run(request)
+            )
+
+        assert raised.value.code is WorkflowErrorCode.TIMEOUT
+        assert monotonic() - started_at < 0.15
+        stored = verification_session.get(Task, task_id)
+        assert stored is not None
+        assert stored.status is TaskStatus.READY
+        assert stored.assigned_agent_id is None
+        assert (
+            list(
+                verification_session.scalars(
+                    select(AuditEvent).where(AuditEvent.task_id == task_id)
+                )
+            )
+            == []
+        )
+        assert developer.requests == []
+        assert handoff_builder.calls == []
+        assert reviewer.requests == []
+    finally:
+        verification_session.close()
+        workflow_session.close()
+        seed_session.close()
+
+
+def test_global_deadline_times_out_a_blocked_checkpoint_row_lock_without_retry(
+    database_engine: Engine, tmp_path: Path
+) -> None:
+    """Prevent synchronous checkpoint locks from escaping the remaining workflow budget."""
+    factory = sessionmaker(bind=database_engine, expire_on_commit=False)
+    seed_session = factory()
+    workflow_session = factory()
+    verification_session = factory()
+    lock_started = ThreadEvent()
+    release_lock = ThreadEvent()
+    lock_thread: Thread | None = None
+    release_timer: Timer | None = None
+    try:
+        task, _, _, request_object = _commit_unique_workflow_scope(seed_session, tmp_path)
+        request = request_object.model_copy(update={"timeout_seconds": 0.03})
+        task_id = task.id
+        developer_result = _developer_result()
+
+        def hold_task_lock() -> None:
+            with factory() as lock_session:
+                locked_task = lock_session.scalar(
+                    select(Task).where(Task.id == task_id).with_for_update()
+                )
+                assert locked_task is not None
+                lock_started.set()
+                release_lock.wait(timeout=2.0)
+                lock_session.rollback()
+
+        class LockingDeveloper(RecordingDeveloperRunner):
+            async def run(self, developer_request: DeveloperRequest) -> DeveloperResult:
+                nonlocal lock_thread, release_timer
+                result = await super().run(developer_request)
+                lock_thread = Thread(target=hold_task_lock, daemon=True)
+                lock_thread.start()
+                assert lock_started.wait(timeout=1.0)
+                release_timer = Timer(0.2, release_lock.set)
+                release_timer.start()
+                return result
+
+        developer = LockingDeveloper(developer_result)
+        handoff_builder = RecordingReviewerHandoffBuilder(
+            _handoff_request(str(task.id), str(task.project_id), developer_result, request)
+        )
+        reviewer = RecordingReviewerRunner(approved_reviewer_result())
+
+        with pytest.raises(WorkflowError) as raised:
+            asyncio.run(
+                WorkflowOrchestrator(
+                    workflow_session,
+                    developer,
+                    reviewer,
+                    handoff_builder,
+                ).run(request)
+            )
+
+        assert raised.value.code is WorkflowErrorCode.TIMEOUT
+        assert release_lock.is_set() is False
+        stored = verification_session.get(Task, task_id)
+        assert stored is not None
+        assert stored.status is TaskStatus.IN_PROGRESS
+        assert len(developer.requests) == 1
+        assert handoff_builder.calls == []
+        assert reviewer.requests == []
+    finally:
+        release_lock.set()
+        if release_timer is not None:
+            release_timer.cancel()
+        if lock_thread is not None:
+            lock_thread.join(timeout=1.0)
+        verification_session.close()
+        workflow_session.close()
+        seed_session.close()
+
+
+@pytest.mark.parametrize(
+    ("transition_site", "concurrent_status"),
+    [
+        ("developer", TaskStatus.WAITING_HUMAN),
+        ("reviewer", TaskStatus.CANCELLED),
+    ],
+)
+def test_concurrent_human_transition_wins_over_a_stale_agent_checkpoint(
+    database_engine: Engine,
+    tmp_path: Path,
+    transition_site: str,
+    concurrent_status: TaskStatus,
+) -> None:
+    """Prevent stale workflow state from overwriting a decision made during an agent call."""
+    factory = sessionmaker(bind=database_engine, expire_on_commit=False)
+    seed_session = factory()
+    workflow_session = factory()
+    human_session = factory()
+    verification_session = factory()
+    try:
+        task, developer_agent, reviewer_agent, request = persisted_workflow_request(
+            seed_session, tmp_path
+        )
+        developer_slug = f"developer-{uuid4().hex[:12]}"
+        reviewer_slug = f"reviewer-{uuid4().hex[:12]}"
+        developer_agent.slug = developer_slug
+        reviewer_agent.slug = reviewer_slug
+        request = request.model_copy(
+            update={
+                "developer_request": request.developer_request.model_copy(
+                    update={
+                        "profile": request.developer_request.profile.model_copy(
+                            update={"id": developer_slug}
+                        ),
+                        "execution_context": (
+                            request.developer_request.execution_context.model_copy(
+                                update={"agent_id": developer_slug}
+                            )
+                        ),
+                    }
+                ),
+                "reviewer_profile": request.reviewer_profile.model_copy(
+                    update={"id": reviewer_slug}
+                ),
+            }
+        )
+        task_id = task.id
+        seed_session.commit()
+        developer_result = _developer_result()
+        handoff = _handoff_request(str(task.id), str(task.project_id), developer_result, request)
+
+        def apply_human_transition() -> None:
+            concurrent_task = human_session.get(Task, task_id, populate_existing=True)
+            assert concurrent_task is not None
+            TaskStateMachine(human_session).transition(
+                concurrent_task,
+                concurrent_status,
+                actor_type=AuditActorType.HUMAN,
+                actor_id="human-operator",
+                reason="Human decision superseded workflow automation.",
+                correlation_id=request.correlation_id,
+            )
+            human_session.commit()
+
+        class TransitioningDeveloper(RecordingDeveloperRunner):
+            async def run(self, developer_request: DeveloperRequest) -> DeveloperResult:
+                result = await super().run(developer_request)
+                apply_human_transition()
+                return result
+
+        class TransitioningReviewer(RecordingReviewerRunner):
+            async def run(self, reviewer_request: ReviewerRequest) -> ReviewerResult:
+                result = await super().run(reviewer_request)
+                apply_human_transition()
+                return result
+
+        developer = (
+            TransitioningDeveloper(developer_result)
+            if transition_site == "developer"
+            else RecordingDeveloperRunner(developer_result)
+        )
+        reviewer = (
+            TransitioningReviewer(approved_reviewer_result())
+            if transition_site == "reviewer"
+            else RecordingReviewerRunner(approved_reviewer_result())
+        )
+        handoff_builder = RecordingReviewerHandoffBuilder(handoff)
+
+        with pytest.raises(WorkflowError) as raised:
+            asyncio.run(
+                WorkflowOrchestrator(
+                    workflow_session,
+                    developer,
+                    reviewer,
+                    handoff_builder,
+                ).run(request)
+            )
+
+        assert raised.value.code is WorkflowErrorCode.INVALID_STATE
+        stored = verification_session.get(Task, task_id)
+        assert stored is not None
+        assert stored.status is concurrent_status
+        events = list(
+            verification_session.scalars(
+                select(AuditEvent)
+                .where(AuditEvent.task_id == task_id)
+                .order_by(AuditEvent.created_at, AuditEvent.id)
+            )
+        )
+        human_event = next(
+            event
+            for event in events
+            if event.event_type == "TASK_STATUS_CHANGED"
+            and event.data["to_status"] == concurrent_status.value
+        )
+        assert human_event.actor_type is AuditActorType.HUMAN
+        assert all(
+            event.created_at <= human_event.created_at or event.event_type != "TASK_STATUS_CHANGED"
+            for event in events
+        )
+        assert all(
+            event.event_type not in {"REVIEW_COMPLETED", "WORKFLOW_COMPLETED"}
+            for event in events
+            if event.created_at > human_event.created_at
+        )
+        assert len(developer.requests) == 1
+        assert len(handoff_builder.calls) == (1 if transition_site == "reviewer" else 0)
+        assert len(reviewer.requests) == (1 if transition_site == "reviewer" else 0)
+    finally:
+        verification_session.close()
+        human_session.close()
+        workflow_session.close()
+        seed_session.close()
 
 
 @pytest.mark.parametrize("cancel_site", ["developer", "handoff", "reviewer"])

--- a/tests/workflows/test_types.py
+++ b/tests/workflows/test_types.py
@@ -1,0 +1,204 @@
+"""Behavioral tests for immutable Phase 16 workflow contracts."""
+
+from __future__ import annotations
+
+import math
+from pathlib import Path
+from uuid import UUID, uuid4
+
+import pytest
+from pydantic import ValidationError
+
+from core.enums import TaskStatus
+from core.reviewer import ReviewDecision
+from core.workflows import (
+    DeveloperReviewerWorkflowRequest,
+    DeveloperReviewerWorkflowResult,
+    WorkflowError,
+    WorkflowErrorCode,
+    WorkflowHandoffContext,
+    WorkflowOutcome,
+)
+from tests.workflows.factories import (
+    approved_reviewer_result,
+    completed_developer_report,
+    handoff_context_values,
+    workflow_request_values,
+)
+
+
+def test_request_retains_persistent_scope_as_a_frozen_bounded_value(tmp_path: Path) -> None:
+    """Prevent a caller from mutating accepted workflow scope or collections."""
+    values = workflow_request_values(tmp_path)
+
+    request = DeveloperReviewerWorkflowRequest.model_validate(values)
+
+    assert isinstance(request.task_id, UUID)
+    assert request.max_review_cycles == 2
+    assert request.timeout_seconds == 30.0
+    with pytest.raises(ValidationError):
+        request.max_review_cycles = 3  # type: ignore[misc]
+    with pytest.raises(ValidationError):
+        DeveloperReviewerWorkflowRequest.model_validate({**values, "unknown": "value"})
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("max_review_cycles", 0),
+        ("max_review_cycles", 11),
+        ("timeout_seconds", 0.0),
+        ("timeout_seconds", 3600.1),
+        ("timeout_seconds", math.inf),
+    ],
+)
+def test_request_rejects_cycle_and_timeout_values_outside_workflow_bounds(
+    tmp_path: Path, field: str, value: object
+) -> None:
+    """Prevent unbounded or non-finite workflow execution limits."""
+    values = workflow_request_values(tmp_path)
+    values[field] = value
+
+    with pytest.raises(ValidationError):
+        DeveloperReviewerWorkflowRequest.model_validate(values)
+
+
+def test_request_public_validation_rejects_a_type_confused_model_copy(tmp_path: Path) -> None:
+    """Prevent model_copy() from bypassing the public workflow input boundary."""
+    request = DeveloperReviewerWorkflowRequest.model_validate(workflow_request_values(tmp_path))
+    forged = request.model_copy(update={"task_id": "not-a-uuid"})
+
+    with pytest.raises(ValidationError):
+        DeveloperReviewerWorkflowRequest.model_validate(forged)
+
+
+def test_handoff_context_copies_collections_and_requires_canonical_uuid_text() -> None:
+    """Prevent later handoff construction from retaining mutable or ambiguous scope data."""
+    values = handoff_context_values()
+    criteria = values["acceptance_criteria"]
+    profiles = values["required_check_profiles"]
+    assert isinstance(criteria, list)
+    assert isinstance(profiles, list)
+
+    context = WorkflowHandoffContext.model_validate(values)
+    criteria.append("A regression test is added.")
+    profiles.append(profiles[0])
+
+    assert context.acceptance_criteria == ("The existing test suite passes.",)
+    assert len(context.required_check_profiles) == 1
+    with pytest.raises(ValidationError):
+        WorkflowHandoffContext.model_validate({**values, "task_id": str(uuid4()).upper()})
+
+
+@pytest.mark.parametrize(
+    ("task_status", "outcome"),
+    [
+        (TaskStatus.WAITING_QA, WorkflowOutcome.REVIEW_CYCLES_EXHAUSTED),
+        (TaskStatus.WAITING_HUMAN, WorkflowOutcome.APPROVED),
+        (TaskStatus.COMPLETED, WorkflowOutcome.APPROVED),
+    ],
+)
+def test_result_rejects_untruthful_terminal_status_and_outcome_pairs(
+    task_status: TaskStatus, outcome: WorkflowOutcome
+) -> None:
+    """Prevent the workflow from reporting an outcome inconsistent with its terminal task state."""
+    with pytest.raises(ValidationError):
+        DeveloperReviewerWorkflowResult(
+            task_status=task_status,
+            outcome=outcome,
+            developer_cycles=1,
+            reviewer_cycles=1,
+            developer_report=completed_developer_report(),
+            reviewer_result=approved_reviewer_result(),
+            correlation_id=uuid4(),
+        )
+
+
+@pytest.mark.parametrize(("developer_cycles", "reviewer_cycles"), [(0, 0), (1, 2), (2, 1)])
+def test_result_requires_equal_nonzero_completed_agent_cycles(
+    developer_cycles: int, reviewer_cycles: int
+) -> None:
+    """Prevent a result from concealing a skipped or unmatched agent invocation."""
+    with pytest.raises(ValidationError):
+        DeveloperReviewerWorkflowResult(
+            task_status=TaskStatus.WAITING_QA,
+            outcome=WorkflowOutcome.APPROVED,
+            developer_cycles=developer_cycles,
+            reviewer_cycles=reviewer_cycles,
+            developer_report=completed_developer_report(),
+            reviewer_result=approved_reviewer_result(),
+            correlation_id=uuid4(),
+        )
+
+
+@pytest.mark.parametrize(
+    ("task_status", "outcome", "reviewer_result"),
+    [
+        (TaskStatus.WAITING_QA, WorkflowOutcome.APPROVED, "changes_requested"),
+        (TaskStatus.WAITING_HUMAN, WorkflowOutcome.REVIEW_CYCLES_EXHAUSTED, "approved"),
+    ],
+)
+def test_result_requires_its_final_reviewer_decision_to_match_its_outcome(
+    task_status: TaskStatus, outcome: WorkflowOutcome, reviewer_result: str
+) -> None:
+    """Prevent terminal workflow metadata from contradicting the final Reviewer decision."""
+    final_reviewer_result = approved_reviewer_result().model_copy(
+        update={
+            "decision": (
+                ReviewDecision.CHANGES_REQUESTED
+                if reviewer_result == "changes_requested"
+                else ReviewDecision.APPROVED
+            )
+        }
+    )
+
+    with pytest.raises(ValidationError):
+        DeveloperReviewerWorkflowResult(
+            task_status=task_status,
+            outcome=outcome,
+            developer_cycles=1,
+            reviewer_cycles=1,
+            developer_report=completed_developer_report(),
+            reviewer_result=final_reviewer_result,
+            correlation_id=uuid4(),
+        )
+
+
+def test_result_retains_only_final_reports_and_scalar_metadata() -> None:
+    """Prevent the workflow result from retaining runtime history or all cycle evidence."""
+    result = DeveloperReviewerWorkflowResult(
+        task_status=TaskStatus.WAITING_QA,
+        outcome=WorkflowOutcome.APPROVED,
+        developer_cycles=1,
+        reviewer_cycles=1,
+        developer_report=completed_developer_report(),
+        reviewer_result=approved_reviewer_result(),
+        correlation_id=uuid4(),
+    )
+
+    assert set(result.model_dump()) == {
+        "task_status",
+        "outcome",
+        "developer_cycles",
+        "reviewer_cycles",
+        "developer_report",
+        "reviewer_result",
+        "correlation_id",
+    }
+    assert result.reviewer_result.decision is ReviewDecision.APPROVED
+
+
+def test_error_exposes_only_an_application_owned_safe_message() -> None:
+    """Prevent sensitive collaborator or persistence text from crossing the workflow boundary."""
+    sensitive_text = "postgres://workflow:super-secret@db.internal/tasks"
+
+    error = WorkflowError(WorkflowErrorCode.PERSISTENCE_FAILURE)
+
+    assert error.code is WorkflowErrorCode.PERSISTENCE_FAILURE
+    assert error.safe_message == "Workflow persistence failed."
+    assert str(error) == "Workflow persistence failed."
+    assert sensitive_text not in str(error)
+    with pytest.raises(TypeError):
+        WorkflowError(WorkflowErrorCode.PERSISTENCE_FAILURE, sensitive_text)  # type: ignore[call-arg]
+    with pytest.raises(TypeError):
+        WorkflowError("PERSISTENCE_FAILURE")  # type: ignore[arg-type]

--- a/tests/workflows/test_types.py
+++ b/tests/workflows/test_types.py
@@ -9,6 +9,7 @@ from uuid import UUID, uuid4
 import pytest
 from pydantic import ValidationError
 
+from core.agents import AgentProfile, AgentReportOutcome
 from core.enums import TaskStatus
 from core.reviewer import ReviewDecision
 from core.workflows import (
@@ -72,6 +73,40 @@ def test_request_public_validation_rejects_a_type_confused_model_copy(tmp_path: 
         DeveloperReviewerWorkflowRequest.model_validate(forged)
 
 
+def test_request_rejects_equal_persistent_developer_and_reviewer_agent_ids(tmp_path: Path) -> None:
+    """Prevent a single persistent agent from being assigned to author and review one task."""
+    values = workflow_request_values(tmp_path)
+    values["reviewer_agent_id"] = values["developer_agent_id"]
+
+    with pytest.raises(ValidationError):
+        DeveloperReviewerWorkflowRequest.model_validate(values)
+
+
+def test_request_revalidates_forged_nested_developer_request_and_reviewer_profile(
+    tmp_path: Path,
+) -> None:
+    """Prevent model_copy() corruption from surviving the public workflow request boundary."""
+    request = DeveloperReviewerWorkflowRequest.model_validate(workflow_request_values(tmp_path))
+    forged_developer_request = request.developer_request.model_copy(
+        update={"required_check_profiles": ("unbounded-profile",)}
+    )
+    forged_reviewer_profile = request.reviewer_profile.model_copy(update={"autonomy_level": 6})
+
+    with pytest.raises(ValidationError) as error:
+        DeveloperReviewerWorkflowRequest.model_validate(
+            request.model_copy(
+                update={
+                    "developer_request": forged_developer_request,
+                    "reviewer_profile": forged_reviewer_profile,
+                }
+            )
+        )
+    assert {issue["loc"][0] for issue in error.value.errors()} == {
+        "developer_request",
+        "reviewer_profile",
+    }
+
+
 def test_handoff_context_copies_collections_and_requires_canonical_uuid_text() -> None:
     """Prevent later handoff construction from retaining mutable or ambiguous scope data."""
     values = handoff_context_values()
@@ -106,6 +141,7 @@ def test_result_rejects_untruthful_terminal_status_and_outcome_pairs(
         DeveloperReviewerWorkflowResult(
             task_status=task_status,
             outcome=outcome,
+            max_review_cycles=1,
             developer_cycles=1,
             reviewer_cycles=1,
             developer_report=completed_developer_report(),
@@ -123,6 +159,7 @@ def test_result_requires_equal_nonzero_completed_agent_cycles(
         DeveloperReviewerWorkflowResult(
             task_status=TaskStatus.WAITING_QA,
             outcome=WorkflowOutcome.APPROVED,
+            max_review_cycles=2,
             developer_cycles=developer_cycles,
             reviewer_cycles=reviewer_cycles,
             developer_report=completed_developer_report(),
@@ -156,10 +193,95 @@ def test_result_requires_its_final_reviewer_decision_to_match_its_outcome(
         DeveloperReviewerWorkflowResult(
             task_status=task_status,
             outcome=outcome,
+            max_review_cycles=1,
             developer_cycles=1,
             reviewer_cycles=1,
             developer_report=completed_developer_report(),
             reviewer_result=final_reviewer_result,
+            correlation_id=uuid4(),
+        )
+
+
+def test_result_revalidates_forged_nested_report_and_reviewer_values() -> None:
+    """Prevent raw nested values from surviving public terminal-result construction."""
+    result = DeveloperReviewerWorkflowResult(
+        task_status=TaskStatus.WAITING_QA,
+        outcome=WorkflowOutcome.APPROVED,
+        max_review_cycles=1,
+        developer_cycles=1,
+        reviewer_cycles=1,
+        developer_report=completed_developer_report(),
+        reviewer_result=approved_reviewer_result(),
+        correlation_id=uuid4(),
+    )
+    forged_report = result.developer_report.model_copy(update={"outcome": "SUCCEEDED"})
+    forged_reviewer_result = result.reviewer_result.model_copy(
+        update={"decision": "APPROVED", "confidence": "0.95"}
+    )
+
+    revalidated = DeveloperReviewerWorkflowResult.model_validate(
+        result.model_copy(
+            update={
+                "developer_report": forged_report,
+                "reviewer_result": forged_reviewer_result,
+            }
+        )
+    )
+
+    assert revalidated.developer_report.outcome is AgentReportOutcome.SUCCEEDED
+    assert revalidated.reviewer_result.decision is ReviewDecision.APPROVED
+    assert type(revalidated.reviewer_result.confidence) is float
+    assert revalidated.reviewer_result.confidence == 0.95
+
+
+@pytest.mark.parametrize("max_review_cycles", [0, 11])
+def test_result_rejects_review_cycle_limits_outside_workflow_bounds(max_review_cycles: int) -> None:
+    """Prevent terminal results from retaining an unbounded configured review limit."""
+    with pytest.raises(ValidationError):
+        DeveloperReviewerWorkflowResult(
+            task_status=TaskStatus.WAITING_QA,
+            outcome=WorkflowOutcome.APPROVED,
+            max_review_cycles=max_review_cycles,
+            developer_cycles=1,
+            reviewer_cycles=1,
+            developer_report=completed_developer_report(),
+            reviewer_result=approved_reviewer_result(),
+            correlation_id=uuid4(),
+        )
+
+
+@pytest.mark.parametrize(
+    ("task_status", "outcome", "max_review_cycles", "cycles", "reviewer_decision"),
+    [
+        (TaskStatus.WAITING_QA, WorkflowOutcome.APPROVED, 1, 2, ReviewDecision.APPROVED),
+        (
+            TaskStatus.WAITING_HUMAN,
+            WorkflowOutcome.REVIEW_CYCLES_EXHAUSTED,
+            2,
+            1,
+            ReviewDecision.CHANGES_REQUESTED,
+        ),
+    ],
+)
+def test_result_requires_cycles_to_truthfully_match_the_configured_limit(
+    task_status: TaskStatus,
+    outcome: WorkflowOutcome,
+    max_review_cycles: int,
+    cycles: int,
+    reviewer_decision: ReviewDecision,
+) -> None:
+    """Prevent approval overruns and premature cycle-exhausted terminal results."""
+    with pytest.raises(ValidationError):
+        DeveloperReviewerWorkflowResult(
+            task_status=task_status,
+            outcome=outcome,
+            max_review_cycles=max_review_cycles,
+            developer_cycles=cycles,
+            reviewer_cycles=cycles,
+            developer_report=completed_developer_report(),
+            reviewer_result=approved_reviewer_result().model_copy(
+                update={"decision": reviewer_decision}
+            ),
             correlation_id=uuid4(),
         )
 
@@ -169,6 +291,7 @@ def test_result_retains_only_final_reports_and_scalar_metadata() -> None:
     result = DeveloperReviewerWorkflowResult(
         task_status=TaskStatus.WAITING_QA,
         outcome=WorkflowOutcome.APPROVED,
+        max_review_cycles=1,
         developer_cycles=1,
         reviewer_cycles=1,
         developer_report=completed_developer_report(),
@@ -179,6 +302,7 @@ def test_result_retains_only_final_reports_and_scalar_metadata() -> None:
     assert set(result.model_dump()) == {
         "task_status",
         "outcome",
+        "max_review_cycles",
         "developer_cycles",
         "reviewer_cycles",
         "developer_report",
@@ -188,17 +312,43 @@ def test_result_retains_only_final_reports_and_scalar_metadata() -> None:
     assert result.reviewer_result.decision is ReviewDecision.APPROVED
 
 
+def test_terminal_result_never_retains_handoff_reviewer_profile_or_system_prompt() -> None:
+    """Prevent transient handoff profile data from becoming terminal workflow history."""
+    profile_marker = "transient reviewer instruction must not enter terminal history"
+    context_values = handoff_context_values()
+    reviewer_profile = context_values["reviewer_profile"]
+    assert isinstance(reviewer_profile, AgentProfile)
+    context_values["reviewer_profile"] = reviewer_profile.model_copy(
+        update={"system_prompt": profile_marker}
+    )
+    context = WorkflowHandoffContext.model_validate(context_values)
+    result = DeveloperReviewerWorkflowResult(
+        task_status=TaskStatus.WAITING_QA,
+        outcome=WorkflowOutcome.APPROVED,
+        max_review_cycles=1,
+        developer_cycles=1,
+        reviewer_cycles=1,
+        developer_report=completed_developer_report(),
+        reviewer_result=approved_reviewer_result(),
+        correlation_id=uuid4(),
+    )
+
+    assert context.reviewer_profile.system_prompt == profile_marker
+    assert "reviewer_profile" not in result.model_dump()
+    assert profile_marker not in result.model_dump_json()
+
+
 def test_error_exposes_only_an_application_owned_safe_message() -> None:
     """Prevent sensitive collaborator or persistence text from crossing the workflow boundary."""
-    sensitive_text = "postgres://workflow:super-secret@db.internal/tasks"
-
     error = WorkflowError(WorkflowErrorCode.PERSISTENCE_FAILURE)
 
     assert error.code is WorkflowErrorCode.PERSISTENCE_FAILURE
     assert error.safe_message == "Workflow persistence failed."
     assert str(error) == "Workflow persistence failed."
-    assert sensitive_text not in str(error)
     with pytest.raises(TypeError):
-        WorkflowError(WorkflowErrorCode.PERSISTENCE_FAILURE, sensitive_text)  # type: ignore[call-arg]
+        WorkflowError(  # type: ignore[call-arg]
+            WorkflowErrorCode.PERSISTENCE_FAILURE,
+            "caller-controlled text is not an accepted workflow error input",
+        )
     with pytest.raises(TypeError):
         WorkflowError("PERSISTENCE_FAILURE")  # type: ignore[arg-type]

--- a/tests/workflows/test_validation.py
+++ b/tests/workflows/test_validation.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from uuid import uuid4
 
 import pytest
+from pydantic import ValidationError
 from sqlalchemy import func, select
 from sqlalchemy.orm import Session
 
@@ -15,10 +16,11 @@ from core.workflows import (
     DeveloperReviewerWorkflowRequest,
     WorkflowError,
     WorkflowErrorCode,
+    WorkflowHandoffContext,
     validate_workflow_request,
 )
 from infrastructure.database.models import AuditEvent, Task
-from tests.workflows.factories import persisted_workflow_request
+from tests.workflows.factories import handoff_context_values, persisted_workflow_request
 
 pytest_plugins = ("tests.database.conftest",)
 
@@ -31,6 +33,7 @@ def _assert_rejected_without_side_effects(
 ) -> None:
     """Ensure preflight never assigns, audits, or invokes later workflow stages."""
     original_status = task.status
+    original_assigned_agent_id = task.assigned_agent_id
     audit_count = session.scalar(select(func.count()).select_from(AuditEvent))
 
     with pytest.raises(WorkflowError) as raised:
@@ -38,7 +41,7 @@ def _assert_rejected_without_side_effects(
 
     assert raised.value.code is expected_code
     assert task.status is original_status
-    assert task.assigned_agent_id is None
+    assert task.assigned_agent_id == original_assigned_agent_id
     assert session.scalar(select(func.count()).select_from(AuditEvent)) == audit_count
 
 
@@ -72,6 +75,30 @@ def test_validation_rejects_a_type_confused_request_before_persistence_side_effe
 ) -> None:
     """Prevent model_copy() corruption from bypassing the public workflow boundary."""
     task, _, _, request = persisted_workflow_request(db_session, tmp_path)
+    forged = request.model_copy(update={"task_id": "not-a-uuid"})
+
+    _assert_rejected_without_side_effects(db_session, task, forged, WorkflowErrorCode.INVALID_INPUT)
+
+
+def test_validation_rejects_a_non_exact_top_level_object() -> None:
+    """Prevent arbitrary objects from reaching request canonicalization."""
+    with pytest.raises(WorkflowError) as raised:
+        validate_workflow_request(None, object())  # type: ignore[arg-type]
+
+    assert raised.value.code is WorkflowErrorCode.INVALID_INPUT
+
+
+def test_validation_preserves_a_preexisting_ready_assignment_on_rejection(
+    db_session: Session, tmp_path: Path
+) -> None:
+    """Prevent rejected preflight from clearing a READY task's existing assignment."""
+    task, developer, _, request = persisted_workflow_request(
+        db_session,
+        tmp_path,
+        task_overrides={"assigned_agent_id": None},
+    )
+    task.assigned_agent_id = developer.id
+    db_session.flush()
     forged = request.model_copy(update={"task_id": "not-a-uuid"})
 
     _assert_rejected_without_side_effects(db_session, task, forged, WorkflowErrorCode.INVALID_INPUT)
@@ -256,6 +283,30 @@ def test_validation_rejects_unrepresentable_persistent_task_content_before_side_
     _assert_rejected_without_side_effects(
         db_session, task, request, WorkflowErrorCode.INVALID_SCOPE
     )
+
+
+def test_validation_rejects_an_overlong_persistent_criterion_without_side_effects(
+    db_session: Session, tmp_path: Path
+) -> None:
+    """Prevent persisted criteria outside the 1,024-character handoff bound from reaching agents."""
+    task, _, _, request = persisted_workflow_request(
+        db_session,
+        tmp_path,
+        task_overrides={"acceptance_criteria": ["x" * 1025]},
+    )
+
+    _assert_rejected_without_side_effects(
+        db_session, task, request, WorkflowErrorCode.INVALID_SCOPE
+    )
+
+
+def test_handoff_context_rejects_a_criterion_above_its_persistent_bound() -> None:
+    """Prevent a relaxed handoff criterion bound from accepting stored overlong task content."""
+    values = handoff_context_values()
+    values["acceptance_criteria"] = ["x" * 1025]
+
+    with pytest.raises(ValidationError):
+        WorkflowHandoffContext.model_validate(values)
 
 
 @pytest.mark.parametrize(

--- a/tests/workflows/test_validation.py
+++ b/tests/workflows/test_validation.py
@@ -21,6 +21,7 @@ from core.workflows import (
 )
 from infrastructure.database.models import AuditEvent, Task
 from tests.workflows.factories import handoff_context_values, persisted_workflow_request
+from tests.workflows.traceback_assertions import assert_workflow_frames_are_scope_free
 
 pytest_plugins = ("tests.database.conftest",)
 
@@ -327,3 +328,49 @@ def test_validation_rejects_reviewer_profile_mismatch_before_side_effects(
     )
 
     _assert_rejected_without_side_effects(db_session, task, forged, WorkflowErrorCode.INVALID_SCOPE)
+
+
+def test_direct_validation_failure_traceback_does_not_retain_workflow_scope(
+    db_session: Session, tmp_path: Path
+) -> None:
+    """Prevent direct preflight errors from retaining task, profile, or workspace objects."""
+    task_marker = "direct-validation-task-marker-71ad"
+    profile_marker = "direct-validation-profile-marker-b426"
+    workspace_marker = "direct-validation-workspace-marker-9c34"
+    workspace_root = tmp_path / workspace_marker
+    workspace_root.mkdir()
+    task, _, _, request = persisted_workflow_request(db_session, tmp_path)
+    task.title = task_marker
+    task.description = task_marker
+    db_session.commit()
+    developer_request = request.developer_request.model_copy(
+        update={
+            "task": request.developer_request.task.model_copy(update={"objective": task_marker}),
+            "execution_context": request.developer_request.execution_context.model_copy(
+                update={"workspace_root": workspace_root}
+            ),
+        }
+    )
+    unsafe_request = request.model_copy(
+        update={
+            "developer_request": developer_request,
+            "reviewer_profile": request.reviewer_profile.model_copy(
+                update={
+                    "id": "other-reviewer",
+                    "system_prompt": profile_marker,
+                }
+            ),
+        }
+    )
+
+    with pytest.raises(WorkflowError) as raised:
+        validate_workflow_request(db_session, unsafe_request)
+
+    assert raised.value.code is WorkflowErrorCode.INVALID_SCOPE
+    assert raised.value.__cause__ is None
+    assert raised.value.__context__ is None
+    assert_workflow_frames_are_scope_free(
+        raised.value.__traceback__,
+        filenames=frozenset({"core/workflows/validation.py"}),
+        markers=(task_marker, profile_marker, workspace_marker),
+    )

--- a/tests/workflows/test_validation.py
+++ b/tests/workflows/test_validation.py
@@ -1,0 +1,278 @@
+"""PostgreSQL integration tests for Phase 16 workflow preflight."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from pathlib import Path
+from uuid import uuid4
+
+import pytest
+from sqlalchemy import func, select
+from sqlalchemy.orm import Session
+
+from core.enums import AgentStatus, TaskStatus
+from core.workflows import (
+    DeveloperReviewerWorkflowRequest,
+    WorkflowError,
+    WorkflowErrorCode,
+    validate_workflow_request,
+)
+from infrastructure.database.models import AuditEvent, Task
+from tests.workflows.factories import persisted_workflow_request
+
+pytest_plugins = ("tests.database.conftest",)
+
+
+def _assert_rejected_without_side_effects(
+    session: Session,
+    task: Task,
+    request: DeveloperReviewerWorkflowRequest,
+    expected_code: WorkflowErrorCode,
+) -> None:
+    """Ensure preflight never assigns, audits, or invokes later workflow stages."""
+    original_status = task.status
+    audit_count = session.scalar(select(func.count()).select_from(AuditEvent))
+
+    with pytest.raises(WorkflowError) as raised:
+        validate_workflow_request(session, request)
+
+    assert raised.value.code is expected_code
+    assert task.status is original_status
+    assert task.assigned_agent_id is None
+    assert session.scalar(select(func.count()).select_from(AuditEvent)) == audit_count
+
+
+def test_validation_returns_a_canonical_persistent_scope(
+    db_session: Session, tmp_path: Path
+) -> None:
+    """Prevent later workflow stages from rebuilding scope from untrusted request fields."""
+    task, developer, reviewer, request = persisted_workflow_request(db_session, tmp_path)
+
+    validated = validate_workflow_request(db_session, request)
+
+    assert validated.request is not request
+    assert validated.task is task
+    assert validated.developer is developer
+    assert validated.reviewer is reviewer
+    assert validated.handoff_context.model_dump(mode="python") == {
+        "task_id": str(task.id),
+        "project_id": str(task.project_id),
+        "task_title": "Correct addition",
+        "task_description": "Correct the faulty addition implementation.",
+        "acceptance_criteria": ("The existing test suite passes.",),
+        "developer_id": "developer-01",
+        "reviewer_id": "reviewer-01",
+        "reviewer_profile": request.reviewer_profile.model_dump(mode="python"),
+        "required_check_profiles": request.developer_request.required_check_profiles,
+    }
+
+
+def test_validation_rejects_a_type_confused_request_before_persistence_side_effects(
+    db_session: Session, tmp_path: Path
+) -> None:
+    """Prevent model_copy() corruption from bypassing the public workflow boundary."""
+    task, _, _, request = persisted_workflow_request(db_session, tmp_path)
+    forged = request.model_copy(update={"task_id": "not-a-uuid"})
+
+    _assert_rejected_without_side_effects(db_session, task, forged, WorkflowErrorCode.INVALID_INPUT)
+
+
+@pytest.mark.parametrize("missing", ["task", "developer", "reviewer"])
+def test_validation_rejects_missing_persistent_scope_before_side_effects(
+    db_session: Session, tmp_path: Path, missing: str
+) -> None:
+    """Prevent nonexistent persistent identities from reaching assignment or collaborators."""
+    task, _, _, request = persisted_workflow_request(db_session, tmp_path)
+    fields = {
+        "task": "task_id",
+        "developer": "developer_agent_id",
+        "reviewer": "reviewer_agent_id",
+    }
+    forged = request.model_copy(update={fields[missing]: uuid4()})
+
+    _assert_rejected_without_side_effects(db_session, task, forged, WorkflowErrorCode.INVALID_SCOPE)
+
+
+def test_validation_rejects_a_non_ready_task_before_side_effects(
+    db_session: Session, tmp_path: Path
+) -> None:
+    """Prevent workflows from reopening an ineligible persistent task."""
+    task, _, _, request = persisted_workflow_request(
+        db_session, tmp_path, task_overrides={"status": TaskStatus.BACKLOG}
+    )
+
+    _assert_rejected_without_side_effects(
+        db_session, task, request, WorkflowErrorCode.INVALID_STATE
+    )
+
+
+@pytest.mark.parametrize("kind", ["persistent_ids", "profile_slugs"])
+def test_validation_rejects_non_independent_author_and_reviewer(
+    db_session: Session, tmp_path: Path, kind: str
+) -> None:
+    """Prevent a persistent or declared identity from authoring and reviewing one task."""
+    task, developer, _, request = persisted_workflow_request(db_session, tmp_path)
+    if kind == "persistent_ids":
+        forged = request.model_copy(update={"reviewer_agent_id": developer.id})
+    else:
+        forged = request.model_copy(
+            update={
+                "reviewer_profile": request.reviewer_profile.model_copy(
+                    update={"id": "developer-01"}
+                )
+            }
+        )
+
+    expected_code = (
+        WorkflowErrorCode.INVALID_INPUT
+        if kind == "persistent_ids"
+        else WorkflowErrorCode.INVALID_SCOPE
+    )
+    _assert_rejected_without_side_effects(db_session, task, forged, expected_code)
+
+
+@pytest.mark.parametrize(
+    ("agent_kind", "overrides", "expected_code"),
+    [
+        ("developer", {"role": "Reviewer"}, WorkflowErrorCode.INVALID_ROLE),
+        ("reviewer", {"role": "Developer"}, WorkflowErrorCode.INVALID_ROLE),
+        ("developer", {"status": AgentStatus.OFFLINE}, WorkflowErrorCode.INVALID_AGENT),
+        ("reviewer", {"status": AgentStatus.BLOCKED}, WorkflowErrorCode.INVALID_AGENT),
+    ],
+)
+def test_validation_rejects_ineligible_persistent_agents_before_side_effects(
+    db_session: Session,
+    tmp_path: Path,
+    agent_kind: str,
+    overrides: dict[str, object],
+    expected_code: WorkflowErrorCode,
+) -> None:
+    """Prevent invalid persistent role or availability from reaching the workflow."""
+    task, _, _, request = persisted_workflow_request(
+        db_session,
+        tmp_path,
+        **{f"{agent_kind}_overrides": overrides},
+    )
+
+    _assert_rejected_without_side_effects(db_session, task, request, expected_code)
+
+
+@pytest.mark.parametrize(
+    ("field", "value_factory"),
+    [
+        (
+            "profile",
+            lambda request: request.developer_request.profile.model_copy(update={"id": "other"}),
+        ),
+        (
+            "task",
+            lambda request: request.developer_request.task.model_copy(update={"task_id": uuid4()}),
+        ),
+        (
+            "execution_context",
+            lambda request: request.developer_request.execution_context.model_copy(
+                update={"task_id": uuid4()}
+            ),
+        ),
+        (
+            "execution_context",
+            lambda request: request.developer_request.execution_context.model_copy(
+                update={"project_id": uuid4()}
+            ),
+        ),
+        (
+            "execution_context",
+            lambda request: request.developer_request.execution_context.model_copy(
+                update={"agent_id": "other"}
+            ),
+        ),
+        (
+            "execution_context",
+            lambda request: request.developer_request.execution_context.model_copy(
+                update={"correlation_id": uuid4()}
+            ),
+        ),
+    ],
+)
+def test_validation_rejects_mismatched_developer_runtime_scope_before_side_effects(
+    db_session: Session,
+    tmp_path: Path,
+    field: str,
+    value_factory: Callable[[DeveloperReviewerWorkflowRequest], object],
+) -> None:
+    """Prevent a Developer request from acting outside its persistent task and identity scope."""
+    task, _, _, request = persisted_workflow_request(db_session, tmp_path)
+    developer_request = request.developer_request.model_copy(update={field: value_factory(request)})
+    forged = request.model_copy(update={"developer_request": developer_request})
+
+    _assert_rejected_without_side_effects(db_session, task, forged, WorkflowErrorCode.INVALID_SCOPE)
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("objective", "Different persistent objective."),
+        ("acceptance_criteria", ("Different criterion.",)),
+    ],
+)
+def test_validation_rejects_developer_task_content_mismatch_before_side_effects(
+    db_session: Session, tmp_path: Path, field: str, value: object
+) -> None:
+    """Prevent developer work from using task text other than the persisted task contract."""
+    task, _, _, request = persisted_workflow_request(db_session, tmp_path)
+    runtime_task = request.developer_request.task.model_copy(update={field: value})
+    forged = request.model_copy(
+        update={
+            "developer_request": request.developer_request.model_copy(update={"task": runtime_task})
+        }
+    )
+
+    _assert_rejected_without_side_effects(db_session, task, forged, WorkflowErrorCode.INVALID_SCOPE)
+
+
+@pytest.mark.parametrize(
+    "task_overrides",
+    [
+        {"title": ""},
+        {"title": "x" * 256},
+        {"description": None},
+        {"description": ""},
+        {"description": "x" * 8193},
+        {"acceptance_criteria": []},
+        {"acceptance_criteria": ["   "]},
+        {"acceptance_criteria": [123]},
+        {"acceptance_criteria": ["same", "same"]},
+        {"acceptance_criteria": [f"criterion {index}" for index in range(17)]},
+    ],
+)
+def test_validation_rejects_unrepresentable_persistent_task_content_before_side_effects(
+    db_session: Session, tmp_path: Path, task_overrides: dict[str, object]
+) -> None:
+    """Prevent malformed or oversized persisted task data from reaching bounded agents."""
+    task, _, _, request = persisted_workflow_request(
+        db_session, tmp_path, task_overrides=task_overrides
+    )
+
+    _assert_rejected_without_side_effects(
+        db_session, task, request, WorkflowErrorCode.INVALID_SCOPE
+    )
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("id", "other-reviewer"),
+        ("role", "Developer"),
+        ("status", AgentStatus.OFFLINE),
+    ],
+)
+def test_validation_rejects_reviewer_profile_mismatch_before_side_effects(
+    db_session: Session, tmp_path: Path, field: str, value: object
+) -> None:
+    """Prevent a Reviewer declaration from diverging from the persistent reviewer identity."""
+    task, _, _, request = persisted_workflow_request(db_session, tmp_path)
+    forged = request.model_copy(
+        update={"reviewer_profile": request.reviewer_profile.model_copy(update={field: value})}
+    )
+
+    _assert_rejected_without_side_effects(db_session, task, forged, WorkflowErrorCode.INVALID_SCOPE)

--- a/tests/workflows/traceback_assertions.py
+++ b/tests/workflows/traceback_assertions.py
@@ -1,0 +1,41 @@
+"""Assertions for leak-resistant public workflow tracebacks."""
+
+from __future__ import annotations
+
+from types import TracebackType
+
+
+def assert_workflow_frames_are_scope_free(
+    traceback: TracebackType | None,
+    *,
+    filenames: frozenset[str],
+    markers: tuple[str, ...],
+) -> None:
+    """Reject sensitive workflow objects and their marker-bearing representations."""
+    forbidden_locals = frozenset(
+        {
+            "self",
+            "session",
+            "request",
+            "scope",
+            "context",
+            "developer_result",
+            "reviewer_result",
+            "handoff",
+            "profile",
+            "task",
+        }
+    )
+    while traceback is not None:
+        frame = traceback.tb_frame
+        if any(frame.f_code.co_filename.endswith(filename) for filename in filenames):
+            retained = sorted(
+                name
+                for name in forbidden_locals.intersection(frame.f_locals)
+                if frame.f_locals[name] is not None
+            )
+            assert retained == [], (frame.f_code.co_name, retained)
+            for value in frame.f_locals.values():
+                rendered = repr(value)
+                assert all(marker not in rendered for marker in markers)
+        traceback = traceback.tb_next


### PR DESCRIPTION
## Summary

- add a bounded Developer-to-Reviewer workflow with persistent task checkpoints
- enforce independent Reviewer authority, fresh evidence handoff, finite review cycles, cancellation, deadlines, and human escalation
- record append-only workflow audit events without persisting prompts or sensitive provider data
- add real PostgreSQL integration coverage and fail-closed security regression tests
- document the Phase 16 architecture, implementation plan, operating constraints, and completed checklist items

## Safety properties

- Developer and Reviewer are distinct persistent agents
- every loop has a finite cycle limit and one overall deadline
- no implicit retries or duplicate collaborator calls
- cancellation propagates immediately
- database checkpoints use row locks and expected-state validation
- Reviewer authority remains read-only and least-privilege
- public error tracebacks do not retain workflow scope, evidence, or Reviewer system prompts
- no QA, Security, generic workflow engine, or Phase 17 implementation is included

## Verification

- Ruff: clean
- mypy strict: clean across 242 source files
- pytest with real PostgreSQL: 1,175 passed
- Ruff format check: 306 files formatted
- Docker API image: rebuilt successfully
- Docker services: API healthy, PostgreSQL healthy
- Alembic: 20260826_0003 (head)
- API health: status ok
- independent scoped review: ready to merge, no Critical, Important, or Minor findings

## Stack

This is a stacked pull request targeting phase-15/reviewer-agent.