### PR TITLE
feat(scoring): add confidence engine

### DIFF
--- a/SYNAPSEOS_DEVELOPMENT_CHECKLIST.md
+++ b/SYNAPSEOS_DEVELOPMENT_CHECKLIST.md
@@ -1432,13 +1432,41 @@ Le score LLM déclaré seul n'est jamais suffisant.
 
 ## Facteurs possibles
 
-- [ ] self-confidence du modèle
-- [ ] expertise agent
-- [ ] qualité des preuves
-- [ ] tests
-- [ ] historique
-- [ ] contradictions
-- [ ] ambiguïtés
+- [x] self-confidence du modèle
+- [x] expertise agent
+- [x] qualité des preuves
+- [x] tests
+- [ ] historique — deferred to Phase 22 reputation/reliability inputs
+- [x] contradictions — represented by the caller-supplied uncertainty penalty
+- [x] ambiguïtés — represented by the caller-supplied uncertainty penalty
+
+## Implementation V1 verified
+
+- [x] immutable `ConfidenceAssessment` with bounded decimal inputs
+- [x] derived `final_confidence` cannot be supplied or mutated by a caller
+- [x] deterministic formula with four-decimal `ROUND_HALF_UP` quantization
+- [x] model self-confidence alone contributes at most `0.10`
+- [x] evidence and deterministic verification outweigh self-confidence
+- [x] uncertainty penalty is subtracted and the result is clamped to `[0.0, 1.0]`
+- [x] invalid, non-finite, and out-of-range values are rejected
+- [x] unit tests cover formula, bounds, immutability, and input validation
+- [x] Phase 22 reputation aggregation is not implemented
+
+Formula:
+
+```text
+final_confidence = clamp(
+    0.10 * self_reported_confidence
+    + 0.30 * evidence_score
+    + 0.40 * verification_score
+    + 0.20 * expertise_score
+    - uncertainty_penalty,
+    0.0,
+    1.0,
+)
+```
+
+This is a deterministic decision signal, not a perfectly calibrated mathematical probability.
 
 ## Prompt Claude Code — Phase 21
 

--- a/core/scoring/__init__.py
+++ b/core/scoring/__init__.py
@@ -1,1 +1,5 @@
-"""Scoring — confidence & reputation (placeholder — implemented in Phases 21-22)."""
+"""Provider-neutral confidence scoring contracts."""
+
+from core.scoring.confidence import ConfidenceAssessment, ConfidenceFactor
+
+__all__ = ["ConfidenceAssessment", "ConfidenceFactor"]

