### PR TITLE
feat(pull-requests): add internal merge gate model

### DIFF
--- a/SYNAPSEOS_DEVELOPMENT_CHECKLIST.md
+++ b/SYNAPSEOS_DEVELOPMENT_CHECKLIST.md
@@ -1382,17 +1382,17 @@ Matérialiser le workflow de validation.
 
 ## PR contient
 
-- [ ] task
-- [ ] auteur
-- [ ] résumé
-- [ ] changements
-- [ ] tests
-- [ ] risques
-- [ ] confidence
-- [ ] reviewer
-- [ ] QA
-- [ ] security
-- [ ] approvals
+- [x] task
+- [x] auteur
+- [x] résumé
+- [x] changements
+- [x] tests
+- [x] risques
+- [x] confidence
+- [x] reviewer
+- [x] QA
+- [x] security
+- [x] approvals
 
 ## Prompt Claude Code — Phase 20
 

--- a/alembic/versions/20260908_0004_pull_request_model.py
+++ b/alembic/versions/20260908_0004_pull_request_model.py
@@ -1,0 +1,246 @@
+"""add Phase 20 internal pull-request model
+
+Revision ID: 20260908_0004
+Revises: 20260826_0003
+Create Date: 2026-09-08
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+from alembic import op
+
+revision: str = "20260908_0004"
+down_revision: str | None = "20260826_0003"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_unique_constraint("uq_tasks_project_id_id", "tasks", ["project_id", "id"])
+    op.create_table(
+        "pull_requests",
+        sa.Column("project_id", sa.UUID(), nullable=False),
+        sa.Column("task_id", sa.UUID(), nullable=False),
+        sa.Column("author_agent_id", sa.UUID(), nullable=False),
+        sa.Column("base_branch", sa.String(length=255), nullable=False),
+        sa.Column("base_sha", sa.String(length=64), nullable=False),
+        sa.Column("head_branch", sa.String(length=255), nullable=False),
+        sa.Column("head_sha", sa.String(length=64), nullable=False),
+        sa.Column("preparation_checksum", sa.String(length=64), nullable=False),
+        sa.Column("title", sa.String(length=200), nullable=False),
+        sa.Column("summary", sa.Text(), nullable=False),
+        sa.Column("changed_paths", postgresql.JSONB(astext_type=sa.Text()), nullable=False),
+        sa.Column("insertions", sa.Integer(), nullable=False),
+        sa.Column("deletions", sa.Integer(), nullable=False),
+        sa.Column("commit_count", sa.Integer(), nullable=False),
+        sa.Column("tests", postgresql.JSONB(astext_type=sa.Text()), nullable=False),
+        sa.Column("risks", postgresql.JSONB(astext_type=sa.Text()), nullable=False),
+        sa.Column("confidence", sa.Numeric(precision=5, scale=4), nullable=False),
+        sa.Column(
+            "status",
+            sa.Enum("OPEN", "BLOCKED", "READY_TO_MERGE", "CLOSED", name="pull_request_status"),
+            nullable=False,
+        ),
+        sa.Column("correlation_id", sa.UUID(), nullable=False),
+        sa.Column("id", sa.UUID(), nullable=False),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.CheckConstraint(
+            "base_branch <> head_branch", name=op.f("ck_pull_requests_branches_distinct")
+        ),
+        sa.CheckConstraint(
+            "commit_count >= 1", name=op.f("ck_pull_requests_commit_count_positive")
+        ),
+        sa.CheckConstraint(
+            "confidence BETWEEN 0 AND 1", name=op.f("ck_pull_requests_confidence_range")
+        ),
+        sa.CheckConstraint(
+            "insertions >= 0 AND deletions >= 0",
+            name=op.f("ck_pull_requests_line_counts_non_negative"),
+        ),
+        sa.ForeignKeyConstraint(
+            ["author_agent_id"],
+            ["agents.id"],
+            name=op.f("fk_pull_requests_author_agent_id_agents"),
+            ondelete="RESTRICT",
+        ),
+        sa.ForeignKeyConstraint(
+            ["project_id"],
+            ["projects.id"],
+            name=op.f("fk_pull_requests_project_id_projects"),
+            ondelete="RESTRICT",
+        ),
+        sa.ForeignKeyConstraint(
+            ["project_id", "task_id"],
+            ["tasks.project_id", "tasks.id"],
+            name=op.f("fk_pull_requests_task_project_scope_tasks"),
+            ondelete="RESTRICT",
+        ),
+        sa.PrimaryKeyConstraint("id", name=op.f("pk_pull_requests")),
+        sa.UniqueConstraint(
+            "preparation_checksum", name=op.f("uq_pull_requests_preparation_checksum")
+        ),
+        sa.UniqueConstraint("correlation_id", name=op.f("uq_pull_requests_correlation_id")),
+    )
+    op.create_index("ix_pull_requests_head_sha", "pull_requests", ["head_sha"])
+    op.create_index("ix_pull_requests_project_status", "pull_requests", ["project_id", "status"])
+    op.create_index("ix_pull_requests_task_created", "pull_requests", ["task_id", "created_at"])
+    op.create_index(
+        "uq_pull_requests_task_head", "pull_requests", ["task_id", "head_sha"], unique=True
+    )
+
+    op.create_table(
+        "pull_request_reviews",
+        sa.Column("pull_request_id", sa.UUID(), nullable=False),
+        sa.Column("reviewer_agent_id", sa.UUID(), nullable=False),
+        sa.Column(
+            "decision",
+            sa.Enum(
+                "APPROVED",
+                "CHANGES_REQUESTED",
+                name="pull_request_review_decision",
+            ),
+            nullable=False,
+        ),
+        sa.Column("summary", sa.String(length=4096), nullable=False),
+        sa.Column("confidence", sa.Numeric(precision=5, scale=4), nullable=False),
+        sa.Column("head_sha", sa.String(length=64), nullable=False),
+        sa.Column("evidence_ref", sa.String(length=255), nullable=False),
+        sa.Column("correlation_id", sa.UUID(), nullable=False),
+        sa.Column("id", sa.UUID(), nullable=False),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.CheckConstraint(
+            "confidence BETWEEN 0 AND 1",
+            name=op.f("ck_pull_request_reviews_confidence_range"),
+        ),
+        sa.ForeignKeyConstraint(
+            ["pull_request_id"],
+            ["pull_requests.id"],
+            name=op.f("fk_pull_request_reviews_pull_request_id_pull_requests"),
+            ondelete="RESTRICT",
+        ),
+        sa.ForeignKeyConstraint(
+            ["reviewer_agent_id"],
+            ["agents.id"],
+            name=op.f("fk_pull_request_reviews_reviewer_agent_id_agents"),
+            ondelete="RESTRICT",
+        ),
+        sa.PrimaryKeyConstraint("id", name=op.f("pk_pull_request_reviews")),
+        sa.UniqueConstraint(
+            "pull_request_id",
+            "head_sha",
+            name=op.f("uq_pull_request_reviews_pull_request_head"),
+        ),
+        sa.UniqueConstraint(
+            "evidence_ref",
+            name=op.f("uq_pull_request_reviews_evidence_ref"),
+        ),
+    )
+    op.create_index(
+        "ix_pull_request_reviews_pr_created",
+        "pull_request_reviews",
+        ["pull_request_id", "created_at"],
+    )
+    op.create_index(
+        "ix_pull_request_reviews_reviewer_created",
+        "pull_request_reviews",
+        ["reviewer_agent_id", "created_at"],
+    )
+
+    op.create_table(
+        "approvals",
+        sa.Column("pull_request_id", sa.UUID(), nullable=False),
+        sa.Column(
+            "kind",
+            sa.Enum("REVIEWER", "QA", "SECURITY", name="approval_kind"),
+            nullable=False,
+        ),
+        sa.Column("approver_agent_id", sa.UUID(), nullable=False),
+        sa.Column(
+            "decision",
+            sa.Enum("APPROVED", "REJECTED", "BLOCKED", name="approval_decision"),
+            nullable=False,
+        ),
+        sa.Column("head_sha", sa.String(length=64), nullable=False),
+        sa.Column("evidence_ref", sa.String(length=255), nullable=False),
+        sa.Column("correlation_id", sa.UUID(), nullable=False),
+        sa.Column("id", sa.UUID(), nullable=False),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.ForeignKeyConstraint(
+            ["approver_agent_id"],
+            ["agents.id"],
+            name=op.f("fk_approvals_approver_agent_id_agents"),
+            ondelete="RESTRICT",
+        ),
+        sa.ForeignKeyConstraint(
+            ["pull_request_id"],
+            ["pull_requests.id"],
+            name=op.f("fk_approvals_pull_request_id_pull_requests"),
+            ondelete="RESTRICT",
+        ),
+        sa.PrimaryKeyConstraint("id", name=op.f("pk_approvals")),
+        sa.UniqueConstraint(
+            "pull_request_id",
+            "kind",
+            "head_sha",
+            name=op.f("uq_approvals_pull_request_kind_head"),
+        ),
+        sa.UniqueConstraint(
+            "evidence_ref",
+            name=op.f("uq_approvals_evidence_ref"),
+        ),
+    )
+    op.create_index(
+        "ix_approvals_approver_created", "approvals", ["approver_agent_id", "created_at"]
+    )
+    op.create_index(
+        "ix_approvals_pr_kind_created",
+        "approvals",
+        ["pull_request_id", "kind", "created_at"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_approvals_pr_kind_created", table_name="approvals")
+    op.drop_index("ix_approvals_approver_created", table_name="approvals")
+    op.drop_table("approvals")
+    op.drop_index("ix_pull_request_reviews_reviewer_created", table_name="pull_request_reviews")
+    op.drop_index("ix_pull_request_reviews_pr_created", table_name="pull_request_reviews")
+    op.drop_table("pull_request_reviews")
+    op.drop_index("uq_pull_requests_task_head", table_name="pull_requests")
+    op.drop_index("ix_pull_requests_task_created", table_name="pull_requests")
+    op.drop_index("ix_pull_requests_project_status", table_name="pull_requests")
+    op.drop_index("ix_pull_requests_head_sha", table_name="pull_requests")
+    op.drop_table("pull_requests")
+    bind = op.get_bind()
+    for enum_name in (
+        "approval_decision",
+        "approval_kind",
+        "pull_request_review_decision",
+        "pull_request_status",
+    ):
+        postgresql.ENUM(name=enum_name).drop(bind, checkfirst=True)
+    op.drop_constraint("uq_tasks_project_id_id", "tasks", type_="unique")

--- a/core/git_workflow/audit.py
+++ b/core/git_workflow/audit.py
@@ -19,6 +19,7 @@ GIT_AUDIT_DATA_KEYS = frozenset(
         "branch_kind",
         "branch_name",
         "base_branch",
+        "base_sha",
         "commit_sha",
         "selected_path_count",
         "changed_path_count",

--- a/core/git_workflow/workflow.py
+++ b/core/git_workflow/workflow.py
@@ -230,7 +230,12 @@ class GitWorkflow:
             GitOperation.VALIDATE_MERGE_REQUIREMENTS,
             evaluate,
             started_data={"preparation_checksum": request.preparation.checksum},
-            completed_data=_merge_validation_audit_data,
+            completed_data=lambda result: {
+                **_merge_validation_audit_data(result),
+                "preparation_checksum": request.preparation.checksum,
+                "commit_sha": request.preparation.head_sha,
+                "base_sha": request.preparation.base_sha,
+            },
         )
 
     async def _execute(

--- a/core/pull_requests/__init__.py
+++ b/core/pull_requests/__init__.py
@@ -1,0 +1,39 @@
+"""Phase 20 internal pull-request validation model."""
+
+from core.pull_requests.gate import MergeGate
+from core.pull_requests.types import (
+    ApprovalDecision,
+    ApprovalEvidence,
+    ApprovalKind,
+    MergeGateDecision,
+    MergeGateReason,
+    MergeGateRequest,
+    MergeGateResult,
+    PullRequestCandidate,
+    PullRequestEvidenceBinding,
+    PullRequestReviewDecision,
+    PullRequestReviewEvidence,
+    PullRequestRisk,
+    PullRequestRiskSeverity,
+    PullRequestStatus,
+    PullRequestTestEvidence,
+)
+
+__all__ = [
+    "ApprovalDecision",
+    "ApprovalEvidence",
+    "ApprovalKind",
+    "MergeGate",
+    "MergeGateDecision",
+    "MergeGateReason",
+    "MergeGateRequest",
+    "MergeGateResult",
+    "PullRequestCandidate",
+    "PullRequestEvidenceBinding",
+    "PullRequestReviewDecision",
+    "PullRequestReviewEvidence",
+    "PullRequestRisk",
+    "PullRequestRiskSeverity",
+    "PullRequestStatus",
+    "PullRequestTestEvidence",
+]

--- a/core/pull_requests/gate.py
+++ b/core/pull_requests/gate.py
@@ -1,0 +1,97 @@
+"""Deterministic fail-closed Phase 20 merge gate."""
+
+from __future__ import annotations
+
+from pydantic import ValidationError
+
+from core.pull_requests.types import (
+    ApprovalDecision,
+    ApprovalKind,
+    MergeGateDecision,
+    MergeGateReason,
+    MergeGateRequest,
+    MergeGateResult,
+    PullRequestReviewDecision,
+)
+
+
+class MergeGate:
+    """Evaluate complete independent evidence without performing a merge."""
+
+    def evaluate(self, request: MergeGateRequest) -> MergeGateResult:
+        try:
+            canonical = MergeGateRequest.model_validate(request.model_dump())
+        except (AttributeError, TypeError, ValueError, ValidationError):
+            return MergeGateResult(
+                decision=MergeGateDecision.BLOCK,
+                reasons=(MergeGateReason.STALE_EVIDENCE,),
+            )
+
+        candidate = canonical.candidate
+        review = canonical.review
+        approvals = {approval.kind: approval for approval in canonical.approvals}
+        reasons: set[MergeGateReason] = set()
+
+        if canonical.expected_task_id != candidate.task_id:
+            reasons.add(MergeGateReason.TASK_MISMATCH)
+        if review is None:
+            reasons.add(MergeGateReason.REVIEW_NOT_APPROVED)
+        elif review.reviewer_agent_id == candidate.author_agent_id:
+            reasons.add(MergeGateReason.AUTHOR_IS_REVIEWER)
+        if review is not None and review.reviewer_role != "Reviewer":
+            reasons.add(MergeGateReason.REVIEWER_ROLE_MISMATCH)
+        if review is not None and review.decision is not PullRequestReviewDecision.APPROVED:
+            reasons.add(MergeGateReason.REVIEW_NOT_APPROVED)
+        if not canonical.branch_mergeable:
+            reasons.add(MergeGateReason.BRANCH_NOT_MERGEABLE)
+        if not canonical.tests or any(
+            not item.passed or item.truncated for item in canonical.tests
+        ):
+            reasons.add(MergeGateReason.TESTS_NOT_PASSED)
+
+        reviewer = approvals.get(ApprovalKind.REVIEWER)
+        qa = approvals.get(ApprovalKind.QA)
+        security = approvals.get(ApprovalKind.SECURITY)
+        if (
+            reviewer is None
+            or reviewer.decision is not ApprovalDecision.APPROVED
+            or review is None
+            or reviewer.approver_agent_id != review.reviewer_agent_id
+        ):
+            reasons.add(MergeGateReason.REVIEWER_APPROVAL_MISSING)
+        if qa is None or qa.decision is not ApprovalDecision.APPROVED:
+            reasons.add(MergeGateReason.QA_NOT_PASSED)
+        if security is None or security.decision is not ApprovalDecision.APPROVED:
+            reasons.add(MergeGateReason.SECURITY_BLOCKED)
+
+        expected_roles = {
+            ApprovalKind.REVIEWER: "Reviewer",
+            ApprovalKind.QA: "QA",
+            ApprovalKind.SECURITY: "Security",
+        }
+        if any(
+            approval.approver_role != expected_roles[approval.kind]
+            for approval in canonical.approvals
+        ):
+            reasons.add(MergeGateReason.APPROVER_ROLE_MISMATCH)
+
+        approval_is_stale = any(
+            item.head_sha != candidate.head_sha or item.correlation_id != candidate.correlation_id
+            for item in canonical.approvals
+        )
+        test_is_stale = any(item.head_sha != candidate.head_sha for item in canonical.tests)
+        review_is_stale = review is not None and (
+            review.head_sha != candidate.head_sha
+            or review.correlation_id != candidate.correlation_id
+        )
+        if approval_is_stale or test_is_stale or review_is_stale:
+            reasons.add(MergeGateReason.STALE_EVIDENCE)
+
+        approver_ids = [item.approver_agent_id for item in canonical.approvals]
+        if candidate.author_agent_id in approver_ids or len(set(approver_ids)) != len(approver_ids):
+            reasons.add(MergeGateReason.APPROVER_IDENTITY_CONFLICT)
+
+        ordered = tuple(reason for reason in MergeGateReason if reason in reasons)
+        if ordered:
+            return MergeGateResult(decision=MergeGateDecision.BLOCK, reasons=ordered)
+        return MergeGateResult(decision=MergeGateDecision.PASS)

--- a/core/pull_requests/types.py
+++ b/core/pull_requests/types.py
@@ -1,0 +1,169 @@
+"""Immutable Phase 20 pull-request and merge-gate contracts."""
+
+from __future__ import annotations
+
+from enum import StrEnum
+from typing import Annotated, Self
+from uuid import UUID
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+
+
+class PullRequestStatus(StrEnum):
+    """Internal pull-request lifecycle states owned by SynapseOS."""
+
+    OPEN = "OPEN"
+    BLOCKED = "BLOCKED"
+    READY_TO_MERGE = "READY_TO_MERGE"
+    CLOSED = "CLOSED"
+
+
+class PullRequestRiskSeverity(StrEnum):
+    """Allowlisted risk severities persisted in pull-request summaries."""
+
+    INFO = "INFO"
+    LOW = "LOW"
+    MEDIUM = "MEDIUM"
+    HIGH = "HIGH"
+    CRITICAL = "CRITICAL"
+
+
+class PullRequestReviewDecision(StrEnum):
+    """Independent reviewer decisions."""
+
+    APPROVED = "APPROVED"
+    CHANGES_REQUESTED = "CHANGES_REQUESTED"
+
+
+class ApprovalKind(StrEnum):
+    """Required independent approval roles."""
+
+    REVIEWER = "REVIEWER"
+    QA = "QA"
+    SECURITY = "SECURITY"
+
+
+class ApprovalDecision(StrEnum):
+    """Terminal approval evidence decisions."""
+
+    APPROVED = "APPROVED"
+    REJECTED = "REJECTED"
+    BLOCKED = "BLOCKED"
+
+
+class MergeGateDecision(StrEnum):
+    """Fail-closed merge-gate outcome."""
+
+    PASS = "PASS"
+    BLOCK = "BLOCK"
+
+
+class MergeGateReason(StrEnum):
+    """Stable reasons explaining a blocked merge gate."""
+
+    TASK_MISMATCH = "TASK_MISMATCH"
+    PROJECT_TASK_MISMATCH = "PROJECT_TASK_MISMATCH"
+    AUTHOR_TASK_MISMATCH = "AUTHOR_TASK_MISMATCH"
+    AUTHOR_IS_REVIEWER = "AUTHOR_IS_REVIEWER"
+    REVIEWER_ROLE_MISMATCH = "REVIEWER_ROLE_MISMATCH"
+    APPROVER_IDENTITY_CONFLICT = "APPROVER_IDENTITY_CONFLICT"
+    APPROVER_ROLE_MISMATCH = "APPROVER_ROLE_MISMATCH"
+    REVIEW_NOT_APPROVED = "REVIEW_NOT_APPROVED"
+    REVIEWER_APPROVAL_MISSING = "REVIEWER_APPROVAL_MISSING"
+    QA_NOT_PASSED = "QA_NOT_PASSED"
+    SECURITY_BLOCKED = "SECURITY_BLOCKED"
+    TESTS_NOT_PASSED = "TESTS_NOT_PASSED"
+    BRANCH_NOT_MERGEABLE = "BRANCH_NOT_MERGEABLE"
+    STALE_EVIDENCE = "STALE_EVIDENCE"
+
+
+class _ImmutableModel(BaseModel):
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+
+class PullRequestEvidenceBinding(_ImmutableModel):
+    """Exact immutable Git state attached to downstream workflow evidence."""
+
+    head_sha: Annotated[str, Field(pattern=r"^[0-9a-f]{40,64}$")]
+    preparation_checksum: Annotated[str, Field(pattern=r"^[0-9a-f]{64}$")]
+
+
+class PullRequestCandidate(_ImmutableModel):
+    pull_request_id: UUID
+    project_id: UUID
+    task_id: UUID
+    author_agent_id: UUID
+    head_sha: Annotated[str, Field(pattern=r"^[0-9a-f]{40,64}$")]
+    confidence: Annotated[float, Field(ge=0.0, le=1.0, allow_inf_nan=False)]
+    correlation_id: UUID
+
+
+class PullRequestReviewEvidence(_ImmutableModel):
+    reviewer_agent_id: UUID
+    reviewer_role: Annotated[str, Field(min_length=1, max_length=64)]
+    decision: PullRequestReviewDecision
+    head_sha: Annotated[str, Field(pattern=r"^[0-9a-f]{40,64}$")]
+    correlation_id: UUID
+
+
+class ApprovalEvidence(_ImmutableModel):
+    kind: ApprovalKind
+    approver_agent_id: UUID
+    approver_role: Annotated[str, Field(min_length=1, max_length=64)]
+    decision: ApprovalDecision
+    head_sha: Annotated[str, Field(pattern=r"^[0-9a-f]{40,64}$")]
+    correlation_id: UUID
+
+
+class PullRequestTestEvidence(_ImmutableModel):
+    name: Annotated[str, Field(pattern=r"^[a-z0-9][a-z0-9._:-]{0,127}$")]
+    passed: bool
+    truncated: bool
+    head_sha: Annotated[str, Field(pattern=r"^[0-9a-f]{40,64}$")]
+
+
+class PullRequestRisk(_ImmutableModel):
+    severity: PullRequestRiskSeverity
+    summary: Annotated[str, Field(min_length=1, max_length=1_024)]
+
+    @field_validator("summary")
+    @classmethod
+    def require_trimmed_summary(cls, value: str) -> str:
+        if value != value.strip() or any(ord(character) < 32 for character in value):
+            raise ValueError("risk summary is invalid")
+        return value
+
+
+class MergeGateRequest(_ImmutableModel):
+    expected_task_id: UUID
+    candidate: PullRequestCandidate
+    review: PullRequestReviewEvidence | None
+    approvals: Annotated[tuple[ApprovalEvidence, ...], Field(max_length=3)]
+    tests: Annotated[tuple[PullRequestTestEvidence, ...], Field(max_length=32)]
+    branch_mergeable: bool
+
+    @field_validator("approvals", "tests", mode="before")
+    @classmethod
+    def copy_sequences(cls, value: object) -> object:
+        if isinstance(value, (list, tuple)):
+            return tuple(value)
+        return value
+
+    @model_validator(mode="after")
+    def require_unique_approval_kinds(self) -> Self:
+        if len({approval.kind for approval in self.approvals}) != len(self.approvals):
+            raise ValueError("approval kinds must be unique")
+        return self
+
+
+class MergeGateResult(_ImmutableModel):
+    decision: MergeGateDecision
+    reasons: Annotated[tuple[MergeGateReason, ...], Field(max_length=16)] = ()
+
+    @model_validator(mode="after")
+    def require_consistent_result(self) -> Self:
+        if self.decision is MergeGateDecision.PASS and self.reasons:
+            raise ValueError("passing gate cannot contain reasons")
+        if self.decision is MergeGateDecision.BLOCK and not self.reasons:
+            raise ValueError("blocked gate requires reasons")
+        return self

--- a/core/workflows/audit.py
+++ b/core/workflows/audit.py
@@ -625,6 +625,16 @@ def _event_data(
             "decision": _require_review_decision(decision).value,
             "review_score": _require_review_score(review_score),
             "finding_count": _require_finding_count(finding_count),
+            **(
+                {
+                    "head_sha": scope.request.pull_request_evidence.head_sha,
+                    "preparation_checksum": (
+                        scope.request.pull_request_evidence.preparation_checksum
+                    ),
+                }
+                if scope.request.pull_request_evidence is not None
+                else {}
+            ),
         }
     if event_type is WorkflowEventType.REVIEW_CYCLE_EXHAUSTED:
         _require_absent(decision, review_score, finding_count)

--- a/core/workflows/pull_request_evidence.py
+++ b/core/workflows/pull_request_evidence.py
@@ -1,0 +1,32 @@
+"""Persistent validation for Phase 20 workflow evidence bindings."""
+
+from __future__ import annotations
+
+from uuid import UUID
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from core.pull_requests import PullRequestEvidenceBinding
+from infrastructure.database.models import PullRequest
+
+
+def matches_persisted_pull_request(
+    session: Session,
+    *,
+    task_id: UUID,
+    correlation_id: UUID,
+    evidence: PullRequestEvidenceBinding | None,
+) -> bool:
+    """Return whether an optional binding exactly matches one immutable PR."""
+    if evidence is None:
+        return True
+    pull_request_id = session.scalar(
+        select(PullRequest.id).where(
+            PullRequest.task_id == task_id,
+            PullRequest.correlation_id == correlation_id,
+            PullRequest.head_sha == evidence.head_sha,
+            PullRequest.preparation_checksum == evidence.preparation_checksum,
+        )
+    )
+    return pull_request_id is not None

--- a/core/workflows/qa_audit.py
+++ b/core/workflows/qa_audit.py
@@ -157,6 +157,16 @@ def _stage_qa_completed(
                 {"profile_id": item.profile_id.value, "status": item.status.value}
                 for item in result.tests
             ],
+            **(
+                {
+                    "head_sha": scope.request.pull_request_evidence.head_sha,
+                    "preparation_checksum": (
+                        scope.request.pull_request_evidence.preparation_checksum
+                    ),
+                }
+                if scope.request.pull_request_evidence is not None
+                else {}
+            ),
         },
     )
 

--- a/core/workflows/qa_types.py
+++ b/core/workflows/qa_types.py
@@ -9,6 +9,7 @@ from uuid import UUID
 from pydantic import BaseModel, ConfigDict, field_validator, model_validator
 
 from core.enums import TaskStatus
+from core.pull_requests import PullRequestEvidenceBinding
 from core.qa import QADecision, QARequest, QAResult
 
 
@@ -47,6 +48,7 @@ class QAWorkflowRequest(_ImmutableQAWorkflowModel):
     qa_agent_id: UUID
     qa_request: QARequest
     correlation_id: UUID
+    pull_request_evidence: PullRequestEvidenceBinding | None = None
 
     @field_validator("qa_request", mode="before")
     @classmethod

--- a/core/workflows/qa_validation.py
+++ b/core/workflows/qa_validation.py
@@ -13,6 +13,7 @@ from core.enums import AgentStatus, TaskStatus
 from core.qa import QAError, validate_qa_request
 from core.workflows.deadline import _configure_transaction_timeouts
 from core.workflows.errors import WorkflowError, WorkflowErrorCode
+from core.workflows.pull_request_evidence import matches_persisted_pull_request
 from core.workflows.qa_errors import (
     QAWorkflowError,
     QAWorkflowErrorCode,
@@ -60,6 +61,13 @@ def _validate_qa_workflow_request_result(
         if type(request) is not QAWorkflowRequest:
             return None, QAWorkflowErrorCode.INVALID_INPUT
         canonical_request = _canonicalize_qa_workflow_request(request)
+        if not matches_persisted_pull_request(
+            session,
+            task_id=canonical_request.task_id,
+            correlation_id=canonical_request.correlation_id,
+            evidence=canonical_request.pull_request_evidence,
+        ):
+            raise QAWorkflowError(QAWorkflowErrorCode.INVALID_INPUT)
         if deadline is not None:
             _configure_transaction_timeouts(session, deadline)
         task, developer, reviewer, qa = _load_qa_scope(session, canonical_request)

--- a/core/workflows/security_audit.py
+++ b/core/workflows/security_audit.py
@@ -170,6 +170,16 @@ def _stage_security_completed(
             "scanner_suite_id": result.scanner.suite_id,
             "scanner_complete": result.scanner.complete,
             "scanner_truncated": result.scanner.truncated,
+            **(
+                {
+                    "head_sha": scope.request.pull_request_evidence.head_sha,
+                    "preparation_checksum": (
+                        scope.request.pull_request_evidence.preparation_checksum
+                    ),
+                }
+                if scope.request.pull_request_evidence is not None
+                else {}
+            ),
         },
     )
 

--- a/core/workflows/security_types.py
+++ b/core/workflows/security_types.py
@@ -10,6 +10,7 @@ from pydantic import BaseModel, ConfigDict, field_validator, model_validator
 
 from core.agents import AgentProfile
 from core.enums import TaskStatus
+from core.pull_requests import PullRequestEvidenceBinding
 from core.qa import QACriterionAssessment, QAFinding, QAResult, QATestEvidence, QATestRecommendation
 from core.security import (
     SecurityDecision,
@@ -108,6 +109,7 @@ class SecurityWorkflowRequest(_ImmutableSecurityWorkflowModel):
     security_agent_id: UUID
     security_request: SecurityRequest
     correlation_id: UUID
+    pull_request_evidence: PullRequestEvidenceBinding | None = None
 
     @field_validator("security_request", mode="before")
     @classmethod

--- a/core/workflows/security_validation.py
+++ b/core/workflows/security_validation.py
@@ -24,6 +24,7 @@ from core.security import (
 )
 from core.workflows.deadline import _configure_transaction_timeouts
 from core.workflows.errors import WorkflowError, WorkflowErrorCode
+from core.workflows.pull_request_evidence import matches_persisted_pull_request
 from core.workflows.security_errors import (
     SecurityWorkflowError,
     SecurityWorkflowErrorCode,
@@ -74,6 +75,13 @@ def _validate_security_workflow_request_result(
     try:
         _validate_raw_workflow_request(request)
         canonical_request = _canonicalize_security_workflow_request(request)
+        if not matches_persisted_pull_request(
+            session,
+            task_id=canonical_request.task_id,
+            correlation_id=canonical_request.correlation_id,
+            evidence=canonical_request.pull_request_evidence,
+        ):
+            raise SecurityWorkflowError(SecurityWorkflowErrorCode.INVALID_INPUT)
         if deadline is not None:
             _configure_transaction_timeouts(session, deadline)
         task, developer, reviewer, qa, security = _load_security_scope(session, canonical_request)

--- a/core/workflows/types.py
+++ b/core/workflows/types.py
@@ -12,6 +12,7 @@ from core.agents import AgentProfile, AgentReport
 from core.commands import CommandProfileId
 from core.developer import DeveloperRequest
 from core.enums import TaskStatus
+from core.pull_requests import PullRequestEvidenceBinding
 from core.reviewer import ReviewDecision, ReviewerResult
 
 Identifier = Annotated[str, Field(pattern=r"^[a-z0-9][a-z0-9._:-]{0,127}$")]
@@ -84,6 +85,7 @@ class DeveloperReviewerWorkflowRequest(_ImmutableWorkflowModel):
     max_review_cycles: Annotated[int, Field(ge=1, le=10)]
     timeout_seconds: Annotated[float, Field(gt=0.0, le=3600.0, allow_inf_nan=False)]
     correlation_id: UUID
+    pull_request_evidence: PullRequestEvidenceBinding | None = None
 
     @field_validator("developer_request", mode="before")
     @classmethod

--- a/core/workflows/validation.py
+++ b/core/workflows/validation.py
@@ -18,6 +18,7 @@ from core.workflows.errors import (
     _discard_exception,
     _raise_workflow_error,
 )
+from core.workflows.pull_request_evidence import matches_persisted_pull_request
 from core.workflows.types import DeveloperReviewerWorkflowRequest, WorkflowHandoffContext
 from infrastructure.database.models import Agent, Task
 
@@ -60,6 +61,13 @@ def _validate_workflow_request_result(
         if type(request) is not DeveloperReviewerWorkflowRequest:
             return None, WorkflowErrorCode.INVALID_INPUT
         canonical_request = _canonicalize_request(request)
+        if not matches_persisted_pull_request(
+            session,
+            task_id=canonical_request.task_id,
+            correlation_id=canonical_request.correlation_id,
+            evidence=canonical_request.pull_request_evidence,
+        ):
+            raise WorkflowError(WorkflowErrorCode.INVALID_INPUT)
         if deadline is not None:
             _configure_transaction_timeouts(session, deadline)
         task, developer, reviewer = _load_scope(session, canonical_request)

--- a/infrastructure/database/append_only.py
+++ b/infrastructure/database/append_only.py
@@ -25,7 +25,11 @@ def _reject_append_only_changes(session: Session, _flush_context: Any, _instance
             )
 
     for entity in session.dirty:
-        if isinstance(entity, AppendOnlyMixin) and entity not in session.new:
+        if (
+            isinstance(entity, AppendOnlyMixin)
+            and entity not in session.new
+            and session.is_modified(entity, include_collections=False)
+        ):
             entity_id = getattr(entity, "id", "<pending>")
             raise AppendOnlyViolationError(
                 f"Cannot update append-only {type(entity).__name__} entity {entity_id}."

--- a/infrastructure/database/models/__init__.py
+++ b/infrastructure/database/models/__init__.py
@@ -3,6 +3,7 @@
 from infrastructure.database.models.execution import AgentRun, Decision, ToolCall
 from infrastructure.database.models.history import AgentScore, AuditEvent
 from infrastructure.database.models.organization import Agent, AgentPermission, Project
+from infrastructure.database.models.pull_requests import Approval, PullRequest, PullRequestReview
 from infrastructure.database.models.work import Task, TaskDependency
 
 __all__ = [
@@ -10,9 +11,12 @@ __all__ = [
     "AgentPermission",
     "AgentRun",
     "AgentScore",
+    "Approval",
     "AuditEvent",
     "Decision",
     "Project",
+    "PullRequest",
+    "PullRequestReview",
     "Task",
     "TaskDependency",
     "ToolCall",

--- a/infrastructure/database/models/organization.py
+++ b/infrastructure/database/models/organization.py
@@ -22,6 +22,11 @@ from infrastructure.database.base import (
 if TYPE_CHECKING:
     from infrastructure.database.models.execution import AgentRun, Decision
     from infrastructure.database.models.history import AgentScore, AuditEvent
+    from infrastructure.database.models.pull_requests import (
+        Approval,
+        PullRequest,
+        PullRequestReview,
+    )
     from infrastructure.database.models.work import Task
 
 
@@ -58,6 +63,15 @@ class Agent(UUIDPrimaryKeyMixin, TimestampMixin, Base):
     decisions: Mapped[list[Decision]] = relationship(back_populates="agent")
     scores: Mapped[list[AgentScore]] = relationship(back_populates="agent")
     permissions: Mapped[list[AgentPermission]] = relationship(back_populates="agent")
+    authored_pull_requests: Mapped[list[PullRequest]] = relationship(
+        back_populates="author", foreign_keys="PullRequest.author_agent_id"
+    )
+    pull_request_reviews: Mapped[list[PullRequestReview]] = relationship(
+        back_populates="reviewer", foreign_keys="PullRequestReview.reviewer_agent_id"
+    )
+    pull_request_approvals: Mapped[list[Approval]] = relationship(
+        back_populates="approver", foreign_keys="Approval.approver_agent_id"
+    )
 
 
 class Project(UUIDPrimaryKeyMixin, TimestampMixin, Base):
@@ -77,6 +91,7 @@ class Project(UUIDPrimaryKeyMixin, TimestampMixin, Base):
     scores: Mapped[list[AgentScore]] = relationship(back_populates="project")
     audit_events: Mapped[list[AuditEvent]] = relationship(back_populates="project")
     agent_permissions: Mapped[list[AgentPermission]] = relationship(back_populates="project")
+    pull_requests: Mapped[list[PullRequest]] = relationship(back_populates="project")
 
 
 class AgentPermission(UUIDPrimaryKeyMixin, CreatedAtMixin, Base):

--- a/infrastructure/database/models/pull_requests.py
+++ b/infrastructure/database/models/pull_requests.py
@@ -1,0 +1,168 @@
+"""Phase 20 internal pull-request validation persistence models."""
+
+from __future__ import annotations
+
+import uuid
+from decimal import Decimal
+from typing import TYPE_CHECKING
+
+from sqlalchemy import (
+    CheckConstraint,
+    Enum,
+    ForeignKey,
+    ForeignKeyConstraint,
+    Index,
+    Integer,
+    Numeric,
+    String,
+    Text,
+    UniqueConstraint,
+)
+from sqlalchemy.dialects.postgresql import JSONB, UUID
+from sqlalchemy.ext.mutable import MutableList
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from core.pull_requests import (
+    ApprovalDecision,
+    ApprovalKind,
+    PullRequestReviewDecision,
+    PullRequestStatus,
+)
+from infrastructure.database.append_only import AppendOnlyMixin
+from infrastructure.database.base import Base, CreatedAtMixin, TimestampMixin, UUIDPrimaryKeyMixin
+
+if TYPE_CHECKING:
+    from infrastructure.database.models.organization import Agent, Project
+    from infrastructure.database.models.work import Task
+
+
+class PullRequest(AppendOnlyMixin, UUIDPrimaryKeyMixin, TimestampMixin, Base):
+    """Provider-neutral internal pull-request aggregate."""
+
+    __tablename__ = "pull_requests"
+    __table_args__ = (
+        CheckConstraint("confidence BETWEEN 0 AND 1", name="confidence_range"),
+        CheckConstraint("insertions >= 0 AND deletions >= 0", name="line_counts_non_negative"),
+        CheckConstraint("commit_count >= 1", name="commit_count_positive"),
+        CheckConstraint("base_branch <> head_branch", name="branches_distinct"),
+        ForeignKeyConstraint(
+            ["project_id", "task_id"],
+            ["tasks.project_id", "tasks.id"],
+            name="task_project_scope",
+            ondelete="RESTRICT",
+        ),
+        Index("ix_pull_requests_project_status", "project_id", "status"),
+        Index("ix_pull_requests_task_created", "task_id", "created_at"),
+        Index("ix_pull_requests_head_sha", "head_sha"),
+        Index("uq_pull_requests_task_head", "task_id", "head_sha", unique=True),
+    )
+
+    project_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("projects.id", ondelete="RESTRICT"), nullable=False
+    )
+    task_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), nullable=False)
+    author_agent_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("agents.id", ondelete="RESTRICT"), nullable=False
+    )
+    base_branch: Mapped[str] = mapped_column(String(255), nullable=False)
+    base_sha: Mapped[str] = mapped_column(String(64), nullable=False)
+    head_branch: Mapped[str] = mapped_column(String(255), nullable=False)
+    head_sha: Mapped[str] = mapped_column(String(64), nullable=False)
+    preparation_checksum: Mapped[str] = mapped_column(String(64), nullable=False, unique=True)
+    title: Mapped[str] = mapped_column(String(200), nullable=False)
+    summary: Mapped[str] = mapped_column(Text, nullable=False)
+    changed_paths: Mapped[list[str]] = mapped_column(
+        MutableList.as_mutable(JSONB), default=list, nullable=False
+    )
+    insertions: Mapped[int] = mapped_column(Integer, nullable=False)
+    deletions: Mapped[int] = mapped_column(Integer, nullable=False)
+    commit_count: Mapped[int] = mapped_column(Integer, nullable=False)
+    tests: Mapped[list[dict[str, object]]] = mapped_column(
+        MutableList.as_mutable(JSONB), default=list, nullable=False
+    )
+    risks: Mapped[list[dict[str, object]]] = mapped_column(
+        MutableList.as_mutable(JSONB), default=list, nullable=False
+    )
+    confidence: Mapped[Decimal] = mapped_column(Numeric(5, 4), nullable=False)
+    status: Mapped[PullRequestStatus] = mapped_column(
+        Enum(PullRequestStatus, name="pull_request_status"),
+        default=PullRequestStatus.OPEN,
+        nullable=False,
+    )
+    correlation_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), nullable=False, unique=True
+    )
+
+    project: Mapped[Project] = relationship(back_populates="pull_requests")
+    task: Mapped[Task] = relationship(back_populates="pull_requests", foreign_keys=[task_id])
+    author: Mapped[Agent] = relationship(
+        back_populates="authored_pull_requests", foreign_keys=[author_agent_id]
+    )
+    reviews: Mapped[list[PullRequestReview]] = relationship(back_populates="pull_request")
+    approvals: Mapped[list[Approval]] = relationship(back_populates="pull_request")
+
+
+class PullRequestReview(AppendOnlyMixin, UUIDPrimaryKeyMixin, CreatedAtMixin, Base):
+    """Immutable independent review of one exact pull-request head."""
+
+    __tablename__ = "pull_request_reviews"
+    __table_args__ = (
+        CheckConstraint("confidence BETWEEN 0 AND 1", name="confidence_range"),
+        UniqueConstraint("pull_request_id", "head_sha", name="pull_request_head"),
+        UniqueConstraint("evidence_ref", name="evidence_ref"),
+        Index("ix_pull_request_reviews_pr_created", "pull_request_id", "created_at"),
+        Index("ix_pull_request_reviews_reviewer_created", "reviewer_agent_id", "created_at"),
+    )
+
+    pull_request_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("pull_requests.id", ondelete="RESTRICT"), nullable=False
+    )
+    reviewer_agent_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("agents.id", ondelete="RESTRICT"), nullable=False
+    )
+    decision: Mapped[PullRequestReviewDecision] = mapped_column(
+        Enum(PullRequestReviewDecision, name="pull_request_review_decision"), nullable=False
+    )
+    summary: Mapped[str] = mapped_column(String(4096), nullable=False)
+    confidence: Mapped[Decimal] = mapped_column(Numeric(5, 4), nullable=False)
+    head_sha: Mapped[str] = mapped_column(String(64), nullable=False)
+    evidence_ref: Mapped[str] = mapped_column(String(255), nullable=False)
+    correlation_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), nullable=False)
+
+    pull_request: Mapped[PullRequest] = relationship(back_populates="reviews")
+    reviewer: Mapped[Agent] = relationship(
+        back_populates="pull_request_reviews", foreign_keys=[reviewer_agent_id]
+    )
+
+
+class Approval(AppendOnlyMixin, UUIDPrimaryKeyMixin, CreatedAtMixin, Base):
+    """Immutable role-specific approval for one exact pull-request head."""
+
+    __tablename__ = "approvals"
+    __table_args__ = (
+        UniqueConstraint("pull_request_id", "kind", "head_sha", name="pull_request_kind_head"),
+        UniqueConstraint("evidence_ref", name="evidence_ref"),
+        Index("ix_approvals_pr_kind_created", "pull_request_id", "kind", "created_at"),
+        Index("ix_approvals_approver_created", "approver_agent_id", "created_at"),
+    )
+
+    pull_request_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("pull_requests.id", ondelete="RESTRICT"), nullable=False
+    )
+    kind: Mapped[ApprovalKind] = mapped_column(
+        Enum(ApprovalKind, name="approval_kind"), nullable=False
+    )
+    approver_agent_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("agents.id", ondelete="RESTRICT"), nullable=False
+    )
+    decision: Mapped[ApprovalDecision] = mapped_column(
+        Enum(ApprovalDecision, name="approval_decision"), nullable=False
+    )
+    head_sha: Mapped[str] = mapped_column(String(64), nullable=False)
+    evidence_ref: Mapped[str] = mapped_column(String(255), nullable=False)
+    correlation_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), nullable=False)
+
+    pull_request: Mapped[PullRequest] = relationship(back_populates="approvals")
+    approver: Mapped[Agent] = relationship(
+        back_populates="pull_request_approvals", foreign_keys=[approver_agent_id]
+    )

--- a/infrastructure/database/models/work.py
+++ b/infrastructure/database/models/work.py
@@ -22,6 +22,7 @@ if TYPE_CHECKING:
     from infrastructure.database.models.execution import AgentRun, Decision
     from infrastructure.database.models.history import AgentScore, AuditEvent
     from infrastructure.database.models.organization import Agent, Project
+    from infrastructure.database.models.pull_requests import PullRequest
 
 
 class Task(UUIDPrimaryKeyMixin, TimestampMixin, Base):
@@ -29,6 +30,7 @@ class Task(UUIDPrimaryKeyMixin, TimestampMixin, Base):
 
     __tablename__ = "tasks"
     __table_args__ = (
+        UniqueConstraint("project_id", "id", name="project_id_id"),
         CheckConstraint(
             "max_iterations >= 1 AND iteration_count >= 0 AND iteration_count <= max_iterations",
             name="iteration_bounds",
@@ -85,6 +87,9 @@ class Task(UUIDPrimaryKeyMixin, TimestampMixin, Base):
     decisions: Mapped[list[Decision]] = relationship(back_populates="task")
     scores: Mapped[list[AgentScore]] = relationship(back_populates="task")
     audit_events: Mapped[list[AuditEvent]] = relationship(back_populates="task")
+    pull_requests: Mapped[list[PullRequest]] = relationship(
+        back_populates="task", foreign_keys="PullRequest.task_id"
+    )
 
 
 class TaskDependency(UUIDPrimaryKeyMixin, CreatedAtMixin, Base):

--- a/infrastructure/database/repositories/__init__.py
+++ b/infrastructure/database/repositories/__init__.py
@@ -2,5 +2,16 @@
 
 from infrastructure.database.repositories.agent_scores import AgentScoreRepository
 from infrastructure.database.repositories.audit_events import AuditEventRepository
+from infrastructure.database.repositories.pull_requests import (
+    ApprovalRepository,
+    PullRequestRepository,
+    PullRequestReviewRepository,
+)
 
-__all__ = ["AgentScoreRepository", "AuditEventRepository"]
+__all__ = [
+    "AgentScoreRepository",
+    "ApprovalRepository",
+    "AuditEventRepository",
+    "PullRequestRepository",
+    "PullRequestReviewRepository",
+]

--- a/infrastructure/database/repositories/pull_requests.py
+++ b/infrastructure/database/repositories/pull_requests.py
@@ -1,0 +1,208 @@
+"""Bounded repositories for Phase 20 pull-request records."""
+
+from __future__ import annotations
+
+import uuid
+
+from pydantic import ValidationError
+from sqlalchemy import Select, select
+from sqlalchemy.orm import Session
+
+from core.git_workflow import PullRequestPreparation
+from core.pull_requests import (
+    ApprovalKind,
+    PullRequestRisk,
+    PullRequestStatus,
+    PullRequestTestEvidence,
+)
+from infrastructure.database.models import Approval, PullRequest, PullRequestReview
+
+
+def _limit(value: int) -> int:
+    if not 1 <= value <= 1000:
+        raise ValueError("limit must be between 1 and 1000")
+    return value
+
+
+def _offset(value: int) -> int:
+    if value < 0:
+        raise ValueError("offset must be non-negative")
+    return value
+
+
+class PullRequestRepository:
+    def __init__(self, session: Session) -> None:
+        self._session = session
+
+    def add(self, pull_request: PullRequest) -> PullRequest:
+        if pull_request.status is not None and pull_request.status is not PullRequestStatus.OPEN:
+            raise ValueError("new pull request must be open")
+        if pull_request.project is None or pull_request.task is None or pull_request.author is None:
+            raise ValueError("pull request scope is incomplete")
+        if (
+            pull_request.task.project_id != pull_request.project.id
+            or pull_request.task.assigned_agent_id != pull_request.author.id
+        ):
+            raise ValueError("pull request scope does not match task assignment")
+        try:
+            preparation = PullRequestPreparation(
+                project_id=pull_request.project.id,
+                task_id=pull_request.task.id,
+                correlation_id=pull_request.correlation_id,
+                base_branch=pull_request.base_branch,
+                base_sha=pull_request.base_sha,
+                head_branch=pull_request.head_branch,
+                head_sha=pull_request.head_sha,
+                title=pull_request.title,
+                summary=pull_request.summary,
+                changed_paths=tuple(pull_request.changed_paths),
+                insertions=pull_request.insertions,
+                deletions=pull_request.deletions,
+                commit_count=pull_request.commit_count,
+                author_logical_id=pull_request.author.slug,
+                checksum=pull_request.preparation_checksum,
+            )
+        except (TypeError, ValueError, ValidationError) as error:
+            del error
+            raise ValueError("pull request preparation is invalid") from None
+        if preparation.calculated_checksum() != pull_request.preparation_checksum:
+            raise ValueError("pull request preparation checksum is invalid")
+        if not 1 <= len(pull_request.tests) <= 32:
+            raise ValueError("pull request test evidence is invalid")
+        try:
+            pull_request.tests = [
+                PullRequestTestEvidence.model_validate(item).model_dump(mode="json")
+                for item in pull_request.tests
+            ]
+            pull_request.risks = [
+                PullRequestRisk.model_validate(item).model_dump(mode="json")
+                for item in pull_request.risks
+            ]
+        except (TypeError, ValueError, ValidationError) as error:
+            del error
+            raise ValueError("pull request test evidence is invalid") from None
+        if len(pull_request.risks) > 32:
+            raise ValueError("pull request risk evidence is invalid")
+        self._session.add(pull_request)
+        return pull_request
+
+    def get_by_id(self, pull_request_id: uuid.UUID) -> PullRequest | None:
+        return self._session.get(PullRequest, pull_request_id)
+
+    def list(
+        self,
+        *,
+        project_id: uuid.UUID | None = None,
+        task_id: uuid.UUID | None = None,
+        status: PullRequestStatus | None = None,
+        limit: int = 100,
+        offset: int = 0,
+    ) -> list[PullRequest]:
+        statement: Select[tuple[PullRequest]] = select(PullRequest)
+        if project_id is not None:
+            statement = statement.where(PullRequest.project_id == project_id)
+        if task_id is not None:
+            statement = statement.where(PullRequest.task_id == task_id)
+        if status is not None:
+            statement = statement.where(PullRequest.status == status)
+        statement = statement.order_by(PullRequest.created_at.desc(), PullRequest.id.desc())
+        statement = statement.limit(_limit(limit)).offset(_offset(offset))
+        return list(self._session.scalars(statement))
+
+
+class PullRequestReviewRepository:
+    def __init__(self, session: Session) -> None:
+        self._session = session
+
+    def add(self, review: PullRequestReview) -> PullRequestReview:
+        pull_request = review.pull_request or self._session.get(PullRequest, review.pull_request_id)
+        if pull_request is None:
+            raise ValueError("pull request does not exist")
+        reviewer_id = (
+            review.reviewer.id if review.reviewer is not None else review.reviewer_agent_id
+        )
+        if reviewer_id == pull_request.author_agent_id:
+            raise ValueError("pull request author cannot review")
+        if review.reviewer is None or review.reviewer.role != "Reviewer":
+            raise ValueError("pull request reviewer role is invalid")
+        if not 1 <= len(review.summary) <= 4096 or review.summary != review.summary.strip():
+            raise ValueError("pull request review summary is invalid")
+        if (
+            review.head_sha != pull_request.head_sha
+            or review.correlation_id != pull_request.correlation_id
+        ):
+            raise ValueError("review evidence scope does not match pull request")
+        self._session.add(review)
+        return review
+
+    def get_by_id(self, review_id: uuid.UUID) -> PullRequestReview | None:
+        return self._session.get(PullRequestReview, review_id)
+
+    def list(
+        self,
+        *,
+        pull_request_id: uuid.UUID,
+        limit: int = 100,
+        offset: int = 0,
+    ) -> list[PullRequestReview]:
+        statement = (
+            select(PullRequestReview)
+            .where(PullRequestReview.pull_request_id == pull_request_id)
+            .order_by(PullRequestReview.created_at.desc(), PullRequestReview.id.desc())
+            .limit(_limit(limit))
+            .offset(_offset(offset))
+        )
+        return list(self._session.scalars(statement))
+
+    def latest(self, pull_request_id: uuid.UUID) -> PullRequestReview | None:
+        items = self.list(pull_request_id=pull_request_id, limit=1)
+        return items[0] if items else None
+
+
+class ApprovalRepository:
+    def __init__(self, session: Session) -> None:
+        self._session = session
+
+    def add(self, approval: Approval) -> Approval:
+        pull_request = approval.pull_request or self._session.get(
+            PullRequest, approval.pull_request_id
+        )
+        if pull_request is None:
+            raise ValueError("pull request does not exist")
+        approver_id = (
+            approval.approver.id if approval.approver is not None else approval.approver_agent_id
+        )
+        if approver_id == pull_request.author_agent_id:
+            raise ValueError("pull request author cannot approve")
+        expected_role = {
+            ApprovalKind.REVIEWER: "Reviewer",
+            ApprovalKind.QA: "QA",
+            ApprovalKind.SECURITY: "Security",
+        }[approval.kind]
+        if approval.approver is None or approval.approver.role != expected_role:
+            raise ValueError("pull request approver role does not match approval kind")
+        if (
+            approval.head_sha != pull_request.head_sha
+            or approval.correlation_id != pull_request.correlation_id
+        ):
+            raise ValueError("approval evidence scope does not match pull request")
+        self._session.add(approval)
+        return approval
+
+    def get_by_id(self, approval_id: uuid.UUID) -> Approval | None:
+        return self._session.get(Approval, approval_id)
+
+    def list(
+        self,
+        *,
+        pull_request_id: uuid.UUID,
+        kind: ApprovalKind | None = None,
+        limit: int = 100,
+        offset: int = 0,
+    ) -> list[Approval]:
+        statement = select(Approval).where(Approval.pull_request_id == pull_request_id)
+        if kind is not None:
+            statement = statement.where(Approval.kind == kind)
+        statement = statement.order_by(Approval.created_at.desc(), Approval.id.desc())
+        statement = statement.limit(_limit(limit)).offset(_offset(offset))
+        return list(self._session.scalars(statement))

--- a/infrastructure/pull_requests/__init__.py
+++ b/infrastructure/pull_requests/__init__.py
@@ -1,0 +1,5 @@
+"""Phase 20 pull-request infrastructure adapters."""
+
+from infrastructure.pull_requests.gate import SQLAlchemyMergeGate
+
+__all__ = ["SQLAlchemyMergeGate"]

--- a/infrastructure/pull_requests/gate.py
+++ b/infrastructure/pull_requests/gate.py
@@ -1,0 +1,249 @@
+"""SQLAlchemy composition for the deterministic Phase 20 MergeGate."""
+
+from __future__ import annotations
+
+import uuid
+
+from sqlalchemy.orm import Session
+
+from core.enums import AuditActorType, AuditResult
+from core.pull_requests import (
+    ApprovalEvidence,
+    ApprovalKind,
+    MergeGate,
+    MergeGateDecision,
+    MergeGateReason,
+    MergeGateRequest,
+    MergeGateResult,
+    PullRequestCandidate,
+    PullRequestReviewEvidence,
+    PullRequestTestEvidence,
+)
+from infrastructure.database.models import Approval, AuditEvent, PullRequest
+from infrastructure.database.repositories import ApprovalRepository, PullRequestReviewRepository
+
+
+class SQLAlchemyMergeGate:
+    """Load persisted evidence and delegate the decision to the pure gate."""
+
+    def __init__(self, session: Session) -> None:
+        self._session = session
+        self._gate = MergeGate()
+
+    def evaluate(
+        self,
+        *,
+        pull_request_id: uuid.UUID,
+        expected_task_id: uuid.UUID,
+        git_evidence_event_id: uuid.UUID,
+    ) -> MergeGateResult:
+        try:
+            return self._evaluate(
+                pull_request_id=pull_request_id,
+                expected_task_id=expected_task_id,
+                git_evidence_event_id=git_evidence_event_id,
+            )
+        except Exception as error:
+            error.__traceback__ = None
+            del error
+            return _blocked(MergeGateReason.STALE_EVIDENCE)
+
+    def _evaluate(
+        self,
+        *,
+        pull_request_id: uuid.UUID,
+        expected_task_id: uuid.UUID,
+        git_evidence_event_id: uuid.UUID,
+    ) -> MergeGateResult:
+        pull_request = self._session.get(PullRequest, pull_request_id)
+        if pull_request is None:
+            return _blocked(MergeGateReason.STALE_EVIDENCE)
+
+        extra_reasons: set[MergeGateReason] = set()
+        if pull_request.task.project_id != pull_request.project_id:
+            extra_reasons.add(MergeGateReason.PROJECT_TASK_MISMATCH)
+        if pull_request.task.assigned_agent_id != pull_request.author_agent_id:
+            extra_reasons.add(MergeGateReason.AUTHOR_TASK_MISMATCH)
+
+        review_model = PullRequestReviewRepository(self._session).latest(pull_request_id)
+        review = None
+        if review_model is not None:
+            review = PullRequestReviewEvidence(
+                reviewer_agent_id=review_model.reviewer_agent_id,
+                reviewer_role=review_model.reviewer.role,
+                decision=review_model.decision,
+                head_sha=review_model.head_sha,
+                correlation_id=review_model.correlation_id,
+            )
+
+        latest_approvals: dict[ApprovalKind, Approval] = {}
+        for approval in ApprovalRepository(self._session).list(pull_request_id=pull_request_id):
+            latest_approvals.setdefault(approval.kind, approval)
+
+        tests = tuple(PullRequestTestEvidence.model_validate(item) for item in pull_request.tests)
+        git_event = self._session.get(AuditEvent, git_evidence_event_id)
+        branch_mergeable = _valid_git_event(git_event, pull_request)
+        if not branch_mergeable:
+            extra_reasons.update(
+                {MergeGateReason.BRANCH_NOT_MERGEABLE, MergeGateReason.STALE_EVIDENCE}
+            )
+
+        review_approval = latest_approvals.get(ApprovalKind.REVIEWER)
+        qa_approval = latest_approvals.get(ApprovalKind.QA)
+        security_approval = latest_approvals.get(ApprovalKind.SECURITY)
+        if not _valid_approval_event(
+            self._event_for(review_approval),
+            pull_request,
+            review_approval,
+            event_type="REVIEW_COMPLETED",
+            expected_action="record_workflow_checkpoint",
+            expected_decision="APPROVED",
+        ):
+            extra_reasons.update(
+                {MergeGateReason.REVIEW_NOT_APPROVED, MergeGateReason.REVIEWER_APPROVAL_MISSING}
+            )
+        qa_event = self._event_for(qa_approval)
+        if not _valid_approval_event(
+            qa_event,
+            pull_request,
+            qa_approval,
+            event_type="QA_COMPLETED",
+            expected_action="record_qa_checkpoint",
+            expected_decision="PASSED",
+        ):
+            extra_reasons.add(MergeGateReason.QA_NOT_PASSED)
+        if not _tests_match_qa_event(tests, qa_event):
+            extra_reasons.add(MergeGateReason.TESTS_NOT_PASSED)
+        security_event = self._event_for(security_approval)
+        if not _valid_approval_event(
+            security_event,
+            pull_request,
+            security_approval,
+            event_type="SECURITY_COMPLETED",
+            expected_action="record_security_checkpoint",
+            expected_decision="PASS",
+        ) or not _valid_security_scan(security_event):
+            extra_reasons.add(MergeGateReason.SECURITY_BLOCKED)
+
+        request = MergeGateRequest(
+            expected_task_id=expected_task_id,
+            candidate=PullRequestCandidate(
+                pull_request_id=pull_request.id,
+                project_id=pull_request.project_id,
+                task_id=pull_request.task_id,
+                author_agent_id=pull_request.author_agent_id,
+                head_sha=pull_request.head_sha,
+                confidence=float(pull_request.confidence),
+                correlation_id=pull_request.correlation_id,
+            ),
+            review=review,
+            approvals=tuple(
+                ApprovalEvidence(
+                    kind=approval.kind,
+                    approver_agent_id=approval.approver_agent_id,
+                    approver_role=approval.approver.role,
+                    decision=approval.decision,
+                    head_sha=approval.head_sha,
+                    correlation_id=approval.correlation_id,
+                )
+                for approval in latest_approvals.values()
+            ),
+            tests=tests,
+            branch_mergeable=branch_mergeable,
+        )
+        result = self._gate.evaluate(request)
+        reasons = set(result.reasons) | extra_reasons
+        ordered = tuple(reason for reason in MergeGateReason if reason in reasons)
+        if ordered:
+            return MergeGateResult(decision=MergeGateDecision.BLOCK, reasons=ordered)
+        return result
+
+    def _event_for(self, approval: Approval | None) -> AuditEvent | None:
+        if approval is None or not approval.evidence_ref.startswith("audit:"):
+            return None
+        try:
+            event_id = uuid.UUID(approval.evidence_ref.removeprefix("audit:"))
+        except ValueError:
+            return None
+        return self._session.get(AuditEvent, event_id)
+
+
+def _common_event_scope(event: AuditEvent | None, pull_request: PullRequest) -> bool:
+    return bool(
+        event is not None
+        and event.actor_type is AuditActorType.AGENT
+        and event.result is AuditResult.SUCCEEDED
+        and event.project_id == pull_request.project_id
+        and event.task_id == pull_request.task_id
+        and event.correlation_id == pull_request.correlation_id
+    )
+
+
+def _valid_git_event(event: AuditEvent | None, pull_request: PullRequest) -> bool:
+    return bool(
+        _common_event_scope(event, pull_request)
+        and event is not None
+        and event.actor_id == pull_request.author.slug
+        and event.event_type == "GIT_OPERATION_COMPLETED"
+        and event.action == "validate_merge_requirements"
+        and event.data.get("merge_decision") == "PASS"
+        and event.data.get("preparation_checksum") == pull_request.preparation_checksum
+        and event.data.get("commit_sha") == pull_request.head_sha
+        and event.data.get("base_sha") == pull_request.base_sha
+    )
+
+
+def _valid_approval_event(
+    event: AuditEvent | None,
+    pull_request: PullRequest,
+    approval: Approval | None,
+    *,
+    event_type: str,
+    expected_action: str,
+    expected_decision: str,
+) -> bool:
+    return bool(
+        approval is not None
+        and _common_event_scope(event, pull_request)
+        and event is not None
+        and event.actor_id == approval.approver.slug
+        and event.event_type == event_type
+        and event.action == expected_action
+        and event.data.get("decision") == expected_decision
+        and event.data.get("head_sha") == pull_request.head_sha
+        and event.data.get("preparation_checksum") == pull_request.preparation_checksum
+    )
+
+
+def _valid_security_scan(event: AuditEvent | None) -> bool:
+    return bool(
+        event is not None
+        and event.data.get("scanner_complete") is True
+        and event.data.get("scanner_truncated") is False
+        and event.data.get("confirmed_blocker_count") == 0
+    )
+
+
+def _tests_match_qa_event(
+    tests: tuple[PullRequestTestEvidence, ...], event: AuditEvent | None
+) -> bool:
+    if not tests or event is None or any(not item.passed or item.truncated for item in tests):
+        return False
+    event_tests = event.data.get("tests")
+    if not isinstance(event_tests, list):
+        return False
+    expected = sorted((item.name, "SUCCEEDED") for item in tests)
+    actual: list[tuple[str, str]] = []
+    for item in event_tests:
+        if not isinstance(item, dict):
+            return False
+        profile_id = item.get("profile_id")
+        status = item.get("status")
+        if not isinstance(profile_id, str) or not isinstance(status, str):
+            return False
+        actual.append((profile_id, status))
+    return sorted(actual) == expected
+
+
+def _blocked(*reasons: MergeGateReason) -> MergeGateResult:
+    return MergeGateResult(decision=MergeGateDecision.BLOCK, reasons=reasons)

--- a/tests/database/test_migrations.py
+++ b/tests/database/test_migrations.py
@@ -14,9 +14,12 @@ EXPECTED_TABLES = {
     "agent_runs",
     "agent_scores",
     "agents",
+    "approvals",
     "audit_events",
     "decisions",
     "projects",
+    "pull_request_reviews",
+    "pull_requests",
     "task_dependencies",
     "tasks",
     "tool_calls",
@@ -37,7 +40,13 @@ def test_migration_supports_upgrade_downgrade_and_second_upgrade(
     command.upgrade(config, "20260825_0001")
     engine = create_engine(migration_database_url)
     try:
-        assert set(inspect(engine).get_table_names()) >= EXPECTED_TABLES - {"agent_permissions"}
+        phase_2_tables = EXPECTED_TABLES - {
+            "agent_permissions",
+            "approvals",
+            "pull_request_reviews",
+            "pull_requests",
+        }
+        assert set(inspect(engine).get_table_names()) >= phase_2_tables
         project_id = uuid.uuid4()
         task_ids = [uuid.uuid4() for _ in range(4)]
         with engine.begin() as connection:

--- a/tests/database/test_pull_requests.py
+++ b/tests/database/test_pull_requests.py
@@ -1,0 +1,990 @@
+"""Real-PostgreSQL tests for the Phase 20 internal pull-request model."""
+
+from __future__ import annotations
+
+import uuid
+from decimal import Decimal
+from pathlib import Path
+
+import pytest
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm import Session
+
+from core.enums import AgentSeniority, AuditActorType, AuditResult
+from core.git_workflow import PullRequestPreparation
+from core.pull_requests import (
+    ApprovalDecision,
+    ApprovalKind,
+    MergeGateDecision,
+    MergeGateReason,
+    PullRequestReviewDecision,
+    PullRequestStatus,
+)
+from infrastructure.database.append_only import AppendOnlyViolationError
+from infrastructure.database.models import (
+    Agent,
+    Approval,
+    AuditEvent,
+    Project,
+    PullRequest,
+    PullRequestReview,
+    Task,
+)
+from infrastructure.database.repositories import (
+    ApprovalRepository,
+    PullRequestRepository,
+    PullRequestReviewRepository,
+)
+from infrastructure.pull_requests import SQLAlchemyMergeGate
+from tests.workflows.factories import persisted_workflow_request
+from tests.workflows.qa_factories import persisted_qa_workflow_request
+from tests.workflows.security_factories import persisted_security_workflow_request
+
+
+def _agent(slug: str, role: str) -> Agent:
+    return Agent(
+        name=slug.replace("-", " ").title(),
+        slug=slug,
+        role=role,
+        department="Engineering",
+        seniority=AgentSeniority.ENGINEER,
+    )
+
+
+def _scope(db_session: Session) -> tuple[Project, Task, Agent, Agent, Agent, Agent]:
+    developer = _agent("phase20-developer", "Developer")
+    reviewer = _agent("phase20-reviewer", "Reviewer")
+    qa = _agent("phase20-qa", "QA")
+    security = _agent("phase20-security", "Security")
+    project = Project(name="Phase 20 project")
+    task = Task(project=project, title="Materialize pull request", assigned_agent=developer)
+    db_session.add_all([developer, reviewer, qa, security, project, task])
+    db_session.flush()
+    return project, task, developer, reviewer, qa, security
+
+
+def _pull_request(
+    project: Project,
+    task: Task,
+    developer: Agent,
+    *,
+    correlation_id: uuid.UUID | None = None,
+) -> PullRequest:
+    head_sha = "a" * 40
+    effective_correlation_id = correlation_id or uuid.uuid4()
+    preparation = PullRequestPreparation(
+        project_id=project.id,
+        task_id=task.id,
+        correlation_id=effective_correlation_id,
+        base_branch="main",
+        base_sha="b" * 40,
+        head_branch=f"feature/{task.id}-pull-request-model",
+        head_sha=head_sha,
+        title="feat(pr): materialize validation workflow",
+        summary="Persist bounded validation evidence.",
+        changed_paths=("core/pull_requests/types.py",),
+        insertions=120,
+        deletions=4,
+        commit_count=2,
+        author_logical_id=developer.slug,
+        checksum="0" * 64,
+    )
+    preparation = preparation.model_copy(update={"checksum": preparation.calculated_checksum()})
+    return PullRequest(
+        project=project,
+        task=task,
+        author=developer,
+        base_branch="main",
+        base_sha="b" * 40,
+        head_branch=f"feature/{task.id}-pull-request-model",
+        head_sha=head_sha,
+        preparation_checksum=preparation.checksum,
+        title="feat(pr): materialize validation workflow",
+        summary="Persist bounded validation evidence.",
+        changed_paths=["core/pull_requests/types.py"],
+        insertions=120,
+        deletions=4,
+        commit_count=2,
+        tests=[{"name": "pytest", "passed": True, "truncated": False, "head_sha": head_sha}],
+        risks=[{"severity": "LOW", "summary": "Internal model only"}],
+        confidence=Decimal("0.8000"),
+        correlation_id=effective_correlation_id,
+    )
+
+
+def _event(
+    pull_request: PullRequest,
+    *,
+    actor: Agent,
+    event_type: str,
+    action: str,
+    data: dict[str, object],
+) -> AuditEvent:
+    resource_type = {
+        "REVIEW_COMPLETED": "DEVELOPER_REVIEWER_WORKFLOW",
+        "QA_COMPLETED": "QA_WORKFLOW",
+        "SECURITY_COMPLETED": "SECURITY_WORKFLOW",
+    }.get(event_type, "PULL_REQUEST_EVIDENCE")
+    return AuditEvent(
+        actor_type=AuditActorType.AGENT,
+        actor_id=actor.slug,
+        project_id=pull_request.project_id,
+        task_id=pull_request.task_id,
+        event_type=event_type,
+        action=action,
+        resource_type=resource_type,
+        resource_id=str(pull_request.task_id),
+        result=AuditResult.SUCCEEDED,
+        data=data,
+        correlation_id=pull_request.correlation_id,
+    )
+
+
+def _persist_complete_evidence(
+    db_session: Session,
+    pull_request: PullRequest,
+    *,
+    developer: Agent,
+    reviewer: Agent,
+    qa: Agent,
+    security: Agent,
+    review_action: str = "record_workflow_checkpoint",
+    qa_action: str = "record_qa_checkpoint",
+    security_action: str = "record_security_checkpoint",
+    git_actor_type: AuditActorType = AuditActorType.AGENT,
+    git_base_sha: str | None = None,
+    qa_tests: list[dict[str, str]] | None = None,
+    security_data: dict[str, object] | None = None,
+) -> AuditEvent:
+    evidence_scope = {
+        "head_sha": pull_request.head_sha,
+        "preparation_checksum": pull_request.preparation_checksum,
+    }
+    review_event = _event(
+        pull_request,
+        actor=reviewer,
+        event_type="REVIEW_COMPLETED",
+        action=review_action,
+        data={"decision": "APPROVED", **evidence_scope},
+    )
+    qa_event = _event(
+        pull_request,
+        actor=qa,
+        event_type="QA_COMPLETED",
+        action=qa_action,
+        data={
+            "decision": "PASSED",
+            "tests": qa_tests
+            if qa_tests is not None
+            else [{"profile_id": "pytest", "status": "SUCCEEDED"}],
+            **evidence_scope,
+        },
+    )
+    security_event = _event(
+        pull_request,
+        actor=security,
+        event_type="SECURITY_COMPLETED",
+        action=security_action,
+        data={
+            **(
+                security_data
+                if security_data is not None
+                else {
+                    "decision": "PASS",
+                    "scanner_complete": True,
+                    "scanner_truncated": False,
+                    "confirmed_blocker_count": 0,
+                }
+            ),
+            **evidence_scope,
+        },
+    )
+    git_event = _event(
+        pull_request,
+        actor=developer,
+        event_type="GIT_OPERATION_COMPLETED",
+        action="validate_merge_requirements",
+        data={
+            "merge_decision": "PASS",
+            "preparation_checksum": pull_request.preparation_checksum,
+            "commit_sha": pull_request.head_sha,
+            "base_sha": git_base_sha or pull_request.base_sha,
+        },
+    )
+    git_event.actor_type = git_actor_type
+    db_session.add_all([review_event, qa_event, security_event, git_event])
+    db_session.flush()
+    PullRequestReviewRepository(db_session).add(
+        PullRequestReview(
+            pull_request=pull_request,
+            reviewer=reviewer,
+            decision=PullRequestReviewDecision.APPROVED,
+            summary="Approved.",
+            confidence=Decimal("0.9000"),
+            head_sha=pull_request.head_sha,
+            evidence_ref=f"audit:{review_event.id}",
+            correlation_id=pull_request.correlation_id,
+        )
+    )
+    approvals = ApprovalRepository(db_session)
+    for kind, agent, event in (
+        (ApprovalKind.REVIEWER, reviewer, review_event),
+        (ApprovalKind.QA, qa, qa_event),
+        (ApprovalKind.SECURITY, security, security_event),
+    ):
+        approvals.add(
+            Approval(
+                pull_request=pull_request,
+                kind=kind,
+                approver=agent,
+                decision=ApprovalDecision.APPROVED,
+                head_sha=pull_request.head_sha,
+                evidence_ref=f"audit:{event.id}",
+                correlation_id=pull_request.correlation_id,
+            )
+        )
+    db_session.flush()
+    return git_event
+
+
+def test_pull_request_repository_persists_and_reads_complete_internal_model(
+    db_session: Session,
+) -> None:
+    project, task, developer, _, _, _ = _scope(db_session)
+    repository = PullRequestRepository(db_session)
+    pull_request = repository.add(_pull_request(project, task, developer))
+    db_session.commit()
+
+    loaded = repository.get_by_id(pull_request.id)
+
+    assert loaded is pull_request
+    assert loaded.status is PullRequestStatus.OPEN
+    assert loaded.task_id == task.id
+    assert loaded.author_agent_id == developer.id
+    assert loaded.changed_paths == ["core/pull_requests/types.py"]
+    assert loaded.tests[0]["passed"] is True
+    assert loaded.risks[0]["severity"] == "LOW"
+    assert repository.list(project_id=project.id, task_id=task.id) == [pull_request]
+
+
+def test_review_and_approvals_are_append_only_and_readable(db_session: Session) -> None:
+    project, task, developer, reviewer, qa, security = _scope(db_session)
+    pull_request = PullRequestRepository(db_session).add(_pull_request(project, task, developer))
+    db_session.flush()
+    review_repository = PullRequestReviewRepository(db_session)
+    approval_repository = ApprovalRepository(db_session)
+    review = review_repository.add(
+        PullRequestReview(
+            pull_request=pull_request,
+            reviewer=reviewer,
+            decision=PullRequestReviewDecision.APPROVED,
+            summary="Independent review passed.",
+            confidence=Decimal("0.9000"),
+            head_sha=pull_request.head_sha,
+            evidence_ref="audit:review",
+            correlation_id=pull_request.correlation_id,
+        )
+    )
+    for kind, agent in (
+        (ApprovalKind.REVIEWER, reviewer),
+        (ApprovalKind.QA, qa),
+        (ApprovalKind.SECURITY, security),
+    ):
+        approval_repository.add(
+            Approval(
+                pull_request=pull_request,
+                kind=kind,
+                approver=agent,
+                decision=ApprovalDecision.APPROVED,
+                head_sha=pull_request.head_sha,
+                evidence_ref=f"audit:{kind.value.lower()}",
+                correlation_id=pull_request.correlation_id,
+            )
+        )
+    db_session.commit()
+
+    assert review_repository.latest(pull_request.id) is review
+    assert len(approval_repository.list(pull_request_id=pull_request.id)) == 3
+
+    review.summary = "Mutated"
+    with pytest.raises(AppendOnlyViolationError, match="append-only"):
+        db_session.flush()
+    db_session.rollback()
+
+    stored_approval = approval_repository.list(pull_request_id=pull_request.id)[0]
+    db_session.delete(stored_approval)
+    with pytest.raises(AppendOnlyViolationError, match="append-only"):
+        db_session.flush()
+
+
+def test_repositories_reject_self_review_stale_evidence_and_author_approval(
+    db_session: Session,
+) -> None:
+    project, task, developer, reviewer, _, _ = _scope(db_session)
+    pull_request = PullRequestRepository(db_session).add(_pull_request(project, task, developer))
+    db_session.flush()
+
+    with pytest.raises(ValueError, match="author cannot review"):
+        PullRequestReviewRepository(db_session).add(
+            PullRequestReview(
+                pull_request=pull_request,
+                reviewer=developer,
+                decision=PullRequestReviewDecision.APPROVED,
+                summary="Invalid self review.",
+                confidence=Decimal("1.0000"),
+                head_sha=pull_request.head_sha,
+                evidence_ref="audit:self-review",
+                correlation_id=pull_request.correlation_id,
+            )
+        )
+
+    with pytest.raises(ValueError, match="evidence scope does not match"):
+        PullRequestReviewRepository(db_session).add(
+            PullRequestReview(
+                pull_request=pull_request,
+                reviewer=reviewer,
+                decision=PullRequestReviewDecision.APPROVED,
+                summary="Stale review.",
+                confidence=Decimal("0.9000"),
+                head_sha="d" * 40,
+                evidence_ref="audit:stale-review",
+                correlation_id=pull_request.correlation_id,
+            )
+        )
+
+    with pytest.raises(ValueError, match="author cannot approve"):
+        ApprovalRepository(db_session).add(
+            Approval(
+                pull_request=pull_request,
+                kind=ApprovalKind.QA,
+                approver=developer,
+                decision=ApprovalDecision.APPROVED,
+                head_sha=pull_request.head_sha,
+                evidence_ref="audit:invalid",
+                correlation_id=pull_request.correlation_id,
+            )
+        )
+
+    wrong_reviewer = _agent("phase20-wrong-reviewer", "QA")
+    with pytest.raises(ValueError, match="reviewer role is invalid"):
+        PullRequestReviewRepository(db_session).add(
+            PullRequestReview(
+                pull_request=pull_request,
+                reviewer=wrong_reviewer,
+                decision=PullRequestReviewDecision.APPROVED,
+                summary="Wrong role.",
+                confidence=Decimal("0.9000"),
+                head_sha=pull_request.head_sha,
+                evidence_ref="audit:wrong-role",
+                correlation_id=pull_request.correlation_id,
+            )
+        )
+
+
+def test_pull_request_is_immutable_and_cannot_be_marked_mergeable_directly(
+    db_session: Session,
+) -> None:
+    project, task, developer, _, _, _ = _scope(db_session)
+    pull_request = PullRequestRepository(db_session).add(_pull_request(project, task, developer))
+    db_session.commit()
+
+    pull_request.status = PullRequestStatus.READY_TO_MERGE
+    with pytest.raises(AppendOnlyViolationError, match="append-only"):
+        db_session.flush()
+
+
+def test_pull_request_repository_rejects_unbound_or_unallowlisted_metadata(
+    db_session: Session,
+) -> None:
+    project, task, developer, _, _, _ = _scope(db_session)
+    repository = PullRequestRepository(db_session)
+    invalid_checksum = _pull_request(project, task, developer)
+    invalid_checksum.preparation_checksum = "d" * 64
+    with pytest.raises(ValueError, match="preparation checksum is invalid"):
+        repository.add(invalid_checksum)
+
+    unsafe_metadata = _pull_request(project, task, developer)
+    unsafe_metadata.tests = [
+        {
+            "name": "pytest",
+            "passed": True,
+            "truncated": False,
+            "head_sha": unsafe_metadata.head_sha,
+            "stdout": "must not be persisted",
+        }
+    ]
+    with pytest.raises(ValueError, match="test evidence is invalid"):
+        repository.add(unsafe_metadata)
+
+
+def test_approval_kind_must_match_the_approver_role(db_session: Session) -> None:
+    project, task, developer, reviewer, _, _ = _scope(db_session)
+    pull_request = PullRequestRepository(db_session).add(_pull_request(project, task, developer))
+    db_session.flush()
+
+    with pytest.raises(ValueError, match="approver role does not match"):
+        ApprovalRepository(db_session).add(
+            Approval(
+                pull_request=pull_request,
+                kind=ApprovalKind.QA,
+                approver=reviewer,
+                decision=ApprovalDecision.APPROVED,
+                head_sha=pull_request.head_sha,
+                evidence_ref="audit:wrong-role",
+                correlation_id=pull_request.correlation_id,
+            )
+        )
+
+
+def test_sqlalchemy_merge_gate_passes_complete_latest_evidence(db_session: Session) -> None:
+    project, task, developer, reviewer, qa, security = _scope(db_session)
+    pull_request = PullRequestRepository(db_session).add(_pull_request(project, task, developer))
+    db_session.flush()
+    review_event = _event(
+        pull_request,
+        actor=reviewer,
+        event_type="REVIEW_COMPLETED",
+        action="record_workflow_checkpoint",
+        data={
+            "decision": "APPROVED",
+            "head_sha": pull_request.head_sha,
+            "preparation_checksum": pull_request.preparation_checksum,
+        },
+    )
+    qa_event = _event(
+        pull_request,
+        actor=qa,
+        event_type="QA_COMPLETED",
+        action="record_qa_checkpoint",
+        data={
+            "decision": "PASSED",
+            "tests": [{"profile_id": "pytest", "status": "SUCCEEDED"}],
+            "head_sha": pull_request.head_sha,
+            "preparation_checksum": pull_request.preparation_checksum,
+        },
+    )
+    security_event = _event(
+        pull_request,
+        actor=security,
+        event_type="SECURITY_COMPLETED",
+        action="record_security_checkpoint",
+        data={
+            "decision": "PASS",
+            "scanner_complete": True,
+            "scanner_truncated": False,
+            "confirmed_blocker_count": 0,
+            "head_sha": pull_request.head_sha,
+            "preparation_checksum": pull_request.preparation_checksum,
+        },
+    )
+    git_event = _event(
+        pull_request,
+        actor=developer,
+        event_type="GIT_OPERATION_COMPLETED",
+        action="validate_merge_requirements",
+        data={
+            "merge_decision": "PASS",
+            "preparation_checksum": pull_request.preparation_checksum,
+            "commit_sha": pull_request.head_sha,
+            "base_sha": pull_request.base_sha,
+        },
+    )
+    db_session.add_all([review_event, qa_event, security_event, git_event])
+    db_session.flush()
+    PullRequestReviewRepository(db_session).add(
+        PullRequestReview(
+            pull_request=pull_request,
+            reviewer=reviewer,
+            decision=PullRequestReviewDecision.APPROVED,
+            summary="Approved.",
+            confidence=Decimal("0.9000"),
+            head_sha=pull_request.head_sha,
+            evidence_ref=f"audit:{review_event.id}",
+            correlation_id=pull_request.correlation_id,
+        )
+    )
+    approvals = ApprovalRepository(db_session)
+    for kind, agent, event in (
+        (ApprovalKind.REVIEWER, reviewer, review_event),
+        (ApprovalKind.QA, qa, qa_event),
+        (ApprovalKind.SECURITY, security, security_event),
+    ):
+        approvals.add(
+            Approval(
+                pull_request=pull_request,
+                kind=kind,
+                approver=agent,
+                decision=ApprovalDecision.APPROVED,
+                head_sha=pull_request.head_sha,
+                evidence_ref=f"audit:{event.id}",
+                correlation_id=pull_request.correlation_id,
+            )
+        )
+    db_session.flush()
+
+    result = SQLAlchemyMergeGate(db_session).evaluate(
+        pull_request_id=pull_request.id,
+        expected_task_id=task.id,
+        git_evidence_event_id=git_event.id,
+    )
+
+    assert result.decision is MergeGateDecision.PASS
+    assert result.reasons == ()
+
+
+def test_sqlalchemy_merge_gate_fails_closed_when_evidence_is_missing(db_session: Session) -> None:
+    project, task, developer, _, _, _ = _scope(db_session)
+    pull_request = PullRequestRepository(db_session).add(_pull_request(project, task, developer))
+    db_session.flush()
+    git_event = _event(
+        pull_request,
+        actor=developer,
+        event_type="GIT_OPERATION_COMPLETED",
+        action="validate_merge_requirements",
+        data={
+            "merge_decision": "PASS",
+            "preparation_checksum": pull_request.preparation_checksum,
+            "commit_sha": pull_request.head_sha,
+            "base_sha": pull_request.base_sha,
+        },
+    )
+    db_session.add(git_event)
+    db_session.flush()
+
+    result = SQLAlchemyMergeGate(db_session).evaluate(
+        pull_request_id=pull_request.id,
+        expected_task_id=task.id,
+        git_evidence_event_id=git_event.id,
+    )
+
+    assert result.decision is MergeGateDecision.BLOCK
+    assert MergeGateReason.REVIEW_NOT_APPROVED in result.reasons
+    assert MergeGateReason.QA_NOT_PASSED in result.reasons
+    assert MergeGateReason.SECURITY_BLOCKED in result.reasons
+
+
+def test_phase20_repositories_expose_no_merge_update_or_delete_methods(
+    db_session: Session,
+) -> None:
+    forbidden = {"delete", "merge", "save", "update", "mark_merged"}
+    repositories = (
+        PullRequestRepository(db_session),
+        PullRequestReviewRepository(db_session),
+        ApprovalRepository(db_session),
+    )
+    assert all(forbidden.isdisjoint(dir(repository)) for repository in repositories)
+
+
+@pytest.mark.parametrize(
+    (
+        "git_actor_type",
+        "review_action",
+        "qa_action",
+        "security_action",
+        "security_data",
+        "expected_reason",
+    ),
+    [
+        (
+            AuditActorType.SYSTEM,
+            "record_workflow_checkpoint",
+            "record_qa_checkpoint",
+            "record_security_checkpoint",
+            None,
+            MergeGateReason.STALE_EVIDENCE,
+        ),
+        (
+            AuditActorType.AGENT,
+            "untrusted_review",
+            "record_qa_checkpoint",
+            "record_security_checkpoint",
+            None,
+            MergeGateReason.REVIEW_NOT_APPROVED,
+        ),
+        (
+            AuditActorType.AGENT,
+            "record_workflow_checkpoint",
+            "untrusted_qa",
+            "record_security_checkpoint",
+            None,
+            MergeGateReason.QA_NOT_PASSED,
+        ),
+        (
+            AuditActorType.AGENT,
+            "record_workflow_checkpoint",
+            "record_qa_checkpoint",
+            "untrusted_security",
+            None,
+            MergeGateReason.SECURITY_BLOCKED,
+        ),
+        (
+            AuditActorType.AGENT,
+            "record_workflow_checkpoint",
+            "record_qa_checkpoint",
+            "record_security_checkpoint",
+            {
+                "decision": "PASS",
+                "scanner_complete": False,
+                "scanner_truncated": False,
+                "confirmed_blocker_count": 0,
+            },
+            MergeGateReason.SECURITY_BLOCKED,
+        ),
+        (
+            AuditActorType.AGENT,
+            "record_workflow_checkpoint",
+            "record_qa_checkpoint",
+            "record_security_checkpoint",
+            {
+                "decision": "PASS",
+                "scanner_complete": True,
+                "scanner_truncated": True,
+                "confirmed_blocker_count": 0,
+            },
+            MergeGateReason.SECURITY_BLOCKED,
+        ),
+        (
+            AuditActorType.AGENT,
+            "record_workflow_checkpoint",
+            "record_qa_checkpoint",
+            "record_security_checkpoint",
+            {
+                "decision": "PASS",
+                "scanner_complete": True,
+                "scanner_truncated": False,
+                "confirmed_blocker_count": 1,
+            },
+            MergeGateReason.SECURITY_BLOCKED,
+        ),
+    ],
+)
+def test_sqlalchemy_merge_gate_rejects_untrusted_audit_evidence(
+    db_session: Session,
+    git_actor_type: AuditActorType,
+    review_action: str,
+    qa_action: str,
+    security_action: str,
+    security_data: dict[str, object] | None,
+    expected_reason: MergeGateReason,
+) -> None:
+    project, task, developer, reviewer, qa, security = _scope(db_session)
+    pull_request = PullRequestRepository(db_session).add(_pull_request(project, task, developer))
+    db_session.flush()
+    git_event = _persist_complete_evidence(
+        db_session,
+        pull_request,
+        developer=developer,
+        reviewer=reviewer,
+        qa=qa,
+        security=security,
+        git_actor_type=git_actor_type,
+        review_action=review_action,
+        qa_action=qa_action,
+        security_action=security_action,
+        security_data=security_data,
+    )
+
+    result = SQLAlchemyMergeGate(db_session).evaluate(
+        pull_request_id=pull_request.id,
+        expected_task_id=task.id,
+        git_evidence_event_id=git_event.id,
+    )
+
+    assert result.decision is MergeGateDecision.BLOCK
+    assert expected_reason in result.reasons
+
+
+def test_sqlalchemy_merge_gate_rejects_fabricated_pull_request_test_summary(
+    db_session: Session,
+) -> None:
+    project, task, developer, reviewer, qa, security = _scope(db_session)
+    pull_request = PullRequestRepository(db_session).add(_pull_request(project, task, developer))
+    db_session.flush()
+    git_event = _persist_complete_evidence(
+        db_session,
+        pull_request,
+        developer=developer,
+        reviewer=reviewer,
+        qa=qa,
+        security=security,
+        qa_tests=[{"profile_id": "ruff", "status": "SUCCEEDED"}],
+    )
+
+    result = SQLAlchemyMergeGate(db_session).evaluate(
+        pull_request_id=pull_request.id,
+        expected_task_id=task.id,
+        git_evidence_event_id=git_event.id,
+    )
+
+    assert result.decision is MergeGateDecision.BLOCK
+    assert MergeGateReason.TESTS_NOT_PASSED in result.reasons
+
+
+def test_postgresql_rejects_reusing_review_evidence_for_another_pull_request(
+    db_session: Session,
+) -> None:
+    project, task, developer, reviewer, _, _ = _scope(db_session)
+    other_task = Task(project=project, title="Second pull request", assigned_agent=developer)
+    db_session.add(other_task)
+    db_session.flush()
+    pull_requests = (
+        PullRequestRepository(db_session).add(_pull_request(project, task, developer)),
+        PullRequestRepository(db_session).add(_pull_request(project, other_task, developer)),
+    )
+    db_session.flush()
+    repository = PullRequestReviewRepository(db_session)
+    for pull_request in pull_requests:
+        repository.add(
+            PullRequestReview(
+                pull_request=pull_request,
+                reviewer=reviewer,
+                decision=PullRequestReviewDecision.APPROVED,
+                summary="Approved.",
+                confidence=Decimal("0.9000"),
+                head_sha=pull_request.head_sha,
+                evidence_ref="audit:single-review-event",
+                correlation_id=pull_request.correlation_id,
+            )
+        )
+
+    with pytest.raises(IntegrityError):
+        db_session.flush()
+
+
+def test_postgresql_rejects_reusing_approval_evidence_for_another_pull_request(
+    db_session: Session,
+) -> None:
+    project, task, developer, reviewer, _, _ = _scope(db_session)
+    other_task = Task(project=project, title="Second pull request", assigned_agent=developer)
+    db_session.add(other_task)
+    db_session.flush()
+    pull_requests = (
+        PullRequestRepository(db_session).add(_pull_request(project, task, developer)),
+        PullRequestRepository(db_session).add(_pull_request(project, other_task, developer)),
+    )
+    db_session.flush()
+    repository = ApprovalRepository(db_session)
+    for pull_request in pull_requests:
+        repository.add(
+            Approval(
+                pull_request=pull_request,
+                kind=ApprovalKind.REVIEWER,
+                approver=reviewer,
+                decision=ApprovalDecision.APPROVED,
+                head_sha=pull_request.head_sha,
+                evidence_ref="audit:single-approval-event",
+                correlation_id=pull_request.correlation_id,
+            )
+        )
+
+    with pytest.raises(IntegrityError):
+        db_session.flush()
+
+
+def test_sqlalchemy_merge_gate_rejects_git_evidence_for_an_outdated_base_tip(
+    db_session: Session,
+) -> None:
+    project, task, developer, reviewer, qa, security = _scope(db_session)
+    pull_request = PullRequestRepository(db_session).add(_pull_request(project, task, developer))
+    db_session.flush()
+    git_event = _persist_complete_evidence(
+        db_session,
+        pull_request,
+        developer=developer,
+        reviewer=reviewer,
+        qa=qa,
+        security=security,
+        git_base_sha="c" * 40,
+    )
+
+    result = SQLAlchemyMergeGate(db_session).evaluate(
+        pull_request_id=pull_request.id,
+        expected_task_id=task.id,
+        git_evidence_event_id=git_event.id,
+    )
+
+    assert result.decision is MergeGateDecision.BLOCK
+    assert MergeGateReason.BRANCH_NOT_MERGEABLE in result.reasons
+    assert MergeGateReason.STALE_EVIDENCE in result.reasons
+
+
+def test_sqlalchemy_merge_gate_fails_closed_for_malformed_persisted_evidence(
+    db_session: Session,
+) -> None:
+    project, task, developer, _, _, _ = _scope(db_session)
+    pull_request = _pull_request(project, task, developer)
+    pull_request.tests = [{"unexpected": "shape"}]
+    db_session.add(pull_request)
+    git_event = _event(
+        pull_request,
+        actor=developer,
+        event_type="GIT_OPERATION_COMPLETED",
+        action="validate_merge_requirements",
+        data={
+            "merge_decision": "PASS",
+            "preparation_checksum": pull_request.preparation_checksum,
+            "commit_sha": pull_request.head_sha,
+        },
+    )
+    db_session.add(git_event)
+    db_session.flush()
+
+    result = SQLAlchemyMergeGate(db_session).evaluate(
+        pull_request_id=pull_request.id,
+        expected_task_id=task.id,
+        git_evidence_event_id=git_event.id,
+    )
+
+    assert result.decision is MergeGateDecision.BLOCK
+    assert result.reasons == (MergeGateReason.STALE_EVIDENCE,)
+
+
+def test_postgresql_rejects_duplicate_review_for_the_same_pull_request_head(
+    db_session: Session,
+) -> None:
+    project, task, developer, reviewer, _, _ = _scope(db_session)
+    pull_request = PullRequestRepository(db_session).add(_pull_request(project, task, developer))
+    db_session.flush()
+    repository = PullRequestReviewRepository(db_session)
+    for suffix in ("first", "second"):
+        repository.add(
+            PullRequestReview(
+                pull_request=pull_request,
+                reviewer=reviewer,
+                decision=PullRequestReviewDecision.APPROVED,
+                summary=f"{suffix.title()} review.",
+                confidence=Decimal("0.9000"),
+                head_sha=pull_request.head_sha,
+                evidence_ref=f"audit:{suffix}",
+                correlation_id=pull_request.correlation_id,
+            )
+        )
+
+    with pytest.raises(IntegrityError):
+        db_session.flush()
+
+
+def test_postgresql_rejects_duplicate_approval_for_the_same_kind_and_head(
+    db_session: Session,
+) -> None:
+    project, task, developer, reviewer, _, _ = _scope(db_session)
+    pull_request = PullRequestRepository(db_session).add(_pull_request(project, task, developer))
+    db_session.flush()
+    repository = ApprovalRepository(db_session)
+    for suffix in ("first", "second"):
+        repository.add(
+            Approval(
+                pull_request=pull_request,
+                kind=ApprovalKind.REVIEWER,
+                approver=reviewer,
+                decision=ApprovalDecision.APPROVED,
+                head_sha=pull_request.head_sha,
+                evidence_ref=f"audit:{suffix}",
+                correlation_id=pull_request.correlation_id,
+            )
+        )
+
+    with pytest.raises(IntegrityError):
+        db_session.flush()
+
+
+def test_postgresql_rejects_pull_request_with_mismatched_project_and_task(
+    db_session: Session,
+) -> None:
+    project, task, developer, _, _, _ = _scope(db_session)
+    other_project = Project(name="Unrelated project")
+    db_session.add(other_project)
+    db_session.flush()
+    pull_request = _pull_request(project, task, developer)
+    pull_request.project = other_project
+    db_session.add(pull_request)
+
+    with pytest.raises(IntegrityError):
+        db_session.flush()
+
+
+def test_postgresql_rejects_reusing_a_pull_request_correlation_id(
+    db_session: Session,
+) -> None:
+    project, task, developer, _, _, _ = _scope(db_session)
+    other_task = Task(project=project, title="Second pull request", assigned_agent=developer)
+    db_session.add(other_task)
+    db_session.flush()
+    correlation_id = uuid.uuid4()
+    db_session.add_all(
+        [
+            _pull_request(project, task, developer, correlation_id=correlation_id),
+            _pull_request(project, other_task, developer, correlation_id=correlation_id),
+        ]
+    )
+
+    with pytest.raises(IntegrityError):
+        db_session.flush()
+
+
+def test_review_repository_rejects_oversized_summary(db_session: Session) -> None:
+    project, task, developer, reviewer, _, _ = _scope(db_session)
+    pull_request = PullRequestRepository(db_session).add(_pull_request(project, task, developer))
+    db_session.flush()
+
+    with pytest.raises(ValueError, match="review summary is invalid"):
+        PullRequestReviewRepository(db_session).add(
+            PullRequestReview(
+                pull_request=pull_request,
+                reviewer=reviewer,
+                decision=PullRequestReviewDecision.APPROVED,
+                summary="x" * 4097,
+                confidence=Decimal("0.9000"),
+                head_sha=pull_request.head_sha,
+                evidence_ref="audit:oversized",
+                correlation_id=pull_request.correlation_id,
+            )
+        )
+
+
+def test_reviewer_workflow_request_accepts_strict_pull_request_evidence_binding(
+    db_session: Session,
+    tmp_path: Path,
+) -> None:
+    request = persisted_workflow_request(db_session, tmp_path)[-1]
+    payload = request.model_dump(mode="python")
+    payload["pull_request_evidence"] = {
+        "head_sha": "a" * 40,
+        "preparation_checksum": "b" * 64,
+    }
+    validated = type(request).model_validate(payload)
+
+    assert validated.pull_request_evidence is not None
+    assert validated.pull_request_evidence.head_sha == "a" * 40
+
+
+def test_qa_workflow_request_accepts_strict_pull_request_evidence_binding(
+    db_session: Session,
+    tmp_path: Path,
+) -> None:
+    request = persisted_qa_workflow_request(db_session, tmp_path)[-1]
+    payload = request.model_dump(mode="python")
+    payload["pull_request_evidence"] = {
+        "head_sha": "a" * 40,
+        "preparation_checksum": "b" * 64,
+    }
+    validated = type(request).model_validate(payload)
+
+    assert validated.pull_request_evidence is not None
+    assert validated.pull_request_evidence.head_sha == "a" * 40
+
+
+def test_security_workflow_request_accepts_strict_pull_request_evidence_binding(
+    db_session: Session,
+    tmp_path: Path,
+) -> None:
+    request = persisted_security_workflow_request(db_session, tmp_path)[-1]
+    payload = request.model_dump(mode="python")
+    payload["pull_request_evidence"] = {
+        "head_sha": "a" * 40,
+        "preparation_checksum": "b" * 64,
+    }
+    validated = type(request).model_validate(payload)
+
+    assert validated.pull_request_evidence is not None
+    assert validated.pull_request_evidence.head_sha == "a" * 40

--- a/tests/database/test_pull_requests.py
+++ b/tests/database/test_pull_requests.py
@@ -20,6 +20,14 @@ from core.pull_requests import (
     PullRequestReviewDecision,
     PullRequestStatus,
 )
+from core.workflows import (
+    QAWorkflowError,
+    SecurityWorkflowError,
+    WorkflowError,
+    validate_qa_workflow_request,
+    validate_security_workflow_request,
+    validate_workflow_request,
+)
 from infrastructure.database.append_only import AppendOnlyViolationError
 from infrastructure.database.models import (
     Agent,
@@ -946,45 +954,82 @@ def test_reviewer_workflow_request_accepts_strict_pull_request_evidence_binding(
     db_session: Session,
     tmp_path: Path,
 ) -> None:
-    request = persisted_workflow_request(db_session, tmp_path)[-1]
+    task, developer, _, request = persisted_workflow_request(db_session, tmp_path)
+    pull_request = _pull_request(
+        task.project, task, developer, correlation_id=request.correlation_id
+    )
+    db_session.add(pull_request)
+    db_session.flush()
     payload = request.model_dump(mode="python")
     payload["pull_request_evidence"] = {
-        "head_sha": "a" * 40,
-        "preparation_checksum": "b" * 64,
+        "head_sha": pull_request.head_sha,
+        "preparation_checksum": pull_request.preparation_checksum,
     }
     validated = type(request).model_validate(payload)
 
     assert validated.pull_request_evidence is not None
     assert validated.pull_request_evidence.head_sha == "a" * 40
+    assert validate_workflow_request(db_session, validated).request == validated
+
+    payload["pull_request_evidence"] = {
+        "head_sha": "c" * 40,
+        "preparation_checksum": pull_request.preparation_checksum,
+    }
+    with pytest.raises(WorkflowError):
+        validate_workflow_request(db_session, type(request).model_validate(payload))
 
 
 def test_qa_workflow_request_accepts_strict_pull_request_evidence_binding(
     db_session: Session,
     tmp_path: Path,
 ) -> None:
-    request = persisted_qa_workflow_request(db_session, tmp_path)[-1]
+    task, developer, _, _, request = persisted_qa_workflow_request(db_session, tmp_path)
+    pull_request = PullRequestRepository(db_session).add(
+        _pull_request(task.project, task, developer, correlation_id=request.correlation_id)
+    )
+    db_session.flush()
     payload = request.model_dump(mode="python")
     payload["pull_request_evidence"] = {
-        "head_sha": "a" * 40,
-        "preparation_checksum": "b" * 64,
+        "head_sha": pull_request.head_sha,
+        "preparation_checksum": pull_request.preparation_checksum,
     }
     validated = type(request).model_validate(payload)
 
     assert validated.pull_request_evidence is not None
     assert validated.pull_request_evidence.head_sha == "a" * 40
+    assert validate_qa_workflow_request(db_session, validated).request == validated
+
+    payload["pull_request_evidence"] = {
+        "head_sha": "c" * 40,
+        "preparation_checksum": pull_request.preparation_checksum,
+    }
+    with pytest.raises(QAWorkflowError):
+        validate_qa_workflow_request(db_session, type(request).model_validate(payload))
 
 
 def test_security_workflow_request_accepts_strict_pull_request_evidence_binding(
     db_session: Session,
     tmp_path: Path,
 ) -> None:
-    request = persisted_security_workflow_request(db_session, tmp_path)[-1]
+    task, developer, _, _, _, request = persisted_security_workflow_request(db_session, tmp_path)
+    pull_request = PullRequestRepository(db_session).add(
+        _pull_request(task.project, task, developer, correlation_id=request.correlation_id)
+    )
+    db_session.flush()
     payload = request.model_dump(mode="python")
     payload["pull_request_evidence"] = {
-        "head_sha": "a" * 40,
-        "preparation_checksum": "b" * 64,
+        "head_sha": pull_request.head_sha,
+        "preparation_checksum": pull_request.preparation_checksum,
     }
     validated = type(request).model_validate(payload)
 
     assert validated.pull_request_evidence is not None
     assert validated.pull_request_evidence.head_sha == "a" * 40
+    assert validate_security_workflow_request(db_session, validated).request == validated
+
+    payload["pull_request_evidence"] = {
+        "head_sha": "c" * 40,
+        "preparation_checksum": pull_request.preparation_checksum,
+    }
+    with pytest.raises(SecurityWorkflowError):
+        validate_security_workflow_request(db_session, type(request).model_validate(payload))

--- a/tests/git_workflow/test_integration.py
+++ b/tests/git_workflow/test_integration.py
@@ -168,6 +168,13 @@ def test_git_workflow_is_end_to_end_audited(
     assert history.truncated is False
     assert preparation.head_sha == commit_result.commit_sha
     assert gate.decision is MergeDecision.PASS
+    merge_validation_event = next(
+        event
+        for event in events
+        if event.action == GitOperation.VALIDATE_MERGE_REQUIREMENTS.value
+        and event.event_type == "GIT_OPERATION_COMPLETED"
+    )
+    assert merge_validation_event.data["base_sha"] == preparation.base_sha
     assert len(events) == len(operations) * 2
     for operation in operations:
         operation_events = [event for event in events if event.action == operation.value]

--- a/tests/pull_requests/__init__.py
+++ b/tests/pull_requests/__init__.py
@@ -1,0 +1,1 @@
+"""Phase 20 pull-request model tests."""

--- a/tests/pull_requests/test_merge_gate.py
+++ b/tests/pull_requests/test_merge_gate.py
@@ -1,0 +1,213 @@
+"""Deterministic fail-closed MergeGate tests."""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+
+from core.pull_requests import (
+    ApprovalDecision,
+    ApprovalEvidence,
+    ApprovalKind,
+    MergeGate,
+    MergeGateDecision,
+    MergeGateReason,
+    MergeGateRequest,
+    PullRequestCandidate,
+    PullRequestReviewDecision,
+    PullRequestReviewEvidence,
+    PullRequestTestEvidence,
+)
+
+
+def _request(**changes: object) -> MergeGateRequest:
+    task_id = uuid.uuid4()
+    author_id = uuid.uuid4()
+    reviewer_id = uuid.uuid4()
+    qa_id = uuid.uuid4()
+    security_id = uuid.uuid4()
+    head_sha = "a" * 40
+    correlation_id = uuid.uuid4()
+    candidate = PullRequestCandidate(
+        pull_request_id=uuid.uuid4(),
+        project_id=uuid.uuid4(),
+        task_id=task_id,
+        author_agent_id=author_id,
+        head_sha=head_sha,
+        confidence=0.8,
+        correlation_id=correlation_id,
+    )
+    review = PullRequestReviewEvidence(
+        reviewer_agent_id=reviewer_id,
+        reviewer_role="Reviewer",
+        decision=PullRequestReviewDecision.APPROVED,
+        head_sha=head_sha,
+        correlation_id=correlation_id,
+    )
+    approvals = (
+        ApprovalEvidence(
+            kind=ApprovalKind.REVIEWER,
+            approver_agent_id=reviewer_id,
+            approver_role="Reviewer",
+            decision=ApprovalDecision.APPROVED,
+            head_sha=head_sha,
+            correlation_id=correlation_id,
+        ),
+        ApprovalEvidence(
+            kind=ApprovalKind.QA,
+            approver_agent_id=qa_id,
+            approver_role="QA",
+            decision=ApprovalDecision.APPROVED,
+            head_sha=head_sha,
+            correlation_id=correlation_id,
+        ),
+        ApprovalEvidence(
+            kind=ApprovalKind.SECURITY,
+            approver_agent_id=security_id,
+            approver_role="Security",
+            decision=ApprovalDecision.APPROVED,
+            head_sha=head_sha,
+            correlation_id=correlation_id,
+        ),
+    )
+    values: dict[str, object] = {
+        "expected_task_id": task_id,
+        "candidate": candidate,
+        "review": review,
+        "approvals": approvals,
+        "tests": (
+            PullRequestTestEvidence(name="pytest", passed=True, truncated=False, head_sha=head_sha),
+        ),
+        "branch_mergeable": True,
+    }
+    values.update(changes)
+    return MergeGateRequest.model_validate(values)
+
+
+def test_gate_passes_only_complete_independent_fresh_evidence() -> None:
+    result = MergeGate().evaluate(_request())
+
+    assert result.decision is MergeGateDecision.PASS
+    assert result.reasons == ()
+
+
+@pytest.mark.parametrize(
+    ("change", "reason"),
+    [
+        ({"expected_task_id": uuid.uuid4()}, MergeGateReason.TASK_MISMATCH),
+        ({"branch_mergeable": False}, MergeGateReason.BRANCH_NOT_MERGEABLE),
+        ({"tests": ()}, MergeGateReason.TESTS_NOT_PASSED),
+        (
+            {
+                "tests": (
+                    PullRequestTestEvidence(
+                        name="pytest", passed=False, truncated=False, head_sha="a" * 40
+                    ),
+                )
+            },
+            MergeGateReason.TESTS_NOT_PASSED,
+        ),
+        (
+            {
+                "tests": (
+                    PullRequestTestEvidence(
+                        name="pytest", passed=True, truncated=True, head_sha="a" * 40
+                    ),
+                )
+            },
+            MergeGateReason.TESTS_NOT_PASSED,
+        ),
+    ],
+)
+def test_gate_blocks_invalid_deterministic_state(
+    change: dict[str, object], reason: MergeGateReason
+) -> None:
+    result = MergeGate().evaluate(_request(**change))
+
+    assert result.decision is MergeGateDecision.BLOCK
+    assert reason in result.reasons
+
+
+def test_gate_blocks_self_review() -> None:
+    request = _request()
+    assert request.review is not None
+    review = request.review.model_copy(
+        update={"reviewer_agent_id": request.candidate.author_agent_id}
+    )
+
+    result = MergeGate().evaluate(request.model_copy(update={"review": review}))
+
+    assert result.decision is MergeGateDecision.BLOCK
+    assert MergeGateReason.AUTHOR_IS_REVIEWER in result.reasons
+
+
+def test_gate_blocks_missing_review() -> None:
+    result = MergeGate().evaluate(_request(review=None))
+
+    assert result.decision is MergeGateDecision.BLOCK
+    assert MergeGateReason.REVIEW_NOT_APPROVED in result.reasons
+
+
+def test_gate_blocks_stale_review_and_approvals() -> None:
+    request = _request()
+    assert request.review is not None
+    stale_review = request.review.model_copy(update={"head_sha": "b" * 40})
+    stale_approvals = tuple(
+        approval.model_copy(update={"head_sha": "b" * 40}) for approval in request.approvals
+    )
+
+    result = MergeGate().evaluate(
+        request.model_copy(update={"review": stale_review, "approvals": stale_approvals})
+    )
+
+    assert result.decision is MergeGateDecision.BLOCK
+    assert MergeGateReason.STALE_EVIDENCE in result.reasons
+
+
+def test_gate_blocks_missing_or_non_approved_required_approval() -> None:
+    request = _request()
+    without_qa = tuple(item for item in request.approvals if item.kind is not ApprovalKind.QA)
+    result = MergeGate().evaluate(request.model_copy(update={"approvals": without_qa}))
+    assert MergeGateReason.QA_NOT_PASSED in result.reasons
+
+    blocked_security = tuple(
+        item.model_copy(update={"decision": ApprovalDecision.BLOCKED})
+        if item.kind is ApprovalKind.SECURITY
+        else item
+        for item in request.approvals
+    )
+    result = MergeGate().evaluate(request.model_copy(update={"approvals": blocked_security}))
+    assert MergeGateReason.SECURITY_BLOCKED in result.reasons
+
+
+def test_gate_blocks_approval_role_spoofing() -> None:
+    request = _request()
+    spoofed = tuple(
+        item.model_copy(update={"approver_role": "Reviewer"})
+        if item.kind is ApprovalKind.SECURITY
+        else item
+        for item in request.approvals
+    )
+
+    result = MergeGate().evaluate(request.model_copy(update={"approvals": spoofed}))
+
+    assert result.decision is MergeGateDecision.BLOCK
+    assert MergeGateReason.APPROVER_ROLE_MISMATCH in result.reasons
+
+
+def test_gate_rejects_duplicate_approval_kinds_at_contract_boundary() -> None:
+    request = _request()
+
+    with pytest.raises(ValueError, match="approval kinds must be unique"):
+        MergeGateRequest.model_validate(
+            request.model_copy(
+                update={
+                    "approvals": (
+                        request.approvals[0],
+                        request.approvals[0],
+                        request.approvals[2],
+                    )
+                }
+            ).model_dump()
+        )


### PR DESCRIPTION
## Summary
- add persistent internal PullRequest, PullRequestReview, and Approval models
- enforce append-only evidence and deterministic fail-closed MergeGate checks
- bind Reviewer, QA, Security, and Git evidence to persisted pull-request state
- add reversible Alembic migration and real PostgreSQL coverage
- update Phase 20 checklist only

## Verification
- TEST_POSTGRES_PORT=55433 make check VENV=/Users/feze/Developer/Neocraft/Projects/SynapseOS/.venv
- 1864 tests passed
- Ruff passed
- mypy strict passed
- README unchanged

## Scope
Phase 20 only. No external GitHub/GitLab API integration and no Phase 21 work.