### PR TITLE
feat(scoring): add reputation engine

### DIFF
--- a/SYNAPSEOS_DEVELOPMENT_CHECKLIST.md
+++ b/SYNAPSEOS_DEVELOPMENT_CHECKLIST.md
@@ -1497,15 +1497,40 @@ Créer tests unitaires et documentation expliquant la formule.
 
 ## Métriques
 
-- [ ] tasks completed
-- [ ] first pass approvals
-- [ ] corrections
-- [ ] regressions
-- [ ] security findings
-- [ ] customer complaints
-- [ ] rollbacks
-- [ ] escalations
-- [ ] collaboration
+- [x] tasks completed — measurable reliability events
+- [x] first pass approvals — measurable review/code-quality events
+- [x] corrections — subsequent events lower or improve the derived projection
+- [x] regressions — measurable reliability/code-quality events
+- [x] security findings — security score events
+- [x] customer complaints — customer-satisfaction score events
+- [x] rollbacks — measurable reliability events
+- [x] escalations — measurable reliability/collaboration events
+- [x] collaboration — collaboration score events
+
+## Implementation V1 verified
+
+- [x] confidence remains a per-decision signal and is excluded from reputation
+- [x] reputation is a deterministic weighted projection of measurable result events
+- [x] reliability is the historical mean of reliability events
+- [x] expertise is calculated independently per validated domain
+- [x] `AgentScore` remains the append-only source of truth
+- [x] current agent reputation and reliability are materialized projections
+- [x] every update stages a sanitized append-only audit event in the same transaction
+- [x] history processing is explicitly bounded to 1,000 events and fails closed at the limit
+- [x] no automatic promotion, demotion, seniority, autonomy, or permission change
+- [x] unit and real-PostgreSQL tests cover calculation, history, updates, and auditing
+
+V1 reputation weights are normalized across the measurable categories present:
+
+```text
+reliability             0.35
+code_quality            0.20
+security                0.20
+collaboration           0.15
+customer_satisfaction   0.10
+```
+
+Confidence and domain expertise never enter the global reputation projection.
 
 ## Prompt Claude Code — Phase 22
 

--- a/core/scoring/__init__.py
+++ b/core/scoring/__init__.py
@@ -1,5 +1,12 @@
 """Provider-neutral confidence scoring contracts."""
 
 from core.scoring.confidence import ConfidenceAssessment, ConfidenceFactor
+from core.scoring.reputation import ReputationEngine, ReputationMeasurement, ReputationSnapshot
 
-__all__ = ["ConfidenceAssessment", "ConfidenceFactor"]
+__all__ = [
+    "ConfidenceAssessment",
+    "ConfidenceFactor",
+    "ReputationEngine",
+    "ReputationMeasurement",
+    "ReputationSnapshot",
+]

