### PR TITLE
feat(audit): add immutable audit service

### DIFF
--- a/SYNAPSEOS_DEVELOPMENT_CHECKLIST.md
+++ b/SYNAPSEOS_DEVELOPMENT_CHECKLIST.md
@@ -1627,15 +1627,28 @@ Pouvoir reconstruire toute l'histoire d'une décision.
 
 ## Événements
 
-- [ ] task transitions
-- [ ] LLM calls
-- [ ] tool calls
-- [ ] permissions
-- [ ] decisions
-- [ ] Git actions
-- [ ] reviews
-- [ ] security
-- [ ] score changes
+- [x] task transitions
+- [x] LLM calls — supported through the standard bounded audit interface
+- [x] tool calls
+- [x] permissions
+- [x] decisions
+- [x] Git actions
+- [x] reviews
+- [x] security
+- [x] score changes
+
+## Implementation verified
+
+- [x] central validated `AuditLogService` exposes append/get/search/reconstruct only
+- [x] timestamp, actor, project/task/run, action, resource, result, correlation, metadata
+- [x] actor/resource/result/correlation filters with bounded pagination
+- [x] deterministic chronological reconstruction by correlation ID
+- [x] shallow bounded metadata rejects sensitive keys and oversized values
+- [x] repositories and service expose no update or delete operations
+- [x] global SQLAlchemy append-only guard still blocks direct Session updates/deletes
+- [x] corrections remain new events linked through `corrects_event_id`
+- [x] real-PostgreSQL tests cover append, filtering, reconstruction, and rejection
+- [x] no Phase 25 intake functionality
 
 ## Prompt Claude Code — Phase 24
 

--- a/infrastructure/audit/__init__.py
+++ b/infrastructure/audit/__init__.py
@@ -1,0 +1,5 @@
+"""Central immutable audit-log interface."""
+
+from infrastructure.audit.service import AuditLogService, AuditRecord
+
+__all__ = ["AuditLogService", "AuditRecord"]

