### PR TITLE
feat(memory): add structured memory v1

### DIFF
--- a/SYNAPSEOS_DEVELOPMENT_CHECKLIST.md
+++ b/SYNAPSEOS_DEVELOPMENT_CHECKLIST.md
@@ -1564,11 +1564,25 @@ Permettre à l'entreprise de se souvenir.
 
 ## Types
 
-- [ ] agent memory
-- [ ] project memory
-- [ ] company memory
-- [ ] decision memory
-- [ ] failure memory
+- [x] agent memory
+- [x] project memory
+- [x] company memory
+- [x] decision memory
+- [x] failure memory
+
+## Implementation V1 verified
+
+- [x] `MemoryEntry`, `MemoryScope`, `MemoryRepository`, and `MemoryService`
+- [x] explicit `AGENT`, `PROJECT`, and `COMPANY` scope binding
+- [x] bounded title, content, source, tags, confidence, pagination, and result count
+- [x] decision and failure memories represented by typed entries
+- [x] case-insensitive SQL search over title and content
+- [x] filtering by scope, project, agent, and tags
+- [x] supersession preserves the old entry and hides it from active search
+- [x] PostgreSQL constraints, indexes, foreign keys, and Alembic migration
+- [x] no automatic prompt, response, or conversation persistence
+- [x] no embeddings, pgvector, vector search, or complex RAG
+- [x] real-PostgreSQL tests cover creation, search, scope validation, and supersession
 
 ## Prompt Claude Code — Phase 23
 