--- a/core/scoring/reputation.py
+++ b/core/scoring/reputation.py
@@ -1,0 +1,102 @@
+"""Deterministic reputation projections from measurable score events."""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from collections.abc import Iterable
+from decimal import ROUND_HALF_UP, Decimal
+from typing import Annotated
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+from core.enums import AgentScoreType
+
+Score = Annotated[Decimal, Field(ge=Decimal("0"), le=Decimal("1"), allow_inf_nan=False)]
+Domain = Annotated[str, Field(pattern=r"^[a-z0-9][a-z0-9-]{0,63}$")]
+
+_WEIGHTS = {
+    AgentScoreType.RELIABILITY: Decimal("0.35"),
+    AgentScoreType.CODE_QUALITY: Decimal("0.20"),
+    AgentScoreType.SECURITY: Decimal("0.20"),
+    AgentScoreType.COLLABORATION: Decimal("0.15"),
+    AgentScoreType.CUSTOMER_SATISFACTION: Decimal("0.10"),
+}
+_ZERO = Decimal("0")
+_QUANTUM = Decimal("0.0001")
+
+
+class ReputationMeasurement(BaseModel):
+    """One validated measurable input retained in append-only history."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    score_type: AgentScoreType
+    value: Score
+    domain: Domain | None = None
+
+    @model_validator(mode="after")
+    def validate_domain_scope(self) -> ReputationMeasurement:
+        """Require domains only for domain-specific expertise events."""
+        if self.score_type is AgentScoreType.EXPERTISE and self.domain is None:
+            raise ValueError("expertise measurements require a domain")
+        if self.score_type is not AgentScoreType.EXPERTISE and self.domain is not None:
+            raise ValueError("domain is only valid for expertise measurements")
+        return self
+
+
+class ReputationSnapshot(BaseModel):
+    """Current deterministic projection derived from immutable measurements."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    reputation: Score
+    reliability: Score
+    expertise_by_domain: dict[Domain, Score]
+    event_count: Annotated[int, Field(ge=0)]
+
+
+class ReputationEngine:
+    """Calculate reputation without changing autonomy or seniority."""
+
+    def calculate(self, measurements: Iterable[ReputationMeasurement]) -> ReputationSnapshot:
+        """Build one snapshot; confidence and expertise never enter global reputation."""
+        retained = tuple(measurements)
+        grouped: dict[AgentScoreType, list[Decimal]] = defaultdict(list)
+        expertise: dict[str, list[Decimal]] = defaultdict(list)
+        for measurement in retained:
+            grouped[measurement.score_type].append(measurement.value)
+            if measurement.score_type is AgentScoreType.EXPERTISE:
+                assert measurement.domain is not None
+                expertise[measurement.domain].append(measurement.value)
+
+        means = {score_type: _mean(values) for score_type, values in grouped.items()}
+        weighted = sum(
+            (
+                means[score_type] * weight
+                for score_type, weight in _WEIGHTS.items()
+                if score_type in means
+            ),
+            start=_ZERO,
+        )
+        present_weight = sum(
+            (weight for score_type, weight in _WEIGHTS.items() if score_type in means), start=_ZERO
+        )
+        reputation = _ZERO if present_weight == _ZERO else weighted / present_weight
+        reliability = means.get(AgentScoreType.RELIABILITY, _ZERO)
+        expertise_by_domain = {
+            domain: _quantize(_mean(values)) for domain, values in expertise.items()
+        }
+        return ReputationSnapshot(
+            reputation=_quantize(reputation),
+            reliability=_quantize(reliability),
+            expertise_by_domain=expertise_by_domain,
+            event_count=len(retained),
+        )
+
+
+def _mean(values: list[Decimal]) -> Decimal:
+    return sum(values, start=_ZERO) / Decimal(len(values))
+
+
+def _quantize(value: Decimal) -> Decimal:
+    return value.quantize(_QUANTUM, rounding=ROUND_HALF_UP)

--- a/infrastructure/scoring/__init__.py
+++ b/infrastructure/scoring/__init__.py
@@ -1,0 +1,5 @@
+"""Persistence-backed scoring services."""
+
+from infrastructure.scoring.service import ReputationHistoryLimitError, SQLAlchemyReputationService
+
+__all__ = ["ReputationHistoryLimitError", "SQLAlchemyReputationService"]