--- a/core/scoring/confidence.py
+++ b/core/scoring/confidence.py
@@ -1,0 +1,64 @@
+"""Deterministic bounded decision-confidence assessment.
+
+Confidence Engine V1 uses the documented heuristic::
+
+    final = clamp(
+        0.10 * self_reported
+        + 0.30 * evidence
+        + 0.40 * verification
+        + 0.20 * expertise
+        - uncertainty_penalty,
+        0,
+        1,
+    )
+
+The result is quantized to four decimal places. It is a deterministic decision
+signal, not a mathematically calibrated probability. Deterministic evidence and
+verification deliberately outweigh the model's self-reported confidence.
+"""
+
+from __future__ import annotations
+
+from decimal import ROUND_HALF_UP, Decimal
+from typing import Annotated
+
+from pydantic import BaseModel, ConfigDict, Field, computed_field
+
+ConfidenceFactor = Annotated[
+    Decimal,
+    Field(ge=Decimal("0"), le=Decimal("1"), allow_inf_nan=False),
+]
+
+_SELF_REPORTED_WEIGHT = Decimal("0.10")
+_EVIDENCE_WEIGHT = Decimal("0.30")
+_VERIFICATION_WEIGHT = Decimal("0.40")
+_EXPERTISE_WEIGHT = Decimal("0.20")
+_MINIMUM = Decimal("0")
+_MAXIMUM = Decimal("1")
+_QUANTUM = Decimal("0.0001")
+
+
+class ConfidenceAssessment(BaseModel):
+    """Immutable inputs and derived confidence for one decision."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    self_reported_confidence: ConfidenceFactor
+    evidence_score: ConfidenceFactor
+    verification_score: ConfidenceFactor
+    expertise_score: ConfidenceFactor
+    uncertainty_penalty: ConfidenceFactor
+
+    @computed_field(return_type=Decimal)  # type: ignore[prop-decorator]
+    @property
+    def final_confidence(self) -> Decimal:
+        """Return the bounded deterministic V1 confidence heuristic."""
+        weighted_score = (
+            self.self_reported_confidence * _SELF_REPORTED_WEIGHT
+            + self.evidence_score * _EVIDENCE_WEIGHT
+            + self.verification_score * _VERIFICATION_WEIGHT
+            + self.expertise_score * _EXPERTISE_WEIGHT
+            - self.uncertainty_penalty
+        )
+        bounded_score = min(_MAXIMUM, max(_MINIMUM, weighted_score))
+        return bounded_score.quantize(_QUANTUM, rounding=ROUND_HALF_UP)

--- a/tests/scoring/__init__.py
+++ b/tests/scoring/__init__.py
@@ -1,0 +1,1 @@
+"""Confidence scoring tests."""

--- a/tests/scoring/test_confidence.py
+++ b/tests/scoring/test_confidence.py
@@ -1,0 +1,88 @@
+"""Tests for the deterministic Phase 21 confidence engine."""
+
+from __future__ import annotations
+
+from decimal import Decimal
+
+import pytest
+from pydantic import ValidationError
+
+from core.scoring import ConfidenceAssessment
+
+
+def test_confidence_uses_evidence_weighted_deterministic_formula() -> None:
+    assessment = ConfidenceAssessment(
+        self_reported_confidence=Decimal("0.80"),
+        evidence_score=Decimal("0.60"),
+        verification_score=Decimal("1.00"),
+        expertise_score=Decimal("0.50"),
+        uncertainty_penalty=Decimal("0.10"),
+    )
+
+    assert assessment.final_confidence == Decimal("0.6600")
+    assert assessment.model_dump()["final_confidence"] == Decimal("0.6600")
+
+
+def test_self_reported_confidence_alone_is_never_sufficient() -> None:
+    assessment = ConfidenceAssessment(
+        self_reported_confidence=Decimal("1"),
+        evidence_score=Decimal("0"),
+        verification_score=Decimal("0"),
+        expertise_score=Decimal("0"),
+        uncertainty_penalty=Decimal("0"),
+    )
+
+    assert assessment.final_confidence == Decimal("0.1000")
+
+
+def test_uncertainty_penalty_clamps_final_confidence_to_zero() -> None:
+    assessment = ConfidenceAssessment(
+        self_reported_confidence=Decimal("0.50"),
+        evidence_score=Decimal("0.20"),
+        verification_score=Decimal("0.10"),
+        expertise_score=Decimal("0.30"),
+        uncertainty_penalty=Decimal("0.90"),
+    )
+
+    assert assessment.final_confidence == Decimal("0.0000")
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("self_reported_confidence", Decimal("-0.01")),
+        ("evidence_score", Decimal("1.01")),
+        ("verification_score", Decimal("NaN")),
+        ("expertise_score", Decimal("Infinity")),
+        ("uncertainty_penalty", Decimal("-Infinity")),
+    ],
+)
+def test_confidence_rejects_unbounded_or_non_finite_inputs(field: str, value: Decimal) -> None:
+    values = {
+        "self_reported_confidence": Decimal("0.5"),
+        "evidence_score": Decimal("0.5"),
+        "verification_score": Decimal("0.5"),
+        "expertise_score": Decimal("0.5"),
+        "uncertainty_penalty": Decimal("0.1"),
+    }
+    values[field] = value
+
+    with pytest.raises(ValidationError):
+        ConfidenceAssessment(**values)
+
+
+def test_final_confidence_cannot_be_supplied_or_mutated() -> None:
+    values = {
+        "self_reported_confidence": Decimal("0.5"),
+        "evidence_score": Decimal("0.5"),
+        "verification_score": Decimal("0.5"),
+        "expertise_score": Decimal("0.5"),
+        "uncertainty_penalty": Decimal("0.1"),
+    }
+
+    with pytest.raises(ValidationError):
+        ConfidenceAssessment.model_validate({**values, "final_confidence": Decimal("1")})
+
+    assessment = ConfidenceAssessment(**values)
+    with pytest.raises(ValidationError):
+        assessment.evidence_score = Decimal("1")  # type: ignore[misc]


### PR DESCRIPTION
## Summary
- add an immutable, provider-neutral ConfidenceAssessment
- derive a bounded Decimal score from evidence-weighted deterministic inputs
- document the V1 formula in the Phase 21 tasklist without changing README
- keep reputation and historical aggregation deferred to Phase 22

## Verification
- full PostgreSQL-backed pytest suite passed
- Ruff checks passed
- Ruff format check passed
- mypy strict passed
- git diff check passed

## Scope
Phase 21 only. Phase 22 is not implemented.