--- a/alembic/versions/20260909_0005_memory_v1.py
+++ b/alembic/versions/20260909_0005_memory_v1.py
@@ -1,0 +1,79 @@
+"""Add structured Memory V1 entries.
+
+Revision ID: 20260909_0005
+Revises: 20260908_0004
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+from alembic import op
+
+revision = "20260909_0005"
+down_revision = "20260908_0004"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    scope = sa.Enum("AGENT", "PROJECT", "COMPANY", name="memory_scope")
+    memory_type = sa.Enum("GENERAL", "DECISION", "FAILURE", name="memory_type")
+    op.create_table(
+        "memory_entries",
+        sa.Column("scope", scope, nullable=False),
+        sa.Column("memory_type", memory_type, nullable=False),
+        sa.Column("title", sa.String(255), nullable=False),
+        sa.Column("content", sa.Text(), nullable=False),
+        sa.Column("source", sa.String(255), nullable=False),
+        sa.Column("project_id", postgresql.UUID(as_uuid=True), nullable=True),
+        sa.Column("agent_id", postgresql.UUID(as_uuid=True), nullable=True),
+        sa.Column("tags", postgresql.ARRAY(sa.String(64)), nullable=False),
+        sa.Column("confidence", sa.Numeric(5, 4), nullable=True),
+        sa.Column("superseded_by_id", postgresql.UUID(as_uuid=True), nullable=True),
+        sa.Column("id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column(
+            "created_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False
+        ),
+        sa.CheckConstraint(
+            "confidence IS NULL OR confidence BETWEEN 0 AND 1",
+            name=op.f("ck_memory_entries_confidence_range"),
+        ),
+        sa.CheckConstraint(
+            "(scope = 'AGENT' AND agent_id IS NOT NULL) OR "
+            "(scope = 'PROJECT' AND project_id IS NOT NULL AND agent_id IS NULL) OR "
+            "(scope = 'COMPANY' AND project_id IS NULL AND agent_id IS NULL)",
+            name=op.f("ck_memory_entries_scope_binding"),
+        ),
+        sa.ForeignKeyConstraint(
+            ["agent_id"],
+            ["agents.id"],
+            ondelete="RESTRICT",
+            name=op.f("fk_memory_entries_agent_id_agents"),
+        ),
+        sa.ForeignKeyConstraint(
+            ["project_id"],
+            ["projects.id"],
+            ondelete="RESTRICT",
+            name=op.f("fk_memory_entries_project_id_projects"),
+        ),
+        sa.ForeignKeyConstraint(
+            ["superseded_by_id"],
+            ["memory_entries.id"],
+            ondelete="RESTRICT",
+            name=op.f("fk_memory_entries_superseded_by_id_memory_entries"),
+        ),
+        sa.PrimaryKeyConstraint("id", name=op.f("pk_memory_entries")),
+    )
+    op.create_index("ix_memory_entries_scope_created", "memory_entries", ["scope", "created_at"])
+    op.create_index(
+        "ix_memory_entries_project_created", "memory_entries", ["project_id", "created_at"]
+    )
+    op.create_index("ix_memory_entries_agent_created", "memory_entries", ["agent_id", "created_at"])
+
+
+def downgrade() -> None:
+    op.drop_table("memory_entries")
+    sa.Enum(name="memory_type").drop(op.get_bind(), checkfirst=True)
+    sa.Enum(name="memory_scope").drop(op.get_bind(), checkfirst=True)

--- a/core/memory/__init__.py
+++ b/core/memory/__init__.py
@@ -1,1 +1,5 @@
-"""Memory subsystem (placeholder — implemented in Phase 23)."""
+"""Provider-neutral Memory V1 contracts."""
+
+from core.memory.types import MemoryScope, MemoryType
+
+__all__ = ["MemoryScope", "MemoryType"]

--- a/core/memory/types.py
+++ b/core/memory/types.py
@@ -1,0 +1,15 @@
+"""Memory V1 enums."""
+
+from enum import StrEnum
+
+
+class MemoryScope(StrEnum):
+    AGENT = "AGENT"
+    PROJECT = "PROJECT"
+    COMPANY = "COMPANY"
+
+
+class MemoryType(StrEnum):
+    GENERAL = "GENERAL"
+    DECISION = "DECISION"
+    FAILURE = "FAILURE"

--- a/infrastructure/database/models/__init__.py
+++ b/infrastructure/database/models/__init__.py
@@ -2,6 +2,7 @@
 
 from infrastructure.database.models.execution import AgentRun, Decision, ToolCall
 from infrastructure.database.models.history import AgentScore, AuditEvent
+from infrastructure.database.models.memory import MemoryEntry
 from infrastructure.database.models.organization import Agent, AgentPermission, Project
 from infrastructure.database.models.pull_requests import Approval, PullRequest, PullRequestReview
 from infrastructure.database.models.work import Task, TaskDependency
@@ -13,6 +14,7 @@ __all__ = [
     "AgentScore",
     "Approval",
     "AuditEvent",
+    "MemoryEntry",
     "Decision",
     "Project",
     "PullRequest",

--- a/infrastructure/database/models/memory.py
+++ b/infrastructure/database/models/memory.py
@@ -1,0 +1,50 @@
+"""Structured PostgreSQL memory entries without embeddings."""
+
+from __future__ import annotations
+
+import uuid
+from decimal import Decimal
+
+from sqlalchemy import CheckConstraint, Enum, ForeignKey, Index, Numeric, String, Text
+from sqlalchemy.dialects.postgresql import ARRAY, UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from core.memory import MemoryScope, MemoryType
+from infrastructure.database.base import Base, CreatedAtMixin, UUIDPrimaryKeyMixin
+
+
+class MemoryEntry(UUIDPrimaryKeyMixin, CreatedAtMixin, Base):
+    """One explicit, attributable and supersedable memory record."""
+
+    __tablename__ = "memory_entries"
+    __table_args__ = (
+        CheckConstraint(
+            "confidence IS NULL OR confidence BETWEEN 0 AND 1", name="confidence_range"
+        ),
+        CheckConstraint(
+            "(scope = 'AGENT' AND agent_id IS NOT NULL) OR "
+            "(scope = 'PROJECT' AND project_id IS NOT NULL AND agent_id IS NULL) OR "
+            "(scope = 'COMPANY' AND project_id IS NULL AND agent_id IS NULL)",
+            name="scope_binding",
+        ),
+        Index("ix_memory_entries_scope_created", "scope", "created_at"),
+        Index("ix_memory_entries_project_created", "project_id", "created_at"),
+        Index("ix_memory_entries_agent_created", "agent_id", "created_at"),
+    )
+
+    scope: Mapped[MemoryScope] = mapped_column(Enum(MemoryScope, name="memory_scope"))
+    memory_type: Mapped[MemoryType] = mapped_column(Enum(MemoryType, name="memory_type"))
+    title: Mapped[str] = mapped_column(String(255))
+    content: Mapped[str] = mapped_column(Text)
+    source: Mapped[str] = mapped_column(String(255))
+    project_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("projects.id", ondelete="RESTRICT"), nullable=True
+    )
+    agent_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("agents.id", ondelete="RESTRICT"), nullable=True
+    )
+    tags: Mapped[list[str]] = mapped_column(ARRAY(String(64)), default=list)
+    confidence: Mapped[Decimal | None] = mapped_column(Numeric(5, 4), nullable=True)
+    superseded_by_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("memory_entries.id", ondelete="RESTRICT"), nullable=True
+    )

--- a/infrastructure/database/repositories/__init__.py
+++ b/infrastructure/database/repositories/__init__.py
@@ -2,6 +2,7 @@
 
 from infrastructure.database.repositories.agent_scores import AgentScoreRepository
 from infrastructure.database.repositories.audit_events import AuditEventRepository
+from infrastructure.database.repositories.memory import MemoryRepository
 from infrastructure.database.repositories.pull_requests import (
     ApprovalRepository,
     PullRequestRepository,
@@ -12,6 +13,7 @@ __all__ = [
     "AgentScoreRepository",
     "ApprovalRepository",
     "AuditEventRepository",
+    "MemoryRepository",
     "PullRequestRepository",
     "PullRequestReviewRepository",
 ]

--- a/infrastructure/database/repositories/memory.py
+++ b/infrastructure/database/repositories/memory.py
@@ -1,0 +1,60 @@
+"""Bounded SQL/textual access to explicit memory entries."""
+
+from __future__ import annotations
+
+import uuid
+
+from sqlalchemy import Select, select
+from sqlalchemy.orm import Session
+
+from core.memory import MemoryScope
+from infrastructure.database.models import MemoryEntry
+
+
+class MemoryRepository:
+    def __init__(self, session: Session) -> None:
+        self._session = session
+
+    def add(self, entry: MemoryEntry) -> MemoryEntry:
+        self._session.add(entry)
+        return entry
+
+    def get_by_id(self, entry_id: uuid.UUID) -> MemoryEntry | None:
+        return self._session.get(MemoryEntry, entry_id)
+
+    def search(
+        self,
+        *,
+        query: str | None = None,
+        scope: MemoryScope | None = None,
+        project_id: uuid.UUID | None = None,
+        agent_id: uuid.UUID | None = None,
+        tags: tuple[str, ...] = (),
+        active_only: bool = True,
+        limit: int = 50,
+        offset: int = 0,
+    ) -> list[MemoryEntry]:
+        if not 1 <= limit <= 100:
+            raise ValueError("limit must be between 1 and 100")
+        if offset < 0:
+            raise ValueError("offset must be non-negative")
+        statement: Select[tuple[MemoryEntry]] = select(MemoryEntry)
+        if query:
+            escaped = query.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
+            pattern = f"%{escaped}%"
+            statement = statement.where(
+                MemoryEntry.title.ilike(pattern, escape="\\")
+                | MemoryEntry.content.ilike(pattern, escape="\\")
+            )
+        if scope is not None:
+            statement = statement.where(MemoryEntry.scope == scope)
+        if project_id is not None:
+            statement = statement.where(MemoryEntry.project_id == project_id)
+        if agent_id is not None:
+            statement = statement.where(MemoryEntry.agent_id == agent_id)
+        if tags:
+            statement = statement.where(MemoryEntry.tags.contains(list(tags)))
+        if active_only:
+            statement = statement.where(MemoryEntry.superseded_by_id.is_(None))
+        statement = statement.order_by(MemoryEntry.created_at.desc(), MemoryEntry.id.desc())
+        return list(self._session.scalars(statement.limit(limit).offset(offset)))

--- a/infrastructure/memory/__init__.py
+++ b/infrastructure/memory/__init__.py
@@ -1,0 +1,5 @@
+"""PostgreSQL Memory V1 service."""
+
+from infrastructure.memory.service import SQLAlchemyMemoryService
+
+__all__ = ["SQLAlchemyMemoryService"]

--- a/infrastructure/memory/service.py
+++ b/infrastructure/memory/service.py
@@ -1,0 +1,121 @@
+"""Explicit bounded memory creation, search, and supersession."""
+
+from __future__ import annotations
+
+import uuid
+from decimal import Decimal
+
+from sqlalchemy.orm import Session
+
+from core.memory import MemoryScope, MemoryType
+from infrastructure.database.models import MemoryEntry
+from infrastructure.database.repositories import MemoryRepository
+
+
+class SQLAlchemyMemoryService:
+    def __init__(self, session: Session) -> None:
+        self._session = session
+        self._repository = MemoryRepository(session)
+
+    def create(
+        self,
+        *,
+        scope: MemoryScope,
+        memory_type: MemoryType,
+        title: str,
+        content: str,
+        source: str,
+        project_id: uuid.UUID | None = None,
+        agent_id: uuid.UUID | None = None,
+        tags: tuple[str, ...] = (),
+        confidence: Decimal | None = None,
+    ) -> MemoryEntry:
+        _validate_scope(scope, project_id, agent_id)
+        _validate_text(title, "title", 255)
+        _validate_text(content, "content", 16_384)
+        _validate_text(source, "source", 255)
+        if confidence is not None and not Decimal("0") <= confidence <= Decimal("1"):
+            raise ValueError("confidence must be between 0 and 1")
+        normalized_tags = sorted(set(tags))
+        if len(normalized_tags) > 32 or any(not tag or len(tag) > 64 for tag in normalized_tags):
+            raise ValueError("tags are invalid")
+        entry = self._repository.add(
+            MemoryEntry(
+                scope=scope,
+                memory_type=memory_type,
+                title=title,
+                content=content,
+                source=source,
+                project_id=project_id,
+                agent_id=agent_id,
+                tags=normalized_tags,
+                confidence=confidence,
+            )
+        )
+        self._session.flush()
+        return entry
+
+    def get(self, entry_id: uuid.UUID) -> MemoryEntry | None:
+        return self._repository.get_by_id(entry_id)
+
+    def search(
+        self,
+        *,
+        query: str | None = None,
+        scope: MemoryScope | None = None,
+        project_id: uuid.UUID | None = None,
+        agent_id: uuid.UUID | None = None,
+        tags: tuple[str, ...] = (),
+        active_only: bool = True,
+        limit: int = 50,
+        offset: int = 0,
+    ) -> list[MemoryEntry]:
+        return self._repository.search(
+            query=query,
+            scope=scope,
+            project_id=project_id,
+            agent_id=agent_id,
+            tags=tags,
+            active_only=active_only,
+            limit=limit,
+            offset=offset,
+        )
+
+    def supersede(
+        self, entry_id: uuid.UUID, *, title: str, content: str, source: str
+    ) -> MemoryEntry:
+        old = self._repository.get_by_id(entry_id)
+        if old is None:
+            raise ValueError("memory does not exist")
+        if old.superseded_by_id is not None:
+            raise ValueError("memory is already superseded")
+        replacement = self.create(
+            scope=old.scope,
+            memory_type=old.memory_type,
+            title=title,
+            content=content,
+            source=source,
+            project_id=old.project_id,
+            agent_id=old.agent_id,
+            tags=tuple(old.tags),
+            confidence=old.confidence,
+        )
+        self._session.flush()
+        old.superseded_by_id = replacement.id
+        return replacement
+
+
+def _validate_scope(
+    scope: MemoryScope, project_id: uuid.UUID | None, agent_id: uuid.UUID | None
+) -> None:
+    if scope is MemoryScope.AGENT and agent_id is None:
+        raise ValueError("agent memory requires agent_id")
+    if scope is MemoryScope.PROJECT and (project_id is None or agent_id is not None):
+        raise ValueError("project memory requires project_id and no agent_id")
+    if scope is MemoryScope.COMPANY and (project_id is not None or agent_id is not None):
+        raise ValueError("company memory cannot have project_id or agent_id")
+
+
+def _validate_text(value: str, field: str, maximum: int) -> None:
+    if not value.strip() or len(value) > maximum:
+        raise ValueError(f"{field} is invalid")

--- a/tests/database/test_memory.py
+++ b/tests/database/test_memory.py
@@ -1,0 +1,93 @@
+"""Real-PostgreSQL tests for Phase 23 Memory V1."""
+
+from decimal import Decimal
+
+import pytest
+from sqlalchemy.orm import Session
+
+from core.enums import AgentSeniority
+from core.memory import MemoryScope, MemoryType
+from infrastructure.database.models import Agent, Project
+from infrastructure.memory import SQLAlchemyMemoryService
+
+
+def test_create_and_search_agent_project_and_company_memories(db_session: Session) -> None:
+    agent = Agent(
+        name="Memory Agent",
+        slug="memory-agent",
+        role="Developer",
+        department="Engineering",
+        seniority=AgentSeniority.ENGINEER,
+    )
+    project = Project(name="Memory Project")
+    db_session.add_all([agent, project])
+    db_session.flush()
+    service = SQLAlchemyMemoryService(db_session)
+
+    agent_memory = service.create(
+        scope=MemoryScope.AGENT,
+        memory_type=MemoryType.FAILURE,
+        title="PostgreSQL timeout",
+        content="The migration timed out during verification.",
+        source="qa-run",
+        agent_id=agent.id,
+        tags=("postgresql", "migration"),
+        confidence=Decimal("0.9"),
+    )
+    service.create(
+        scope=MemoryScope.PROJECT,
+        memory_type=MemoryType.DECISION,
+        title="Database choice",
+        content="Use PostgreSQL for transactional state.",
+        source="adr-0001",
+        project_id=project.id,
+    )
+    service.create(
+        scope=MemoryScope.COMPANY,
+        memory_type=MemoryType.GENERAL,
+        title="Review policy",
+        content="Authors do not approve their own changes.",
+        source="constitution",
+    )
+    db_session.flush()
+
+    assert service.get(agent_memory.id) == agent_memory
+    assert service.search(query="PostgreSQL", scope=MemoryScope.AGENT) == [agent_memory]
+    assert service.search(tags=("migration",), agent_id=agent.id) == [agent_memory]
+
+
+def test_supersession_preserves_old_memory_and_hides_it_from_active_search(
+    db_session: Session,
+) -> None:
+    service = SQLAlchemyMemoryService(db_session)
+    old = service.create(
+        scope=MemoryScope.COMPANY,
+        memory_type=MemoryType.GENERAL,
+        title="Test command",
+        content="Run pytest without PostgreSQL.",
+        source="operator",
+    )
+    replacement = service.supersede(
+        old.id,
+        title="Test command",
+        content="Run pytest with real PostgreSQL.",
+        source="operator-correction",
+    )
+    db_session.flush()
+
+    assert old.superseded_by_id == replacement.id
+    assert service.get(old.id) == old
+    assert service.search(query="Test command") == [replacement]
+    historical_ids = {entry.id for entry in service.search(query="Test command", active_only=False)}
+    assert historical_ids == {old.id, replacement.id}
+
+
+def test_scope_bindings_are_enforced_before_persistence(db_session: Session) -> None:
+    with pytest.raises(ValueError, match="project memory requires project_id"):
+        SQLAlchemyMemoryService(db_session).create(
+            scope=MemoryScope.PROJECT,
+            memory_type=MemoryType.GENERAL,
+            title="Invalid",
+            content="Missing project scope.",
+            source="test",
+        )


### PR DESCRIPTION
## Summary
- add explicit agent, project, and company memory entries
- add bounded SQL text search, filters, and supersession history
- add PostgreSQL constraints, indexes, repository, service, and Alembic migration

## Verification
- full pytest suite with real PostgreSQL
- Ruff lint and format checks
- mypy strict
- git diff check

## Scope
Phase 23 only. No embeddings, pgvector, RAG, implicit conversation persistence, or Phase 24 work. README is unchanged.