--- a/infrastructure/scoring/service.py
+++ b/infrastructure/scoring/service.py
@@ -1,0 +1,103 @@
+"""Atomic append-only score recording and current reputation projection."""
+
+from __future__ import annotations
+
+import uuid
+from decimal import Decimal
+
+from sqlalchemy import func, select
+from sqlalchemy.orm import Session
+
+from core.enums import AgentScoreType, AuditActorType, AuditResult, ScoreSourceType
+from core.scoring import ReputationEngine, ReputationMeasurement, ReputationSnapshot
+from infrastructure.database.models import Agent, AgentScore, AuditEvent
+from infrastructure.database.repositories import AgentScoreRepository, AuditEventRepository
+
+_MAX_HISTORY_EVENTS = 1000
+
+
+class ReputationHistoryLimitError(RuntimeError):
+    """Raised before an update would exceed the bounded V1 calculation window."""
+
+
+class SQLAlchemyReputationService:
+    """Record score evidence and update current projections in one caller transaction."""
+
+    def __init__(self, session: Session) -> None:
+        self._session = session
+        self._scores = AgentScoreRepository(session)
+        self._audits = AuditEventRepository(session)
+        self._engine = ReputationEngine()
+
+    def record_measurement(
+        self,
+        *,
+        agent_id: uuid.UUID,
+        score_type: AgentScoreType,
+        value: Decimal,
+        justification: str,
+        source_type: ScoreSourceType,
+        domain: str | None = None,
+        project_id: uuid.UUID | None = None,
+        task_id: uuid.UUID | None = None,
+        source_id: str | None = None,
+        correlation_id: uuid.UUID | None = None,
+    ) -> ReputationSnapshot:
+        """Append one measurement, recalculate projections, and stage a safe audit event."""
+        measurement = ReputationMeasurement(score_type=score_type, value=value, domain=domain)
+        agent = self._session.get(Agent, agent_id)
+        if agent is None:
+            raise ValueError("agent does not exist")
+        count = self._session.scalar(
+            select(func.count()).select_from(AgentScore).where(AgentScore.agent_id == agent_id)
+        )
+        if count is None or count >= _MAX_HISTORY_EVENTS:
+            raise ReputationHistoryLimitError("bounded reputation history limit reached")
+
+        score = AgentScore(
+            agent_id=agent_id,
+            project_id=project_id,
+            task_id=task_id,
+            score_type=measurement.score_type,
+            value=measurement.value,
+            justification=justification,
+            source_type=source_type,
+            source_id=source_id,
+            metadata_={"domain": measurement.domain} if measurement.domain is not None else {},
+        )
+        self._scores.add(score)
+        self._session.flush()
+        history = self._scores.list(agent_id=agent_id, limit=_MAX_HISTORY_EVENTS)
+        snapshot = self._engine.calculate(tuple(_measurement(item) for item in history))
+        agent.reputation_score = snapshot.reputation
+        agent.reliability_score = snapshot.reliability
+        self._audits.add(
+            AuditEvent(
+                actor_type=AuditActorType.SYSTEM,
+                actor_id="reputation-engine-v1",
+                project_id=project_id,
+                task_id=task_id,
+                event_type="AGENT_REPUTATION_UPDATED",
+                action="record_measurement",
+                resource_type="AGENT",
+                resource_id=str(agent_id),
+                result=AuditResult.SUCCEEDED,
+                data={
+                    "score_type": score_type.value,
+                    "source_type": source_type.value,
+                    "reputation": str(snapshot.reputation),
+                    "reliability": str(snapshot.reliability),
+                },
+                correlation_id=correlation_id,
+            )
+        )
+        return snapshot
+
+
+def _measurement(score: AgentScore) -> ReputationMeasurement:
+    domain = score.metadata_.get("domain")
+    return ReputationMeasurement(
+        score_type=score.score_type,
+        value=score.value,
+        domain=domain if isinstance(domain, str) else None,
+    )

--- a/tests/database/test_reputation_service.py
+++ b/tests/database/test_reputation_service.py
@@ -1,0 +1,74 @@
+"""Real-PostgreSQL tests for audited reputation updates."""
+
+from decimal import Decimal
+
+from sqlalchemy.orm import Session
+
+from core.enums import AgentScoreType, AgentSeniority, ScoreSourceType
+from infrastructure.database.models import Agent, AgentScore, AuditEvent
+from infrastructure.scoring import SQLAlchemyReputationService
+
+
+def test_record_measurement_updates_projection_and_appends_history_and_audit(
+    db_session: Session,
+) -> None:
+    agent = Agent(
+        name="Measured Agent",
+        slug="measured-agent",
+        role="Developer",
+        department="Engineering",
+        seniority=AgentSeniority.ENGINEER,
+    )
+    db_session.add(agent)
+    db_session.flush()
+    service = SQLAlchemyReputationService(db_session)
+
+    service.record_measurement(
+        agent_id=agent.id,
+        score_type=AgentScoreType.RELIABILITY,
+        value=Decimal("0.8"),
+        justification="QA suite passed",
+        source_type=ScoreSourceType.QA,
+    )
+    service.record_measurement(
+        agent_id=agent.id,
+        score_type=AgentScoreType.CODE_QUALITY,
+        value=Decimal("0.6"),
+        justification="Independent review score",
+        source_type=ScoreSourceType.REVIEW,
+    )
+    db_session.flush()
+
+    assert agent.reliability_score == Decimal("0.8000")
+    assert agent.reputation_score == Decimal("0.7273")
+    assert len(db_session.query(AgentScore).all()) == 2
+    events = db_session.query(AuditEvent).all()
+    assert len(events) == 2
+    assert events[-1].event_type == "AGENT_REPUTATION_UPDATED"
+    assert events[-1].data["score_type"] == "CODE_QUALITY"
+
+
+def test_expertise_update_is_historical_without_changing_global_projection(
+    db_session: Session,
+) -> None:
+    agent = Agent(
+        name="Domain Agent",
+        slug="domain-agent",
+        role="Developer",
+        department="Engineering",
+        seniority=AgentSeniority.ENGINEER,
+    )
+    db_session.add(agent)
+    db_session.flush()
+
+    snapshot = SQLAlchemyReputationService(db_session).record_measurement(
+        agent_id=agent.id,
+        score_type=AgentScoreType.EXPERTISE,
+        value=Decimal("0.9"),
+        justification="Verified payments task",
+        source_type=ScoreSourceType.SYSTEM,
+        domain="payments",
+    )
+
+    assert snapshot.expertise_by_domain == {"payments": Decimal("0.9000")}
+    assert agent.reputation_score == Decimal("0.0000")