--- a/infrastructure/audit/service.py
+++ b/infrastructure/audit/service.py
@@ -1,0 +1,116 @@
+"""Validated append-only audit recording and bounded reconstruction."""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime
+from typing import Annotated
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+from sqlalchemy.orm import Session
+
+from core.enums import AuditActorType, AuditResult
+from infrastructure.database.models import AuditEvent
+from infrastructure.database.repositories import AuditEventRepository
+
+AuditText = Annotated[str, Field(min_length=1, max_length=255)]
+_SENSITIVE_KEYS = frozenset(
+    {"api_key", "authorization", "content", "password", "prompt", "response", "secret", "token"}
+)
+
+
+class AuditRecord(BaseModel):
+    """Complete bounded input for one standard audit event."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    actor_type: AuditActorType
+    actor_id: AuditText
+    project_id: uuid.UUID | None = None
+    task_id: uuid.UUID | None = None
+    agent_run_id: uuid.UUID | None = None
+    event_type: AuditText
+    action: AuditText
+    resource_type: AuditText | None = None
+    resource_id: AuditText | None = None
+    result: AuditResult
+    correlation_id: uuid.UUID | None = None
+    metadata: Annotated[dict[str, object], Field(max_length=32)] = Field(default_factory=dict)
+
+    @field_validator("actor_id", "event_type", "action", "resource_type", "resource_id")
+    @classmethod
+    def reject_blank_text(cls, value: str | None) -> str | None:
+        if value is not None and not value.strip():
+            raise ValueError("audit text must not be blank")
+        return value
+
+    @field_validator("metadata")
+    @classmethod
+    def validate_metadata(cls, value: dict[str, object]) -> dict[str, object]:
+        for key, item in value.items():
+            if key.lower() in _SENSITIVE_KEYS:
+                raise ValueError("sensitive audit metadata key is forbidden")
+            if len(key) > 64 or not isinstance(item, (str, int, float, bool, type(None))):
+                raise ValueError("audit metadata must be shallow and bounded")
+            if isinstance(item, str) and len(item) > 1024:
+                raise ValueError("audit metadata value is too long")
+        return dict(value)
+
+
+class AuditLogService:
+    """Standard API exposing append and read operations only."""
+
+    def __init__(self, session: Session) -> None:
+        self._session = session
+        self._repository = AuditEventRepository(session)
+
+    def append(self, record: AuditRecord) -> AuditEvent:
+        event = self._repository.add(
+            AuditEvent(
+                actor_type=record.actor_type,
+                actor_id=record.actor_id,
+                project_id=record.project_id,
+                task_id=record.task_id,
+                agent_run_id=record.agent_run_id,
+                event_type=record.event_type,
+                action=record.action,
+                resource_type=record.resource_type,
+                resource_id=record.resource_id,
+                result=record.result,
+                data=dict(record.metadata),
+                correlation_id=record.correlation_id,
+                created_at=datetime.now(UTC),
+            )
+        )
+        self._session.flush()
+        return event
+
+    def get(self, event_id: uuid.UUID) -> AuditEvent | None:
+        return self._repository.get_by_id(event_id)
+
+    def search(
+        self,
+        *,
+        actor_type: AuditActorType | None = None,
+        actor_id: str | None = None,
+        resource_type: str | None = None,
+        resource_id: str | None = None,
+        result: AuditResult | None = None,
+        correlation_id: uuid.UUID | None = None,
+        limit: int = 100,
+        offset: int = 0,
+    ) -> list[AuditEvent]:
+        return self._repository.list(
+            actor_type=actor_type,
+            actor_id=actor_id,
+            resource_type=resource_type,
+            resource_id=resource_id,
+            result=result,
+            correlation_id=correlation_id,
+            limit=limit,
+            offset=offset,
+        )
+
+    def reconstruct(self, correlation_id: uuid.UUID, *, limit: int = 1000) -> list[AuditEvent]:
+        events = self._repository.list(correlation_id=correlation_id, limit=limit)
+        return list(reversed(events))

--- a/infrastructure/database/repositories/audit_events.py
+++ b/infrastructure/database/repositories/audit_events.py
@@ -7,6 +7,7 @@ import uuid
 from sqlalchemy import Select, select
 from sqlalchemy.orm import Session
 
+from core.enums import AuditActorType, AuditResult
 from infrastructure.database.models import AuditEvent
 from infrastructure.database.repositories.agent_scores import _validate_limit, _validate_offset
 
@@ -32,6 +33,11 @@ class AuditEventRepository:
         agent_run_id: uuid.UUID | None = None,
         event_type: str | None = None,
         correlation_id: uuid.UUID | None = None,
+        actor_type: AuditActorType | None = None,
+        actor_id: str | None = None,
+        resource_type: str | None = None,
+        resource_id: str | None = None,
+        result: AuditResult | None = None,
         limit: int = 100,
         offset: int = 0,
     ) -> list[AuditEvent]:
@@ -46,6 +52,16 @@ class AuditEventRepository:
             statement = statement.where(AuditEvent.event_type == event_type)
         if correlation_id is not None:
             statement = statement.where(AuditEvent.correlation_id == correlation_id)
+        if actor_type is not None:
+            statement = statement.where(AuditEvent.actor_type == actor_type)
+        if actor_id is not None:
+            statement = statement.where(AuditEvent.actor_id == actor_id)
+        if resource_type is not None:
+            statement = statement.where(AuditEvent.resource_type == resource_type)
+        if resource_id is not None:
+            statement = statement.where(AuditEvent.resource_id == resource_id)
+        if result is not None:
+            statement = statement.where(AuditEvent.result == result)
         statement = statement.order_by(AuditEvent.created_at.desc(), AuditEvent.id.desc())
         statement = statement.limit(_validate_limit(limit)).offset(_validate_offset(offset))
         return list(self._session.scalars(statement))

--- a/tests/database/test_audit_log_service.py
+++ b/tests/database/test_audit_log_service.py
@@ -1,0 +1,89 @@
+"""Real-PostgreSQL tests for the central immutable audit log."""
+
+import uuid
+
+import pytest
+from sqlalchemy.orm import Session
+
+from core.enums import AuditActorType, AuditResult
+from infrastructure.audit import AuditLogService, AuditRecord
+
+
+def test_append_and_filter_complete_audit_events(db_session: Session) -> None:
+    correlation_id = uuid.uuid4()
+    service = AuditLogService(db_session)
+    event = service.append(
+        AuditRecord(
+            actor_type=AuditActorType.AGENT,
+            actor_id="reviewer-01",
+            event_type="DECISION_RECORDED",
+            action="approve_change",
+            resource_type="DECISION",
+            resource_id="decision-42",
+            result=AuditResult.SUCCEEDED,
+            correlation_id=correlation_id,
+            metadata={"confidence": "0.8400", "evidence_count": 3},
+        )
+    )
+    db_session.flush()
+
+    assert service.get(event.id) == event
+    assert service.search(
+        actor_type=AuditActorType.AGENT,
+        actor_id="reviewer-01",
+        resource_type="DECISION",
+        resource_id="decision-42",
+        result=AuditResult.SUCCEEDED,
+        correlation_id=correlation_id,
+    ) == [event]
+
+
+def test_reconstruct_returns_correlated_history_in_chronological_order(db_session: Session) -> None:
+    correlation_id = uuid.uuid4()
+    service = AuditLogService(db_session)
+    first = service.append(
+        AuditRecord(
+            actor_type=AuditActorType.SYSTEM,
+            actor_id="workflow",
+            event_type="DECISION_STARTED",
+            action="start",
+            result=AuditResult.SUCCEEDED,
+            correlation_id=correlation_id,
+        )
+    )
+    second = service.append(
+        AuditRecord(
+            actor_type=AuditActorType.SYSTEM,
+            actor_id="workflow",
+            event_type="DECISION_COMPLETED",
+            action="complete",
+            result=AuditResult.SUCCEEDED,
+            correlation_id=correlation_id,
+        )
+    )
+    db_session.flush()
+
+    assert service.reconstruct(correlation_id) == [first, second]
+
+
+def test_sensitive_metadata_is_rejected_before_persistence(db_session: Session) -> None:
+    service = AuditLogService(db_session)
+    with pytest.raises(ValueError, match="sensitive audit metadata key"):
+        service.append(
+            AuditRecord(
+                actor_type=AuditActorType.SYSTEM,
+                actor_id="runtime",
+                event_type="LLM_CALL",
+                action="complete",
+                result=AuditResult.SUCCEEDED,
+                metadata={"prompt": "private client text"},
+            )
+        )
+
+    assert service.search() == []
+
+
+def test_standard_audit_service_exposes_no_update_or_delete(db_session: Session) -> None:
+    service = AuditLogService(db_session)
+    assert not hasattr(service, "update")
+    assert not hasattr(service, "delete")


### PR DESCRIPTION
## Summary
- add a central validated append-only audit service
- add complete actor, resource, result, and correlation filters
- add deterministic chronological reconstruction and sensitive metadata rejection

## Verification
- full pytest suite with real PostgreSQL
- Ruff lint and format checks
- mypy strict
- git diff check

## Scope
Phase 24 only. Existing append-only guards remain active. Phase 25 is not implemented. README is unchanged.