--- a/tests/scoring/test_reputation.py
+++ b/tests/scoring/test_reputation.py
@@ -1,0 +1,47 @@
+"""Unit tests for measurable reputation projections."""
+
+from decimal import Decimal
+
+from core.enums import AgentScoreType
+from core.scoring import ReputationEngine, ReputationMeasurement
+
+
+def test_reputation_is_weighted_from_measurable_outcomes_only() -> None:
+    snapshot = ReputationEngine().calculate(
+        (
+            ReputationMeasurement(score_type=AgentScoreType.RELIABILITY, value=Decimal("0.8")),
+            ReputationMeasurement(score_type=AgentScoreType.CODE_QUALITY, value=Decimal("0.6")),
+            ReputationMeasurement(score_type=AgentScoreType.SECURITY, value=Decimal("1.0")),
+            ReputationMeasurement(score_type=AgentScoreType.CONFIDENCE, value=Decimal("1.0")),
+        )
+    )
+
+    assert snapshot.reliability == Decimal("0.8000")
+    assert snapshot.reputation == Decimal("0.8000")
+    assert snapshot.event_count == 4
+
+
+def test_expertise_is_kept_per_domain_and_excluded_from_global_reputation() -> None:
+    snapshot = ReputationEngine().calculate(
+        (
+            ReputationMeasurement(
+                score_type=AgentScoreType.EXPERTISE, value=Decimal("0.7"), domain="payments"
+            ),
+            ReputationMeasurement(
+                score_type=AgentScoreType.EXPERTISE, value=Decimal("0.9"), domain="payments"
+            ),
+        )
+    )
+
+    assert snapshot.expertise_by_domain == {"payments": Decimal("0.8000")}
+    assert snapshot.reputation == Decimal("0.0000")
+    assert snapshot.reliability == Decimal("0.0000")
+
+
+def test_corrections_and_regressions_can_lower_reputation_without_mutating_history() -> None:
+    engine = ReputationEngine()
+    first = ReputationMeasurement(score_type=AgentScoreType.RELIABILITY, value=Decimal("1"))
+    regression = ReputationMeasurement(score_type=AgentScoreType.RELIABILITY, value=Decimal("0"))
+
+    assert engine.calculate((first,)).reputation == Decimal("1.0000")
+    assert engine.calculate((first, regression)).reputation == Decimal("0.5000")


### PR DESCRIPTION
## Summary
- derive reputation, reliability, and domain expertise from append-only score events
- atomically update agent projections and append sanitized audit events
- keep confidence separate and exclude automatic promotion, autonomy, and permission changes

## Verification
- full pytest suite with real PostgreSQL
- Ruff lint and format checks
- mypy strict
- git diff check

## Scope
Phase 22 only. Phase 23 memory is not implemented. README is unchanged.