### PR TITLE
docs(roadmap): define frontend and v2 governance

### DIFF
--- a/SYNAPSEOS_DEVELOPMENT_CHECKLIST.md
+++ b/SYNAPSEOS_DEVELOPMENT_CHECKLIST.md
@@ -2354,9 +2354,17 @@ Donner une interface humaine pour piloter SynapseOS.
 Implémente UNIQUEMENT le frontend V1 de SynapseOS.
 
 Stack :
-Nuxt 3 + TypeScript.
+Nuxt 4 + TypeScript.
 
-Avant de choisir une UI library, inspecte le repository et la décision d'architecture existante.
+Before implementing any frontend feature or selecting a UI library, read and follow
+`docs/frontend-architecture-roadmap.md`. This document is the authoritative implementation
+specification for the frontend. Any intentional divergence requires an explicit ADR and a
+corresponding checklist update.
+
+The frontend is a client of the SynapseOS backend runtime. It must not duplicate, weaken, or bypass
+backend permissions, state machines, audit rules, security vetoes, workspace isolation, or tool
+authority. The browser must never receive direct shell, filesystem, database, or provider-secret
+access.
 
 Créer d'abord :
 - app shell
@@ -2639,6 +2647,77 @@ Agent / Runtime
     -> LLM Router
     -> provider
 ```
+
+---
+
+# V2 BACKEND ARCHITECTURE BACKLOG — Agent Governance Extensions
+
+## Status and source of truth
+
+This backlog is approved as the future backend governance direction for SynapseOS, but remains
+deferred until the current V1 roadmap has been completed and reconciled. It is not a frontend or UI
+specification. Do not mark any V2 extension complete and do not implement it implicitly inside a V1
+phase.
+
+Before planning or implementing any V2 governance extension, read and follow
+`docs/synapseos v2-agent-governance-extensions.md`. That document is the authoritative architecture
+and implementation specification for the entities, evidence, rules, decisions, persistence,
+runtime controls, auditing, and sequencing described below. Any intentional divergence requires an
+explicit ADR and a corresponding checklist update.
+
+## Strategic components
+
+- [ ] Agent Genome — maintain a versioned, evidence-based profile of demonstrated capabilities,
+      strengths, weaknesses, efficiency, historical outcomes, and normal behavior
+- [ ] Agent Trust Score — derive auditable historical and runtime trust signals from outcomes,
+      failures, incidents, reviews, QA, security, and observed behavior
+- [ ] Autonomy Governor — lease bounded, scoped, observable, and revocable autonomy for a specific
+      task and action
+- [ ] AI Manager — assign and reassign work, coordinate agents, and react to cost, risk, blockers,
+      trust, and runtime conditions without expanding authority
+
+## Mandatory authority hierarchy
+
+```text
+Security veto
+    ↓
+Permission Engine
+    ↓
+Autonomy Governor
+    ↓
+AI Manager
+    ↓
+Agent Runtime
+```
+
+Agent Genome and Agent Trust Score provide decision signals only. Trust must never grant a
+permission. The Autonomy Governor must never bypass the Permission Engine or a security veto. The
+AI Manager must never directly grant, broaden, or override authority. Existing backend security,
+permission, human-approval, audit, runtime-bound, and least-privilege invariants remain superior
+constraints.
+
+## Required implementation order
+
+```text
+1. Agent Genome
+2. Agent Trust Score
+3. Autonomy Governor
+4. AI Manager
+```
+
+The future extension phase families are reserved as follows:
+
+```text
+EXT-GEN-01 → EXT-GEN-08
+EXT-TRUST-01 → EXT-TRUST-08
+EXT-GOV-01 → EXT-GOV-08
+EXT-MGR-01 → EXT-MGR-10
+```
+
+These identifiers must not be merged into or substituted for existing V1 phase numbers. Before V2
+implementation begins, reconcile their exact placement and dependencies against the completed V1
+roadmap. Delivery retains the repository rule: one extension phase = one clear objective = one PR =
+one validation.
 
 ---
 

--- a/docs/frontend-architecture-roadmap.md
+++ b/docs/frontend-architecture-roadmap.md
@@ -1,0 +1,4849 @@
+# SynapseOS — Frontend Architecture & Implementation Roadmap
+
+> **Status:** Architecture decision record and implementation specification — approved design direction, implementation intentionally deferred until the backend/runtime is sufficiently mature.
+>
+> **Repository target:** `cedrickdev/SynapseOS`
+>
+> **Intended path:** `docs/frontend-architecture-roadmap.md`
+>
+> **Core delivery rule inherited from SynapseOS:** **one phase = one clear objective = one PR = one validation**. The frontend must be implemented progressively and must not bypass backend invariants, permissions, state machines, or auditability.
+
+---
+
+## 1. Purpose of this document
+
+This document is the complete frontend architecture specification for SynapseOS. It converts the validated product and technical decisions into a roadmap that can later be executed phase by phase.
+
+It is deliberately more than a technology list. For each major subsystem it records:
+
+- the objective;
+- why the technology was selected;
+- how it integrates with SynapseOS;
+- expected installation/configuration approach;
+- target file/folder structure;
+- security and architecture rules;
+- testing expectations;
+- acceptance criteria;
+- common failure modes;
+- deliberately deferred scope;
+- Definition of Done.
+
+This document is also intended to prevent architecture drift. A future implementation should not silently replace a validated technology or weaken a validated invariant without an explicit ADR/update to this specification.
+
+### 1.1 Important sequencing decision
+
+The SynapseOS backend/runtime remains the priority. The frontend must not pressure the backend into premature endpoints, duplicate business rules in the browser, or introduce workarounds around unfinished runtime components.
+
+Frontend implementation begins only when the backend exposes stable enough contracts for the first vertical slices. Mock data may be used during visual prototyping, but mock-only behavior must never be confused with runtime behavior.
+
+### 1.2 Existing backend invariants the frontend must respect
+
+The frontend is a client of the SynapseOS runtime, not a second runtime. In particular:
+
+- task status changes remain controlled by the backend `TaskStateMachine`;
+- tool authorization remains controlled by the Permission Engine;
+- agent/tool actions remain auditable;
+- dangerous operations remain bounded and explicitly authorized;
+- the browser never gets direct shell, filesystem, provider-secret, or database authority;
+- provider-neutral backend contracts remain provider-neutral in the UI;
+- raw runtime evidence may be sensitive and must be redacted/permission-checked before display;
+- frontend confidence visualizations must never imply that a confidence score is objective truth.
+
+---
+
+# 2. Product vision: a real company simulator, not a generic dashboard
+
+The frontend must make SynapseOS feel like a living, observable software company operated by AI agents while remaining operationally serious.
+
+The interface therefore has **three complementary modes**.
+
+## 2.1 Company View / Company Simulator
+
+The Company View is the immersive representation of the organization.
+
+Its purpose is to answer quickly:
+
+- Which departments are active?
+- Which agents are working?
+- What is each agent working on?
+- Which tasks are blocked?
+- Which review or security gates are waiting?
+- Where is a workflow currently moving?
+- What changed in the company recently?
+
+The Company Simulator must **never invent activity for entertainment**. Every animation, status, transition, badge, line, packet, warning, or conversation metaphor must map to a real backend state or event.
+
+Examples of valid semantic visuals:
+
+- an available agent appears idle/asleep;
+- a working agent appears at a workstation;
+- a blocked agent receives a warning state;
+- delegation can be visualized as communication between agent nodes;
+- a reviewer receiving a dossier maps to a real review request;
+- a security stop maps to a real veto/blocked transition;
+- a task packet moving between agents maps to a real workflow transition;
+- a completed test/pipeline stage changes state only after the real result exists.
+
+Example live sequence:
+
+```text
+Backend Agent — implementing task
+        ↓
+pytest failed
+        ↓
+corrective loop
+        ↓
+pytest passed
+        ↓
+Reviewer Agent
+        ↓
+changes requested
+        ↓
+Developer correction
+        ↓
+review accepted
+```
+
+### Agent cards
+
+An agent card may expose, subject to permissions:
+
+- name;
+- role;
+- department;
+- current status;
+- current task;
+- model/provider identity where allowed;
+- confidence value with appropriate caveat;
+- current iteration;
+- last tool/action;
+- elapsed runtime;
+- token/cost metrics when available;
+- blocking reason;
+- last event timestamp.
+
+### Morning Meeting / Daily Briefing
+
+A Daily Briefing may summarize:
+
+- active projects;
+- work completed since the previous briefing;
+- blocked tasks;
+- review backlog;
+- QA/security findings;
+- provider incidents;
+- cost/token anomalies;
+- priorities for the current period.
+
+The briefing must be generated from actual system state/evidence. It must not fabricate fictional employee dialogue.
+
+## 2.2 Control Center
+
+The Control Center is the serious administration and operational cockpit.
+
+It covers:
+
+- Projects;
+- Agents;
+- Tasks;
+- Runs;
+- Reviews;
+- Approvals;
+- Providers;
+- Tools;
+- Skills;
+- Permissions;
+- Costs/tokens;
+- Memory;
+- Context Intelligence;
+- Notifications;
+- Security;
+- Audit;
+- settings.
+
+The visual language should be dense but readable: compact navigation, strong tables, drawers, filters, obvious statuses, minimal decorative chrome.
+
+## 2.3 Deep Inspect
+
+Deep Inspect is for technical investigation.
+
+It may expose, with strict permission/redaction rules:
+
+- run timelines;
+- structured runtime events;
+- tool calls;
+- command profiles;
+- stdout/stderr excerpts;
+- traces;
+- audit events;
+- retry/corrective-loop history;
+- model-routing decisions;
+- selected context metadata;
+- security failures.
+
+Deep Inspect is where xterm-style presentation is appropriate. It must not become an unrestricted shell.
+
+---
+
+# 3. UX identity and navigation
+
+## 3.1 Visual references
+
+The desired level of polish and interaction is inspired by:
+
+- Linear;
+- Vercel;
+- Supabase;
+- GitLab;
+- GitHub.
+
+These are references for principles and quality, not templates to copy pixel-for-pixel.
+
+Desired characteristics:
+
+- dark-first;
+- neutral surfaces;
+- dense but readable information;
+- thin borders;
+- restrained use of shadow;
+- precise typography;
+- compact sidebar;
+- drawers/panels for detail inspection;
+- strong table UX;
+- clear states/badges;
+- terminal-like technical surfaces;
+- excellent keyboard navigation;
+- command palette as a first-class navigation surface.
+
+## 3.2 Proposed information architecture
+
+```text
+Company
+├── Office / Simulator
+├── Departments
+└── Daily Briefing
+
+Projects
+├── All Projects
+└── Project Detail
+
+Agents
+├── Directory
+├── Agent Detail
+└── Department Views
+
+Operations
+├── Tasks
+├── Runs
+├── Reviews
+└── Approvals
+
+Intelligence
+├── Memory
+├── Context Intelligence
+├── Model Routing
+└── Costs / Usage
+
+Security
+├── Findings
+├── Vetoes
+├── Permissions
+└── Audit
+
+Administration
+├── Providers
+├── Tools
+├── Skills
+├── Artifacts
+└── Settings
+```
+
+This navigation can evolve, but Company View, Control Center, and Deep Inspect must remain conceptually distinct.
+
+---
+
+# 4. Validated technology stack
+
+## 4.1 Core frontend
+
+- **Nuxt**
+- **Vue**
+- **TypeScript (strict)**
+- **Nuxt UI**
+- **Tailwind CSS**
+
+### Why Nuxt instead of Next.js
+
+Nuxt is the validated choice because:
+
+- the backend is already an independent FastAPI system, so Next.js server actions/full-stack coupling is not required;
+- SynapseOS is an application/cockpit, not primarily an SEO content site;
+- Vue Composition API is well suited to highly interactive stateful surfaces;
+- Pinia integrates naturally for application/UI state;
+- Nuxt provides a clean application framework around Vue;
+- the team/user already has Vue/Nuxt familiarity;
+- the frontend remains independently deployable against the provider-neutral Python backend.
+
+Next.js/React has strengths such as ecosystem size, React Flow, and animation libraries, but those strengths do not outweigh the Nuxt fit for this product.
+
+## 4.2 Styling and component layer
+
+- **Nuxt UI** for application primitives;
+- **Tailwind CSS** for layout/design freedom.
+
+Vuetify is intentionally not the default because the desired Linear/Vercel/Supabase-style product requires more visual control and less Material-design gravity.
+
+## 4.3 State management
+
+- **Pinia** — client/application/UI state;
+- **TanStack Query for Vue** — server state.
+
+Pinia owns things such as:
+
+- authenticated-user UI state that is safe to cache client-side;
+- UI preferences;
+- selected agent/project where appropriate;
+- simulator presentation state;
+- temporary filters/layout preferences;
+- local interaction state that is genuinely global.
+
+TanStack Query owns remote FastAPI state:
+
+- projects;
+- agents;
+- tasks;
+- runs;
+- audits;
+- reviews;
+- providers;
+- permissions;
+- artifacts;
+- metrics.
+
+**Rule:** do not duplicate the complete API cache into Pinia.
+
+## 4.4 API and contract generation
+
+- FastAPI OpenAPI as backend schema source;
+- **Orval** to generate TypeScript types/clients/TanStack Query integration;
+- generated code isolated under `api/generated/`;
+- application-facing composables/adapters wrap generated code where appropriate.
+
+Generated files are never manually edited.
+
+## 4.5 Communication model
+
+- **REST** for commands, CRUD and explicit request/response interactions;
+- **SSE** as the primary server → browser real-time channel;
+- **WebSocket only when genuine bidirectional low-latency interaction is required**.
+
+Typical SSE events:
+
+```text
+agent.started
+agent.completed
+agent.failed
+agent.blocked
+task.status_changed
+run.iteration_started
+run.iteration_completed
+tool.started
+tool.completed
+tool.failed
+review.requested
+review.changes_requested
+review.approved
+security.veto
+provider.health_changed
+approval.required
+pipeline.stage_changed
+```
+
+SSE is favored for normal live runtime events because it is HTTP-friendly, simpler operationally, and naturally fits one-way event streaming.
+
+WebSocket is reserved for future use cases such as:
+
+- interactive terminal sessions;
+- direct agent chat requiring continuous bidirectional messages;
+- live collaborative control surfaces.
+
+## 4.6 Workflow and organization visualization
+
+- **Vue Flow** — primary interactive workflow/company graph engine.
+
+Uses:
+
+- agent nodes;
+- department graph;
+- workflow state;
+- task movement;
+- delegation edges;
+- review handoffs;
+- zoom/pan/selection;
+- interactive dependency views when appropriate.
+
+## 4.7 Custom data visualization
+
+- **D3.js** for custom visualizations where a standard chart abstraction is insufficient.
+
+Examples:
+
+- agent heatmaps;
+- dependency topology;
+- inter-department flows;
+- memory/RAG topology;
+- decision networks;
+- context-flow visualizations;
+- specialized cost/usage topology.
+
+D3 must not reinvent Vue Flow.
+
+## 4.8 Standard analytics charts
+
+- **ECharts** for ordinary dashboard analytics.
+
+Examples:
+
+- cost/day;
+- tokens/project;
+- latency/provider;
+- success rate/agent;
+- retries;
+- tool calls;
+- security findings;
+- memory hit rate;
+- context-compression savings;
+- run duration distributions.
+
+Rule of separation:
+
+```text
+Vue Flow → workflows/org graphs
+D3       → custom/advanced visualizations
+ECharts  → standard analytics
+```
+
+## 4.9 Motion
+
+- **Motion for Vue** — default UI and semantic micro-animation layer;
+- **GSAP** — only for complex synchronized Company Simulator sequences.
+
+Motion for Vue handles:
+
+- panel transitions;
+- cards;
+- state changes;
+- micro-interactions;
+- layout transitions.
+
+GSAP is reserved for:
+
+- synchronized multi-agent sequences;
+- task packet movement;
+- coordinated simulator timelines;
+- advanced choreography that would be cumbersome with ordinary transitions.
+
+Animations must remain semantic and respect `prefers-reduced-motion`.
+
+## 4.10 Authentication
+
+- **Authentik**, self-hosted, deployed as part of the infrastructure;
+- OIDC/OAuth flow between Nuxt, Authentik and FastAPI.
+
+Target model:
+
+```text
+Nuxt
+  ↓
+Authentik
+  ↓ OIDC
+FastAPI
+  ↓
+SynapseOS authorization / Permission Engine
+```
+
+Authentik handles identity concerns:
+
+- login;
+- MFA;
+- password reset;
+- sessions;
+- users/groups;
+- OIDC/SSO.
+
+SynapseOS retains business authorization:
+
+- workspace/project roles;
+- agent permissions;
+- tool permissions;
+- approval rights;
+- security veto authority;
+- deployment authority;
+- workflow transition authority.
+
+**Authentication is not authorization.**
+
+Authentik deployment details are version-sensitive. At implementation time, verify the official deployment architecture/dependencies instead of freezing assumptions (for example, do not add Redis merely because an older deployment guide required it).
+
+## 4.11 Forms and client validation
+
+- **Zod** for client-side schemas/parsing/types;
+- **vee-validate** for form lifecycle/state/errors.
+
+Frontend validation improves UX. FastAPI/Pydantic remains authoritative.
+
+## 4.12 Testing
+
+- **Vitest** — unit tests;
+- **Vue Test Utils** — component tests;
+- **Playwright** — E2E/integration browser tests;
+- **axe-core + Playwright** — automated accessibility checks where applicable.
+
+Also required:
+
+- TypeScript strict;
+- ESLint;
+- consistent formatting via Prettier or the Nuxt ecosystem tooling chosen at bootstrap.
+
+## 4.13 Observability
+
+- **Sentry** — browser error reporting and frontend performance;
+- **OpenTelemetry** — distributed correlation across frontend/backend/runtime.
+
+Desired trace chain:
+
+```text
+Nuxt
+→ FastAPI
+→ Orchestrator
+→ Agent
+→ Tool
+→ LLM
+→ Reviewer
+```
+
+Observability must not capture secrets, provider tokens, unredacted prompts, sensitive file content or unrestricted raw outputs.
+
+## 4.14 Terminal / raw logs
+
+- **xterm.js** for technical terminal/log-like views.
+
+Two concepts must remain separate:
+
+- **Run Timeline** — structured, readable runtime events;
+- **Terminal / Raw Logs** — lower-level stdout/stderr/command evidence.
+
+xterm.js is not permission to create a browser-to-shell bypass.
+
+## 4.15 Icons
+
+- **Lucide Icons** for standard product icons;
+- custom SynapseOS icons for domain concepts such as:
+  - Agent;
+  - Department;
+  - Memory;
+  - Decision;
+  - Security veto;
+  - Model router;
+  - Context compression;
+  - Tool call;
+  - Review loop.
+
+## 4.16 Command Palette
+
+Use **Nuxt UI Command Palette** rather than introducing another heavy dependency initially.
+
+Primary shortcut:
+
+```text
+Cmd/Ctrl + K
+```
+
+Candidate actions:
+
+- open project;
+- open agent;
+- search tasks/runs;
+- show failed runs;
+- navigate to Security;
+- pause/request pause where backend allows it;
+- open audit;
+- switch organization/workspace;
+- switch docs language/version in the documentation app.
+
+Candidate navigation shortcuts:
+
+```text
+G P → Projects
+G A → Agents
+G R → Runs
+/   → Search
+Esc → Close drawer/modal/palette
+```
+
+Shortcuts may become configurable later; they are not all mandatory for the first frontend slice.
+
+---
+
+# 5. Search, notifications, files, tables and task management
+
+## 5.1 Global search
+
+Initial decision:
+
+```text
+PostgreSQL + FastAPI search endpoint(s)
+```
+
+Do **not** introduce Meilisearch on day one.
+
+A unified endpoint may look conceptually like:
+
+```http
+GET /search?q=oauth
+```
+
+Search targets can include:
+
+- projects;
+- agents;
+- tasks;
+- runs;
+- decisions;
+- audit events;
+- skills;
+- tools;
+- documentation entries where applicable.
+
+PostgreSQL full-text search and/or trigram search should be considered before adding another service.
+
+### Meilisearch later
+
+Meilisearch becomes justified when requirements include:
+
+- hundreds of thousands or millions of highly searchable records;
+- strong fuzzy matching;
+- advanced ranking;
+- instant autocomplete at scale;
+- search latency that PostgreSQL can no longer meet acceptably.
+
+If introduced later, search indexing must have explicit synchronization/consistency rules and failure handling.
+
+## 5.2 Notifications
+
+Validated model:
+
+```text
+SynapseOS backend
+      ↓
+Event stream / SSE
+      ↓
+Nuxt
+├── immediate toast
+└── persistent Notification Center
+```
+
+Examples:
+
+- Reviewer requested changes;
+- Security veto issued;
+- Agent blocked;
+- Provider unavailable;
+- Task completed;
+- Approval required;
+- Budget threshold reached;
+- Deployment finished/failed.
+
+Severity model:
+
+```text
+INFO
+→ task completed
+→ agent assigned
+
+WARNING
+→ agent blocked
+→ provider degraded
+→ budget near threshold
+
+CRITICAL
+→ security veto
+→ production deployment failed
+→ sensitive permission escalation
+→ provider outage affecting critical work
+```
+
+### Persistence rule
+
+Persistent notifications are backend data. Read/unread state must not live only in Pinia.
+
+### Deferred external channels
+
+Later integrations may include:
+
+- email;
+- Slack;
+- Discord;
+- generic webhook.
+
+They are not required for the first frontend implementation.
+
+## 5.3 Files and artifacts
+
+Validated storage architecture:
+
+```text
+PostgreSQL
+→ metadata
+→ ownership
+→ project/task/run relationship
+→ type
+→ status
+→ permissions
+→ checksum
+
+MinIO
+→ actual object bytes
+→ specifications
+→ reports
+→ screenshots
+→ builds
+→ artifacts
+→ exports
+```
+
+Use **MinIO** as the initial self-hosted S3-compatible object storage.
+
+Do not store large binaries directly in PostgreSQL unless a narrowly justified exception is documented.
+
+Target upload flow:
+
+```text
+User / Agent
+     ↓
+FastAPI authorization + validation
+     ↓
+S3-compatible storage / MinIO
+     ↓
+PostgreSQL metadata
+```
+
+For large browser uploads, support **presigned URLs** so bytes can travel directly to object storage after the backend has authorized the operation.
+
+Frontend capabilities:
+
+- drag and drop;
+- progress;
+- cancel/retry where safe;
+- preview where safe and supported;
+- download;
+- permission-aware actions;
+- project/task/run association;
+- checksum/status where relevant.
+
+Never render untrusted HTML/file content directly in the application context without appropriate sandboxing/sanitization.
+
+## 5.4 Large tables
+
+Use **TanStack Table for Vue** for data-heavy screens.
+
+Likely screens:
+
+- Agents;
+- Tasks;
+- Runs;
+- Audit logs;
+- Decisions;
+- Tool calls;
+- Providers;
+- Permissions;
+- Artifacts.
+
+Expected capabilities:
+
+- multi-column sorting;
+- server-side filtering;
+- server-side pagination;
+- row selection;
+- hide/show columns;
+- grouping where useful;
+- persistent table preferences where useful;
+- virtualization for large result sets;
+- URL-serializable filters where navigation/bookmarking benefits.
+
+Separation:
+
+```text
+Nuxt UI       → visual controls/primitives
+TanStack Table → headless table behavior
+```
+
+Virtualization should be enabled only where necessary, not mechanically on every table.
+
+## 5.5 Task management and Kanban
+
+The task experience must include a true Trello/Jira-style **Kanban**, but the backend state machine remains authoritative.
+
+Canonical task states currently include:
+
+```text
+BACKLOG
+READY
+ASSIGNED
+IN_PROGRESS
+WAITING_REVIEW
+CHANGES_REQUESTED
+WAITING_QA
+WAITING_SECURITY
+BLOCKED
+COMPLETED
+FAILED
+CANCELLED
+```
+
+The UI may organize columns differently for usability, but it must never fabricate a transition the backend does not allow.
+
+Example:
+
+```text
+IN_PROGRESS → WAITING_REVIEW
+```
+
+may be valid.
+
+A direct browser move such as:
+
+```text
+BACKLOG → COMPLETED
+```
+
+must be rejected when the backend `TaskStateMachine` does not permit it.
+
+### Drag and drop
+
+Use **VueDraggable / SortableJS** for Kanban drag-and-drop instead of hand-rolling pointer interactions.
+
+Drag/drop sequence:
+
+1. user moves card;
+2. UI computes requested transition;
+3. backend command is sent;
+4. backend validates permission + state transition;
+5. successful response/event confirms state;
+6. UI commits/reconciles visual state;
+7. rejection restores previous state and explains the reason.
+
+Optimistic updates must be used cautiously. For security-sensitive or workflow-critical transitions, confirmation from the backend may be preferable before final visual commitment.
+
+### Task card fields
+
+Possible card content:
+
+- title;
+- project;
+- assigned agent;
+- priority;
+- status;
+- progress where meaningfully defined;
+- iteration count;
+- reviewer;
+- elapsed time;
+- blocking reason;
+- required approval/security state.
+
+### Multiple task views
+
+The same task model should support multiple representations:
+
+```text
+Kanban
+→ day-to-day operational workflow
+
+Table
+→ dense analysis/filtering
+
+Timeline
+→ chronological history
+
+Dependency Graph
+→ dependency structure
+
+Company View
+→ who is working on what
+```
+
+The views must not each invent their own task state logic.
+
+---
+
+# 6. Internationalization
+
+Use **`@nuxtjs/i18n` from V1**.
+
+Initial locales:
+
+```text
+fr
+en
+```
+
+Potential structure:
+
+```text
+i18n/
+├── locales/
+│   ├── en.json
+│   └── fr.json
+└── config.ts
+```
+
+No important user-facing business copy should be hardcoded repeatedly inside components.
+
+Prefer:
+
+```vue
+<UButton>{{ $t('projects.actions.create') }}</UButton>
+```
+
+over:
+
+```vue
+<UButton>Créer un projet</UButton>
+```
+
+Domain key examples:
+
+```text
+agents.status.working
+agents.status.blocked
+tasks.status.waiting_review
+security.veto
+reviews.changes_requested
+providers.unavailable
+company.daily_briefing
+```
+
+### Canonical enum rule
+
+Backend/database values remain canonical technical values, typically English uppercase enums:
+
+```text
+WAITING_REVIEW
+CHANGES_REQUESTED
+COMPLETED
+```
+
+The UI translates their labels:
+
+```text
+WAITING_REVIEW
+→ En attente de revue
+→ Waiting for review
+```
+
+Never localize stored enum values themselves.
+
+Locale preference may be detected initially and persisted as a user preference once profile/settings contracts exist.
+
+---
+
+# 7. Design system
+
+The design system is a product contract, not just a Tailwind configuration.
+
+## 7.1 Direction
+
+- dark-first;
+- serious, technical and modern;
+- compact information density;
+- neutral background/surface palette;
+- restrained accent color;
+- semantic status colors;
+- thin borders;
+- minimal shadows;
+- high readability;
+- consistent status representation across every view.
+
+## 7.2 Design tokens
+
+Define tokens for at least:
+
+```text
+colors
+spacing
+radius
+border
+typography
+elevation
+motion
+status
+department
+agent-state
+```
+
+Tokens should live in a reusable layer and be consumable by both `apps/web` and `apps/docs` once shared packages are introduced.
+
+## 7.3 Typography
+
+Use:
+
+- a highly readable sans-serif for product UI;
+- monospace for logs, IDs, commands, hashes, model names, token counts and technical metadata.
+
+Exact font selection can be finalized during visual implementation, but it must preserve readability and license/deployment simplicity.
+
+## 7.4 Agent statuses
+
+At minimum support consistent representations for states such as:
+
+```text
+AVAILABLE
+WORKING
+BLOCKED
+REVIEWING
+FAILED
+WAITING_APPROVAL
+```
+
+The same state must not appear green in one screen and orange in another without a defined semantic reason.
+
+Color cannot be the only channel. Use icon, text, shape/badge, or another accessible cue.
+
+## 7.5 Departments
+
+Do not create a rainbow UI where every department receives a loud saturated color.
+
+Use a neutral base and subtle visual signatures for departments such as:
+
+- Engineering;
+- Product;
+- QA;
+- Security;
+- future departments.
+
+## 7.6 Component principles
+
+Important primitives include:
+
+- sidebar;
+- top bar;
+- command palette;
+- badge/status pill;
+- drawer;
+- modal;
+- table controls;
+- filter bar;
+- empty state;
+- error state;
+- skeleton/loading state;
+- timeline event;
+- metric card;
+- agent card;
+- task card;
+- confirmation/approval dialog;
+- code/log block.
+
+Build domain components on top of primitives. Avoid giant generic components controlled by dozens of boolean props.
+
+---
+
+# 8. Target Nuxt repository architecture
+
+Use a **feature-first architecture**.
+
+Do not put the entire application in a flat `components/` directory.
+
+Target structure:
+
+```text
+apps/web/
+├── app.vue
+├── nuxt.config.ts
+├── package.json
+│
+├── pages/
+│   ├── index.vue
+│   ├── company/
+│   ├── projects/
+│   ├── agents/
+│   ├── tasks/
+│   ├── runs/
+│   ├── reviews/
+│   ├── security/
+│   ├── intelligence/
+│   └── settings/
+│
+├── features/
+│   ├── agents/
+│   ├── projects/
+│   ├── tasks/
+│   ├── runs/
+│   ├── reviews/
+│   ├── permissions/
+│   ├── security/
+│   ├── providers/
+│   ├── memory/
+│   ├── context/
+│   ├── notifications/
+│   └── company-simulator/
+│
+├── components/
+│   ├── ui/
+│   ├── layout/
+│   └── shared/
+│
+├── composables/
+├── stores/
+├── middleware/
+├── layouts/
+├── plugins/
+├── utils/
+├── types/
+├── assets/
+├── public/
+│
+├── api/
+│   ├── generated/
+│   └── adapters/
+│
+├── i18n/
+│   └── locales/
+│       ├── en.json
+│       └── fr.json
+│
+└── tests/
+```
+
+Feature example:
+
+```text
+features/tasks/
+├── components/
+│   ├── TaskCard.vue
+│   ├── TaskKanban.vue
+│   └── TaskDetailsDrawer.vue
+├── composables/
+│   └── useTasks.ts
+├── schemas/
+│   └── task.schema.ts
+├── types/
+├── queries/
+├── utils/
+└── tests/
+```
+
+Responsibility rules:
+
+```text
+pages/
+→ route-level composition
+
+features/
+→ domain-specific frontend behavior
+
+components/ui/
+→ reusable visual primitives
+
+components/shared/
+→ reusable cross-domain application components
+
+api/generated/
+→ Orval output only
+
+api/adapters/
+→ stable app-facing wrappers/mapping where needed
+
+stores/
+→ global client/UI state only
+
+TanStack Query
+→ remote/server state
+```
+
+## 8.1 Web app and documentation app
+
+Long-term structure:
+
+```text
+apps/
+├── web/
+└── docs/
+
+packages/
+├── ui/
+├── icons/
+├── config/
+└── optional shared tooling
+```
+
+Do not prematurely extract packages. Start with two apps and extract only genuinely shared code/design primitives.
+
+---
+
+# 9. Frontend security architecture
+
+## 9.1 Zero-trust frontend principle
+
+The browser is never a trusted policy enforcement boundary.
+
+Frontend guards exist for UX/navigation. Backend authorization is mandatory for every sensitive operation.
+
+```text
+Authentication
+→ Authentik / OIDC
+
+Authorization
+→ FastAPI + SynapseOS Permission Engine
+
+Frontend route/button guards
+→ UX only
+```
+
+## 9.2 Baseline protections
+
+Implement and verify:
+
+- strict Content Security Policy appropriate to the deployed app;
+- XSS prevention and output encoding;
+- explicit sanitization for any rich/untrusted rendered content;
+- secure cookies where the selected auth/session architecture uses cookies;
+- `HttpOnly` for session material that JavaScript does not need to access;
+- `Secure` in HTTPS environments;
+- appropriate `SameSite` policy;
+- CSRF mitigation according to the final OIDC/session flow;
+- minimal CORS allowlist on FastAPI;
+- security headers;
+- dependency auditing;
+- no secret values in client bundles;
+- no provider API keys in browser-accessible runtime configuration;
+- no sensitive token persistence in `localStorage`.
+
+If the chosen OIDC design supports a backend/BFF-style session with HttpOnly cookies, prefer it over persistent browser-readable bearer tokens.
+
+## 9.3 Sensitive-data display policy
+
+Do not display by default:
+
+- API keys;
+- access/refresh tokens;
+- credentials;
+- secret environment values;
+- sensitive prompt portions;
+- raw tool output that has not passed visibility/redaction rules;
+- private file content outside user permissions.
+
+## 9.4 Telemetry redaction
+
+Before sending data to Sentry/OpenTelemetry/analytics/session replay:
+
+- remove tokens;
+- remove cookies/authorization headers;
+- remove provider secrets;
+- avoid raw prompts by default;
+- avoid raw file content;
+- avoid raw unrestricted tool responses;
+- scrub query strings/URL params where secrets could appear;
+- redact personal/sensitive workspace content according to policy.
+
+Session replay, if enabled, must include masking/blocking rules for sensitive fields and surfaces.
+
+## 9.5 xterm.js security
+
+Required flow:
+
+```text
+xterm.js
+   ↓
+explicit frontend action
+   ↓
+FastAPI
+   ↓
+Permission Engine
+   ↓
+Command Runner / ToolExecutor
+   ↓
+bounded result
+```
+
+Forbidden architecture:
+
+```text
+xterm.js → direct host shell
+```
+
+Interactive terminal functionality, if introduced later, must still use backend command profiles, audit, timeout, workspace isolation and permission checks.
+
+## 9.6 Risk-based confirmations
+
+UI confirmation can reflect backend risk levels:
+
+```text
+LOW
+→ immediate action if authorized
+
+MEDIUM
+→ explicit confirmation
+
+HIGH
+→ strong confirmation + clear consequences
+
+CRITICAL
+→ backend approval workflow required
+```
+
+Examples that may require elevated/critical treatment:
+
+- delete workspace/project;
+- production deployment;
+- provider credential changes;
+- permission elevation;
+- security veto override;
+- destructive tool execution.
+
+A red modal is not a security boundary.
+
+---
+
+# 10. Responsive design and accessibility
+
+## 10.1 Device strategy
+
+SynapseOS is **desktop-first but responsive**, not conventionally mobile-first.
+
+### Desktop
+
+Full experience:
+
+- Company Simulator;
+- advanced Kanban;
+- dense tables;
+- complex graphs;
+- terminal/log views;
+- multi-panel Deep Inspect.
+
+### Tablet
+
+Full capability where practical, adapted through:
+
+- collapsible panels;
+- horizontal Kanban scrolling;
+- simplified graph controls;
+- drawer-based detail views.
+
+### Mobile
+
+Prioritize supervision and high-value actions:
+
+- notifications;
+- agents/statuses;
+- tasks;
+- approvals;
+- incidents;
+- lightweight run inspection.
+
+Do not force the complete desktop Company Simulator onto a small screen. Use an alternate compact list/timeline representation of departments, agents, tasks and states.
+
+## 10.2 Accessibility target
+
+Target **WCAG 2.2 AA**.
+
+Requirements:
+
+- full keyboard operation for critical workflows;
+- visible focus;
+- logical focus order;
+- accessible form labels;
+- ARIA only where semantic HTML is insufficient;
+- sufficient contrast;
+- screen-reader-friendly statuses;
+- error messages connected to inputs;
+- no status communicated by color alone;
+- accessible dialogs/drawers;
+- accessible tables and sort controls;
+- accessible command palette.
+
+Core keyboard behavior:
+
+```text
+Cmd/Ctrl + K
+Tab / Shift+Tab
+Enter
+Escape
+Arrow keys
+```
+
+## 10.3 Reduced motion
+
+Respect:
+
+```css
+prefers-reduced-motion
+```
+
+Company Simulator animations that are not essential must reduce or disable automatically. Semantic information must remain understandable without animation.
+
+## 10.4 Accessibility testing
+
+Use axe-core with Playwright for automated detection on critical routes, complemented by manual keyboard and screen-reader spot checks. Automated tooling is not considered complete accessibility validation by itself.
+
+---
+
+# 11. Build and deployment architecture
+
+## 11.1 Container model
+
+Validated target:
+
+```text
+Nuxt app
+   ↓
+Docker image
+   ↓
+reverse proxy
+   ↓
+HTTPS
+```
+
+Infrastructure choices:
+
+- Docker;
+- Docker Compose for development/self-hosted environments;
+- GitHub Container Registry (GHCR);
+- Traefik as preferred reverse proxy for the multi-service self-hosted topology;
+- HTTPS/TLS termination;
+- environment-specific runtime configuration;
+- health checks.
+
+## 11.2 Why Traefik
+
+SynapseOS is expected to expose multiple independently deployable services. Traefik is a good fit for centralized routing/TLS in that topology.
+
+Example hostnames:
+
+```text
+app.synapseos.dev
+api.synapseos.dev
+auth.synapseos.dev
+docs.synapseos.dev
+```
+
+Potential service set:
+
+```text
+web
+api
+postgres
+authentik
+minio
+ollama
+observability
+docs
+```
+
+This is not a requirement to start every service in every environment. Compose profiles or environment-specific stacks may be used to keep development lightweight.
+
+## 11.3 Environments
+
+At minimum:
+
+```text
+development
+staging
+production
+```
+
+Configurations and credentials must be isolated between environments.
+
+Never make `staging` and `production` share mutable data stores or privileged secrets merely for convenience.
+
+## 11.4 Nuxt runtime configuration
+
+Use Nuxt runtime configuration deliberately:
+
+```text
+runtimeConfig
+├── private
+└── public
+```
+
+Only values explicitly safe for the browser belong in public runtime config.
+
+Remember that anything sent to the client is public regardless of how the variable is named.
+
+## 11.5 Health checks
+
+Expose/check the minimum signals required to distinguish:
+
+- process started;
+- application ready;
+- critical dependency unavailable where relevant.
+
+Frontend health should not simply return healthy if the generated server cannot serve the app.
+
+Backend readiness remains a separate concern.
+
+---
+
+# 12. CI/CD pipeline
+
+CI/CD is a first-class SynapseOS subsystem, not an afterthought.
+
+## 12.1 Workflow organization
+
+Recommended structure:
+
+```text
+.github/workflows/
+├── frontend-ci.yml
+├── backend-ci.yml
+├── e2e.yml
+├── security.yml
+├── docker.yml
+├── deploy-staging.yml
+└── deploy-production.yml
+```
+
+The exact split may be adjusted to avoid duplicated setup or excessive workflow overhead, but avoid one unreadable monolithic workflow.
+
+## 12.2 Frontend pull-request quality gate
+
+Target sequence:
+
+```text
+Pull Request
+   ↓
+install dependencies with locked versions
+   ↓
+ESLint
+   ↓
+TypeScript strict / Nuxt typecheck
+   ↓
+Vitest unit tests
+   ↓
+Vue Test Utils component tests
+   ↓
+Nuxt production build
+   ↓
+Playwright E2E where applicable
+   ↓
+Accessibility checks
+   ↓
+Dependency/security checks
+```
+
+A failed mandatory quality gate blocks merge according to repository protection rules.
+
+## 12.3 Backend pipeline remains independent
+
+The frontend must not replace the backend's quality pipeline. Existing backend checks continue independently, including the project's established tooling such as:
+
+- Ruff;
+- strict mypy;
+- pytest;
+- migration checks;
+- security/invariant tests.
+
+## 12.4 Cross-stack E2E pipeline
+
+A dedicated integration pipeline should start the minimum real stack necessary for critical workflows, for example:
+
+```text
+Nuxt
+FastAPI
+PostgreSQL
+Authentik
+MinIO
+required runtime dependencies
+        ↓
+Playwright
+```
+
+Critical scenario example:
+
+```text
+login
+→ create/open project
+→ create/open task
+→ launch/observe authorized agent work
+→ receive SSE update
+→ reviewer workflow
+→ changes requested
+→ correction
+→ completion
+```
+
+Do not make E2E tests depend on nondeterministic paid LLM behavior where a deterministic/fake provider contract can validate the frontend flow more reliably. Separate deterministic product-flow tests from optional live-provider smoke tests.
+
+## 12.5 Docker image pipeline
+
+After successful merge/release conditions:
+
+```text
+build image
+→ scan image
+→ push GHCR
+→ assign immutable tag
+```
+
+Use immutable or traceable tags, for example:
+
+```text
+synapseos-web:sha-abc123
+synapseos-web:1.4.0
+synapseos-web:latest
+```
+
+`latest` must never be the only rollback reference.
+
+## 12.6 Staging deployment
+
+Typical target:
+
+```text
+main
+ ↓
+CI complete
+ ↓
+Docker image
+ ↓
+GHCR
+ ↓
+deploy staging
+ ↓
+health checks
+ ↓
+smoke tests
+```
+
+Staging deployment may be automatic after a protected successful main build.
+
+## 12.7 Production deployment
+
+Do not deploy production automatically merely because a commit hit `main`.
+
+Preferred release model:
+
+```text
+release/tag
+    ↓
+known tested artifact
+    ↓
+production approval gate
+    ↓
+deploy
+    ↓
+health checks
+    ↓
+smoke tests
+```
+
+The approval gate may be manual initially. The key property is that production promotion is explicit and traceable.
+
+## 12.8 Rollback
+
+A failed deployment must have an operational rollback story:
+
+```text
+new deployment unhealthy
+      ↓
+select previous known-good immutable image
+      ↓
+rollback
+      ↓
+health + smoke verification
+```
+
+Rollback procedures must be documented and tested in staging before they are trusted in production.
+
+## 12.9 Preview environments
+
+Future enhancement:
+
+```text
+PR #142
+→ preview-142.synapseos.dev
+```
+
+Useful for Company Simulator, Kanban and major UI changes.
+
+Preview environments are deliberately deferred until CI, staging and deployment basics are stable.
+
+## 12.10 CI/CD secrets
+
+Secrets must come from protected GitHub Environments/Secrets or another approved secret-management mechanism.
+
+Forbidden:
+
+- committed `.env` secrets;
+- hardcoded API keys in workflow YAML;
+- passwords in Dockerfiles;
+- secrets leaked via build args that become inspectable image metadata;
+- echoing secrets in logs.
+
+Use GitHub environments such as:
+
+```text
+development
+staging
+production
+```
+
+Production should have stronger protection/approval rules.
+
+## 12.11 SynapseOS visualizes its own pipeline
+
+Later, SynapseOS should ingest CI/CD events and render them as real organization activity.
+
+Example:
+
+```text
+Developer Agent
+    ↓
+PR #142
+    ↓
+CI running
+
+✓ Ruff
+✓ mypy
+✓ pytest
+✓ frontend
+● E2E
+○ Security
+○ Deploy
+```
+
+This is a real-data integration, not a fake simulator animation.
+
+---
+
+# 13. Official SynapseOS documentation site
+
+SynapseOS must have a first-class public documentation product, not only raw Markdown rendered by GitHub.
+
+## 13.1 Validated documentation stack
+
+```text
+apps/docs/
+├── Nuxt
+├── Nuxt Content
+├── Nuxt UI
+├── Tailwind CSS
+├── @nuxtjs/i18n
+└── Command Palette
+```
+
+Additional capabilities:
+
+- Mermaid for architecture/workflow diagrams;
+- OpenAPI-driven API reference;
+- Scalar as the preferred modern OpenAPI renderer candidate;
+- FR/EN;
+- dark/light mode;
+- documentation search;
+- version-ready architecture;
+- GitHub edit links;
+- dedicated docs CI.
+
+## 13.2 Product goal
+
+Target experience quality is inspired by:
+
+- Linear Docs;
+- GitHub Docs;
+- Vercel Docs;
+- Stripe Docs;
+- Supabase Docs.
+
+The result should still have a distinct SynapseOS identity.
+
+## 13.3 Target desktop layout
+
+```text
+┌─────────────────────────────────────────────────────────────┐
+│ SynapseOS Docs        Search / Cmd+K             GitHub     │
+├───────────────┬────────────────────────────┬────────────────┤
+│ Navigation    │ Main documentation content │ On this page   │
+│               │                            │                │
+│ Getting Start │ Headings                   │ Overview       │
+│ Concepts      │ Examples                   │ Configuration  │
+│ Agents        │ Code blocks                │ Security       │
+│ Tools         │ Diagrams                   │                │
+│ Skills        │                            │                │
+│ Memory        │                            │                │
+│ API           │                            │                │
+└───────────────┴────────────────────────────┴────────────────┘
+```
+
+## 13.4 Required UX
+
+- compact left navigation;
+- right-hand table of contents on capable screen sizes;
+- global search;
+- `Cmd/Ctrl + K`;
+- dark/light mode;
+- FR/EN;
+- copy-code buttons;
+- syntax highlighting;
+- callouts;
+- tabs;
+- Mermaid diagrams;
+- deep links to headings;
+- previous/next navigation;
+- responsive mobile navigation;
+- edit-on-GitHub action;
+- clear version indicator once versioning is active.
+
+## 13.5 Documentation Command Palette
+
+Example query:
+
+```text
+> agent runtime
+```
+
+Possible results:
+
+```text
+Agent Runtime
+Create an Agent
+Agent Lifecycle
+Agent Permissions
+Agent Runtime API
+```
+
+Actions can include:
+
+- open GitHub repository;
+- go to API reference;
+- switch to French/English;
+- switch documentation version;
+- copy installation command;
+- navigate to a concept/guide.
+
+## 13.6 Documentation information architecture
+
+Initial structure:
+
+```text
+01. Getting Started
+    ├── Introduction
+    ├── What is SynapseOS?
+    ├── Installation
+    ├── Quickstart
+    └── Docker
+
+02. Core Concepts
+    ├── Agents
+    ├── Departments
+    ├── Projects
+    ├── Tasks
+    ├── Runs
+    ├── Tools
+    ├── Skills
+    ├── Permissions
+    ├── Reviews
+    └── Loop Engineering
+
+03. Architecture
+    ├── System Overview
+    ├── Agent Runtime
+    ├── Tool Executor
+    ├── Permission Engine
+    ├── Multi-Agent Workflows
+    ├── Memory
+    ├── Context Intelligence
+    ├── Model Router
+    └── Audit System
+
+04. Guides
+    ├── Create an Agent
+    ├── Create a Tool
+    ├── Create a Skill
+    ├── Add an LLM Provider
+    ├── Build a Workflow
+    └── Configure Permissions
+
+05. API Reference
+    ├── Authentication
+    ├── Agents
+    ├── Projects
+    ├── Tasks
+    ├── Runs
+    └── Events
+
+06. Deployment
+    ├── Docker
+    ├── Production
+    ├── Authentik
+    ├── MinIO
+    └── Observability
+
+07. Security
+
+08. Contributing
+
+09. Changelog
+```
+
+As the product evolves, CLI/SDK sections can be added when they actually exist.
+
+## 13.7 Product docs vs engineering docs
+
+Keep two audiences clear:
+
+```text
+Product documentation
+→ how to use SynapseOS
+
+Engineering documentation
+→ how SynapseOS works internally
+```
+
+Example:
+
+- “Create a project” is product documentation;
+- “Developer ↔ Reviewer workflow internals” is engineering documentation.
+
+Both belong in the official docs but should not be mixed into one overloaded page.
+
+## 13.8 API reference
+
+Do not maintain endpoint reference manually when FastAPI already emits OpenAPI.
+
+Target chain:
+
+```text
+FastAPI
+   ↓
+openapi.json
+   ↓
+API documentation renderer
+   ↓
+SynapseOS API Reference
+```
+
+Scalar is the preferred candidate for a modern embedded API reference.
+
+The API reference should inherit or visually align with the SynapseOS docs shell where practical.
+
+## 13.9 Documentation search
+
+Start simple:
+
+- Nuxt Content-generated index/local search or another low-infrastructure approach compatible with the docs stack;
+- Command Palette uses the same search data where practical.
+
+Do not add Meilisearch before size/latency/fuzzy-search requirements justify it.
+
+## 13.10 Documentation versioning
+
+Architecture must be version-ready, e.g.:
+
+```text
+v1.0
+v1.1
+v2.0
+```
+
+A visible notice may eventually say:
+
+```text
+You are viewing SynapseOS v1.x
+```
+
+Do not create fake version complexity before the first stable public version exists.
+
+## 13.11 Mermaid
+
+Mermaid is strongly recommended for:
+
+- multi-agent workflows;
+- task state machines;
+- LLM routing;
+- Permission Engine flows;
+- Context Intelligence Layer;
+- deployment topology;
+- CI/CD flows.
+
+Diagrams must remain source-controlled and reviewable.
+
+## 13.12 Documentation CI
+
+Pull-request pipeline:
+
+```text
+Docs PR
+ ↓
+Markdown/MDC lint
+ ↓
+broken-link checks
+ ↓
+Nuxt typecheck
+ ↓
+production build
+ ↓
+preview/smoke validation
+```
+
+Broken internal links should fail CI once the link checker is stable enough to be authoritative.
+
+Deployment:
+
+```text
+build docs
+ ↓
+Docker image / deploy artifact
+ ↓
+deploy
+ ↓
+docs.synapseos.dev
+```
+
+---
+
+# 14. Observability UX and runtime-event model
+
+The frontend should favor **structured events** over parsing human-readable logs.
+
+## 14.1 Event envelope
+
+The exact backend contract is backend-owned, but the frontend benefits from a normalized event shape conceptually containing:
+
+```text
+event_id
+event_type
+timestamp
+workspace_id/project_id
+task_id (optional)
+run_id (optional)
+agent_id (optional)
+severity
+summary
+metadata (bounded/redacted)
+correlation/trace id (where available)
+```
+
+## 14.2 Event ordering and reconnect
+
+SSE implementation must define behavior for:
+
+- reconnect;
+- duplicate event delivery;
+- missed event recovery where supported;
+- out-of-order timestamps;
+- disconnected/degraded banner;
+- background-tab resume;
+- query-cache reconciliation after reconnect.
+
+The UI must not assume a TCP-like forever-perfect stream.
+
+## 14.3 Timeline vs audit
+
+Do not confuse:
+
+- **operational timeline**: human-readable runtime progression;
+- **audit log**: durable security/forensic record.
+
+The frontend can display both, but a pretty timeline must not be treated as the authoritative audit trail.
+
+---
+
+# 15. Memory, RAG and Context Intelligence frontend readiness
+
+The backend roadmap introduces memory progressively and includes a future Context Intelligence Layer. The frontend architecture must be ready to surface those capabilities without requiring them to exist on day one.
+
+Potential future views:
+
+- memory entries relevant to a task/agent;
+- memory source and recency;
+- retrieval hits/misses;
+- memory hit rate;
+- context budget usage;
+- raw vs optimized context size;
+- tokens saved by compression;
+- context classification;
+- provider/model route selected;
+- reason/constraints for routing where safely exposable;
+- access to raw source content only when permission and retention policies allow it.
+
+D3 can support memory/context topology. ECharts can support aggregate compression/token metrics.
+
+**Do not implement an elaborate RAG visualization before the backend memory contracts exist.**
+
+---
+
+# 16. Frontend implementation roadmap
+
+> **Execution rule:** do not implement all phases at once. Each phase should normally map to a focused PR with its own tests, acceptance evidence, and explicit “not implemented” list.
+>
+> Package-install examples below use `pnpm` for readability. At implementation time, use the repository-standard package manager and commit the corresponding lockfile. Do not introduce a second package manager merely because an example uses `pnpm`.
+
+## PHASE FE-0 — Backend readiness and contract inventory
+
+### Objective
+
+Confirm the backend is ready for the first frontend vertical slice and identify authoritative contracts before creating UI behavior.
+
+### Work
+
+- inventory existing FastAPI routes;
+- export/inspect OpenAPI;
+- inventory task states and transition endpoints;
+- inventory auth/permission expectations;
+- inventory agent/run/review/audit models;
+- inventory SSE/event contracts if already implemented;
+- identify endpoints that do **not** yet exist rather than mocking them as permanent assumptions;
+- produce a frontend/backend contract matrix.
+
+### Rules
+
+- no backend business-rule duplication;
+- no undocumented fake API contract committed as if final;
+- no direct DB access from frontend;
+- no “temporary” permission bypass.
+
+### Tests/validation
+
+- OpenAPI parses successfully;
+- required first-slice endpoints are listed with status: available / missing / unstable;
+- all backend enums used by the first slice are mapped without renaming their canonical values.
+
+### Acceptance criteria
+
+- frontend team can name the backend source of truth for auth, task state, permissions and run events;
+- known contract gaps are explicit.
+
+### Deliberately out of scope
+
+- visual implementation;
+- Company Simulator;
+- speculative endpoints.
+
+### Definition of Done
+
+Contract inventory reviewed before FE-1 begins.
+
+---
+
+## PHASE FE-1 — Nuxt + TypeScript application bootstrap
+
+### Objective
+
+Create `apps/web` as a minimal, strict, production-buildable Nuxt application.
+
+### Install
+
+Conceptually:
+
+```bash
+pnpm add nuxt vue
+pnpm add -D typescript eslint
+```
+
+Use Nuxt-recommended setup/version commands at implementation time instead of copying stale versions from this document.
+
+### Configuration
+
+- strict TypeScript;
+- environment/runtime config skeleton;
+- ESLint;
+- formatting convention;
+- build scripts;
+- basic test scripts;
+- no secrets in checked-in config.
+
+### Target files
+
+```text
+apps/web/
+├── app.vue
+├── nuxt.config.ts
+├── package.json
+├── tsconfig.json
+├── pages/
+├── components/
+├── features/
+├── composables/
+├── stores/
+├── api/
+├── i18n/
+└── tests/
+```
+
+### Rules
+
+- no business features yet;
+- no direct fetch wrappers spread across components;
+- no disabling TypeScript strictness to make bootstrap pass.
+
+### Tests
+
+- app mounts;
+- production build succeeds;
+- typecheck succeeds;
+- lint succeeds.
+
+### Common errors
+
+- client/server API usage mixed accidentally;
+- runtime environment secrets placed in public config;
+- duplicate app initialization plugins.
+
+### Acceptance criteria
+
+A clean Nuxt shell builds in CI-equivalent conditions.
+
+### Deliberately out of scope
+
+Auth, API generation, simulator and feature pages.
+
+---
+
+## PHASE FE-2 — Nuxt UI + Tailwind + design tokens
+
+### Objective
+
+Establish the visual foundation without building domain features.
+
+### Install
+
+Install current Nuxt UI/Tailwind integration according to official Nuxt UI guidance.
+
+### Configuration
+
+Define:
+
+- dark-first theme;
+- light-mode compatibility;
+- neutral surface scale;
+- primary accent;
+- semantic statuses;
+- spacing/radius/border/elevation tokens;
+- typography and monospace roles;
+- motion tokens;
+- focus styles.
+
+### Target files
+
+Possible structure:
+
+```text
+apps/web/assets/css/main.css
+apps/web/app.config.ts
+apps/web/components/ui/
+apps/web/components/layout/
+```
+
+Shared tokens may move to `packages/ui` later.
+
+### Rules
+
+- avoid one-off hex values throughout feature components;
+- color is never the only status cue;
+- no excessive shadows/gradients that contradict the validated identity;
+- reusable primitives before duplicated markup.
+
+### Tests
+
+- representative primitives render in dark/light modes;
+- focus is visible;
+- semantic status components have textual/icon cues;
+- basic visual regression may be added once stable.
+
+### Common errors
+
+- over-customizing Nuxt UI before real screens exist;
+- department rainbow palette;
+- contrast regressions in dark mode.
+
+### Acceptance criteria
+
+A small internal showcase page demonstrates the agreed SynapseOS visual language.
+
+### Deliberately out of scope
+
+Company Simulator choreography and custom D3 graphics.
+
+---
+
+## PHASE FE-3 — Application shell, navigation and Command Palette
+
+### Objective
+
+Create the stable navigation skeleton for Company View, Control Center and Deep Inspect entry points.
+
+### Technology
+
+- Nuxt layouts/pages;
+- Nuxt UI navigation primitives;
+- Nuxt UI Command Palette;
+- Lucide Icons.
+
+### Install
+
+Install Lucide Vue integration if not already pulled transitively/available through the chosen Nuxt UI setup.
+
+### Configuration/integration
+
+- compact sidebar;
+- responsive header;
+- workspace/project context location;
+- `Cmd/Ctrl+K` global palette;
+- route search/action registry;
+- keyboard focus management.
+
+### Target files
+
+```text
+layouts/default.vue
+components/layout/AppSidebar.vue
+components/layout/AppHeader.vue
+features/command-palette/
+pages/company/
+pages/projects/
+pages/agents/
+pages/tasks/
+pages/runs/
+pages/security/
+pages/intelligence/
+```
+
+### Rules
+
+- palette actions invoking mutations still go through normal permission-aware API flows;
+- keyboard shortcuts must not conflict with text inputs;
+- no inaccessible div-only navigation.
+
+### Tests
+
+- keyboard opens/closes palette;
+- arrow/enter navigation works;
+- routes are reachable;
+- mobile sidebar works;
+- `Esc` restores focus appropriately.
+
+### Common errors
+
+- global shortcut firing while typing;
+- focus trapped after drawer close;
+- route and palette registries drifting apart.
+
+### Acceptance criteria
+
+All primary sections can be reached by navigation and keyboard without feature implementations.
+
+---
+
+## PHASE FE-4 — i18n foundation
+
+### Objective
+
+Make FR/EN a structural capability before feature text proliferates.
+
+### Technology
+
+`@nuxtjs/i18n`.
+
+### Install
+
+```bash
+pnpm add @nuxtjs/i18n
+```
+
+Verify the current official module setup for the selected Nuxt version.
+
+### Configuration
+
+- `fr` and `en` locales;
+- explicit fallback locale;
+- consistent key naming;
+- locale-switch UI;
+- persistence strategy when user settings exist.
+
+### Files
+
+```text
+i18n/locales/fr.json
+i18n/locales/en.json
+i18n/config.ts
+```
+
+### Rules
+
+- never translate backend enum values themselves;
+- translate labels/messages around canonical values;
+- no feature ships with large new blocks of hardcoded user-facing strings.
+
+### Tests
+
+- locale switching;
+- missing-key behavior;
+- enum-label mapping;
+- critical pages render in both locales.
+
+### Common errors
+
+- using translated strings as API values;
+- concatenating translated fragments that break grammar;
+- duplicate keys with different meaning.
+
+### Acceptance criteria
+
+Shell and design-system showcase are fully usable in FR and EN.
+
+---
+
+## PHASE FE-5 — Orval API generation and adapters
+
+### Objective
+
+Make FastAPI OpenAPI the source of frontend API types and reduce hand-maintained contract drift.
+
+### Technology
+
+Orval + generated TypeScript client/TanStack Query bindings.
+
+### Install
+
+Install Orval as a development dependency and the HTTP/query integration selected by its current Nuxt/Vue guidance.
+
+### Configuration
+
+- OpenAPI source path/URL;
+- deterministic generated output;
+- generated folder excluded from manual edits;
+- generation script;
+- CI check that generation is up to date where practical.
+
+### Files
+
+```text
+orval.config.*
+api/generated/
+api/adapters/
+```
+
+### Integration rules
+
+- UI components do not import low-level generated internals everywhere;
+- use feature composables/adapters for behavior that needs mapping, caching policy or permission-aware UX;
+- avoid rewriting backend-generated DTOs by hand unless a UI-specific view model is genuinely different.
+
+### Tests
+
+- generation succeeds against current OpenAPI;
+- generated client typechecks;
+- a smoke request to `/health` or safe endpoint succeeds in integration environment.
+
+### Common errors
+
+- committing stale generated files;
+- manual changes overwritten by regeneration;
+- generated nullable/optional semantics ignored by UI.
+
+### Acceptance criteria
+
+A documented single command regenerates the API layer reproducibly.
+
+---
+
+## PHASE FE-6 — TanStack Query server-state layer
+
+### Objective
+
+Establish one coherent strategy for remote data caching, loading, retries and invalidation.
+
+### Install
+
+Install the current `@tanstack/vue-query` package.
+
+### Configuration
+
+Define defaults for:
+
+- stale times by data class;
+- retry policy;
+- refetch behavior;
+- mutation invalidation;
+- error normalization;
+- offline/reconnect behavior where useful.
+
+### Rules
+
+- server state belongs here, not copied wholesale into Pinia;
+- do not retry unsafe mutations blindly;
+- authentication failures are not normal retriable network errors;
+- permission failures should surface clearly.
+
+### Tests
+
+- query loading/success/error;
+- invalidation after mutation;
+- retry boundaries;
+- cache update after SSE reconciliation later.
+
+### Common errors
+
+- default retries hammering failed providers/endpoints;
+- stale cached permission view after role change;
+- query keys inconsistent across features.
+
+### Acceptance criteria
+
+At least one real backend resource uses the standard query abstraction end-to-end.
+
+---
+
+## PHASE FE-7 — Pinia client/UI state
+
+### Objective
+
+Introduce Pinia only for genuine application/client state.
+
+### Install
+
+Install Pinia/Nuxt integration according to current Nuxt guidance.
+
+### Suggested stores
+
+- UI preferences;
+- simulator viewport/presentation state;
+- selected contextual entity where route state is insufficient;
+- non-server command-palette preferences;
+- ephemeral global UI state.
+
+### Rules
+
+Do not create stores that mirror `projects`, `tasks`, `runs`, etc. when TanStack Query already owns them.
+
+### Tests
+
+- store actions/getters;
+- persistence only for explicitly safe preferences;
+- reset on logout/workspace change where required.
+
+### Common errors
+
+- persisted sensitive state;
+- server cache duplication;
+- cross-workspace stale selections.
+
+### Acceptance criteria
+
+Pinia has a small, clearly documented responsibility boundary.
+
+---
+
+## PHASE FE-8 — Authentik OIDC integration
+
+### Objective
+
+Use a mature identity provider instead of building password/session identity from scratch.
+
+### Technology
+
+Authentik + OIDC.
+
+### Infrastructure installation
+
+Authentik runs in the Docker/self-hosted infrastructure, using the current official Authentik deployment requirements.
+
+### Configuration
+
+- OIDC application/provider for SynapseOS;
+- redirect/callback URIs for development/staging/production;
+- logout flow;
+- groups/claims only where useful;
+- MFA policy as deployment policy requires;
+- secret storage outside client bundle.
+
+### Nuxt integration
+
+Prefer a secure session architecture in which browser-readable long-lived tokens are minimized. Exact implementation can use an appropriate Nuxt server/BFF/session mechanism if compatible with the final deployment design.
+
+### FastAPI integration
+
+FastAPI validates identity/token/session context and maps authenticated identity to SynapseOS authorization context. Business roles remain SynapseOS-owned.
+
+### Rules
+
+- no custom password storage in Nuxt;
+- no provider secrets in client runtime config;
+- no auth token persisted in `localStorage` by default;
+- route middleware is UX, not authorization;
+- logout clears local caches and sensitive UI state.
+
+### Tests
+
+- login redirect/callback;
+- authenticated API request;
+- expired session;
+- logout;
+- unauthorized/forbidden behavior;
+- workspace switching does not leak prior cached data.
+
+### Common errors
+
+- callback URL mismatch;
+- CORS/CSRF confusion;
+- ID token used incorrectly as API authorization token;
+- browser-readable refresh tokens persisted insecurely;
+- frontend role claim treated as final authority.
+
+### Acceptance criteria
+
+A user can authenticate through Authentik and FastAPI independently enforces authorization.
+
+### Deliberately out of scope
+
+Building a custom identity provider.
+
+---
+
+## PHASE FE-9 — Forms: Zod + vee-validate
+
+### Objective
+
+Standardize form parsing, validation and error UX.
+
+### Install
+
+```bash
+pnpm add zod vee-validate
+```
+
+Add the current supported Zod integration adapter if the selected versions require it.
+
+### Rules
+
+- Zod is client validation, not backend authority;
+- backend validation errors must map cleanly to forms;
+- sensitive fields never logged;
+- reusable domain schemas live with their features.
+
+### Tests
+
+- valid/invalid submission;
+- backend validation mapping;
+- touched/dirty state;
+- keyboard submission;
+- error-summary/focus behavior on complex forms.
+
+### Common errors
+
+- duplicating Pydantic semantics imperfectly;
+- treating frontend validation as security;
+- losing server error detail.
+
+### Acceptance criteria
+
+First project/task/settings forms share a consistent validation pattern.
+
+---
+
+## PHASE FE-10 — SSE real-time event stream
+
+### Objective
+
+Add one robust server→browser live event channel for runtime updates before introducing WebSockets.
+
+### Technology
+
+Server-Sent Events (SSE), using the browser/EventSource-compatible approach or a small client wrapper when headers/auth requirements demand it.
+
+### Backend prerequisite
+
+A stable, permission-filtered SSE endpoint with documented event types and reconnect semantics.
+
+### Integration
+
+Create a dedicated real-time layer instead of opening EventSource connections ad hoc inside pages.
+
+Potential structure:
+
+```text
+features/realtime/
+├── composables/useEventStream.ts
+├── event-types.ts
+├── event-router.ts
+├── reconnect-policy.ts
+└── tests/
+```
+
+### Event handling
+
+Events should update:
+
+- visible timelines;
+- notification triggers;
+- TanStack Query cache/invalidation;
+- Company Simulator state;
+- run/status badges.
+
+### Required behavior
+
+- reconnect with bounded backoff;
+- detect disconnected/degraded state;
+- deduplicate events when event IDs exist;
+- reconcile critical server state after reconnect;
+- cleanly close streams on logout/context change;
+- prevent cross-workspace event leakage;
+- avoid unbounded in-memory event history.
+
+### Tests
+
+- connection established;
+- event routing;
+- duplicate event handling;
+- reconnect;
+- logout closes stream;
+- workspace switch closes/reopens scoped stream;
+- malformed/unknown event handled safely;
+- cache reflects authoritative state after reconnect.
+
+### Common errors
+
+- creating one stream per component;
+- treating SSE as guaranteed exactly-once delivery;
+- memory leak from listeners;
+- stale state after network sleep/resume;
+- exposing events the user is no longer allowed to observe.
+
+### Acceptance criteria
+
+An agent/task/run status can change in the backend and appear in the UI without polling as the normal path.
+
+### Deliberately out of scope
+
+WebSocket interactive terminal/chat.
+
+---
+
+## PHASE FE-11 — Notifications and toast system
+
+### Objective
+
+Turn relevant backend events into useful, persistent and non-spammy user notifications.
+
+### Technology
+
+- Nuxt UI toast primitives;
+- backend-persisted Notification Center;
+- SSE for live delivery.
+
+### UI
+
+Implement:
+
+- toast for immediate feedback;
+- notification drawer/center;
+- unread count;
+- severity;
+- mark read/unread;
+- link to relevant project/task/run/review;
+- empty/error/loading states.
+
+### Rules
+
+- not every SSE event deserves a toast;
+- notification persistence comes from backend;
+- user must be able to distinguish informational, warning and critical items;
+- do not expose sensitive payload details in notification previews.
+
+### Tests
+
+- real-time notification arrival;
+- unread persistence;
+- mark read;
+- duplicate suppression where backend/event IDs permit;
+- critical notification accessibility;
+- deep link destination.
+
+### Acceptance criteria
+
+Reviewer changes, security veto, agent block and approval-required scenarios are surfaced appropriately.
+
+### Deliberately out of scope
+
+Email/Slack/Discord/webhook channels.
+
+---
+
+## PHASE FE-12 — Data-heavy tables with TanStack Table
+
+### Objective
+
+Create reusable table architecture for dense operational data.
+
+### Install
+
+Install the current Vue package for TanStack Table and virtualization package only if a measured use case requires it.
+
+### First candidate
+
+Runs or Agents table.
+
+### Capabilities
+
+- server pagination;
+- server sorting;
+- server filters;
+- column visibility;
+- row actions;
+- loading skeleton;
+- empty state;
+- error state;
+- accessible headers/sorting;
+- optional row selection.
+
+### URL state
+
+For valuable shareable views, serialize stable filters/sort/page into the URL.
+
+### Tests
+
+- sort mapping to API;
+- filters;
+- pagination;
+- invalid URL filter fallback;
+- loading/error/empty;
+- keyboard-accessible row actions.
+
+### Common errors
+
+- loading full datasets into browser just to sort;
+- unstable column IDs;
+- virtualization breaking keyboard navigation;
+- table state diverging from URL/query cache.
+
+### Acceptance criteria
+
+One production-grade table becomes the reference implementation for later data screens.
+
+---
+
+## PHASE FE-13 — Project and task operational UI
+
+### Objective
+
+Create the first substantial Control Center vertical slice using real backend projects/tasks.
+
+### Features
+
+- project list/detail;
+- task list/detail;
+- task filters;
+- task state visualization;
+- permissions-aware actions;
+- task history/timeline link;
+- dependency summaries.
+
+### Rules
+
+- canonical backend states displayed, not redefined;
+- transitions always requested from backend;
+- mutation errors retain previous authoritative state;
+- acceptance criteria and blocking reason remain visible where useful.
+
+### Tests
+
+- create/view/update supported project/task fields;
+- forbidden mutations;
+- invalid transition feedback;
+- status updates arriving through SSE;
+- i18n labels for all known states.
+
+### Acceptance criteria
+
+A user can manage/inspect tasks without needing the future simulator.
+
+---
+
+## PHASE FE-14 — Kanban + drag and drop
+
+### Objective
+
+Add the validated Trello/Jira-style task board on top of the already working task APIs.
+
+### Technology
+
+VueDraggable / SortableJS.
+
+### Install
+
+Install the maintained Vue wrapper/SortableJS package selected at implementation time; verify Nuxt SSR/client compatibility.
+
+### Behavior
+
+- columns map to canonical workflow states or documented groups;
+- drag requests a backend state transition;
+- backend validates state + actor permission;
+- rejection restores the card and explains why;
+- real-time events reconcile moves initiated by agents/other users.
+
+### Accessibility
+
+Drag/drop must have an accessible alternative. A user unable to use pointer drag must still be able to request an allowed transition through keyboard/menu actions.
+
+### Tests
+
+- valid drag;
+- invalid drag;
+- permission denied;
+- concurrent external status change;
+- SSE reconciliation;
+- keyboard alternative;
+- mobile horizontal board behavior.
+
+### Common errors
+
+- optimistic card move never rolled back;
+- duplicated task after concurrent event;
+- direct client-only reorder mistaken for backend transition;
+- inaccessible drag-only interaction.
+
+### Acceptance criteria
+
+Kanban is a representation of the real `TaskStateMachine`, not a separate workflow engine.
+
+---
+
+## PHASE FE-15 — Runs, reviews, approvals and Deep Inspect timeline
+
+### Objective
+
+Expose the core engineering loop in a readable operational view.
+
+### Features
+
+- run list/detail;
+- iteration timeline;
+- developer evidence summary;
+- reviewer request/result;
+- changes-requested path;
+- approvals;
+- tool call summaries;
+- security-related stops where available;
+- correlation/trace navigation when safe.
+
+### UX separation
+
+Use:
+
+- human-readable structured timeline first;
+- raw/technical evidence behind expandable Deep Inspect surfaces.
+
+### Rules
+
+- never expose provider secrets or raw sensitive prompts by default;
+- reviewer “approved” label maps to backend result;
+- frontend cannot manufacture approval;
+- audit identifiers remain linkable where permissions permit.
+
+### Tests
+
+- completed/failed/cancelled run;
+- multi-iteration run;
+- reviewer changes request;
+- approval required/denied;
+- missing redacted fields handled gracefully.
+
+### Acceptance criteria
+
+A user can understand why an agent workflow succeeded, failed, or stopped without reading raw logs first.
+
+---
+
+## PHASE FE-16 — xterm.js raw logs / technical console
+
+### Objective
+
+Provide a terminal-quality presentation for bounded command/log output without bypassing SynapseOS execution controls.
+
+### Install
+
+Install `xterm`/current xterm.js packages and required fit/resize add-ons only as needed.
+
+### Configuration
+
+- read-only by default;
+- resize handling;
+- bounded buffer/history;
+- safe copy behavior;
+- clear stdout/stderr distinction if backend provides it;
+- sanitized URLs/escape sequences where applicable.
+
+### Security rules
+
+- no direct SSH/host shell;
+- no browser-supplied arbitrary command execution unless a future backend capability explicitly authorizes it;
+- command actions pass Permission Engine/Command Runner;
+- output visibility follows workspace/project permissions;
+- dangerous terminal escape/content handling reviewed.
+
+### Tests
+
+- large bounded output;
+- resize;
+- redacted content;
+- permission denied;
+- terminated/cancelled command;
+- no uncontrolled memory growth.
+
+### Common errors
+
+- treating xterm as a shell backend;
+- rendering infinite logs;
+- ANSI/escape handling security bugs;
+- secrets copied into telemetry.
+
+### Acceptance criteria
+
+Technical logs are inspectable without weakening backend command isolation.
+
+---
+
+## PHASE FE-17 — Analytics with ECharts
+
+### Objective
+
+Add standard operational analytics only after reliable metrics endpoints exist.
+
+### Install
+
+Install ECharts and a Vue/Nuxt-friendly integration pattern compatible with client-side rendering.
+
+### Initial charts
+
+- tokens by project/time;
+- run success/failure;
+- latency by provider/model;
+- retries/iterations;
+- tool-call volume;
+- cost where cost data is available;
+- security findings;
+- agent reliability/reputation trends where meaningful.
+
+### Rules
+
+- charts must include accessible labels/summary values;
+- avoid misleading axes/truncated scales;
+- distinguish missing data from zero;
+- confidence/reputation metrics require explanatory copy/tooltip.
+
+### Tests
+
+- data transform unit tests;
+- empty/partial data;
+- timezone boundaries;
+- responsive rendering;
+- locale number/date formatting.
+
+### Acceptance criteria
+
+Charts summarize real metrics and link to underlying records where useful.
+
+---
+
+## PHASE FE-18 — Company Simulator V1 with Vue Flow
+
+### Objective
+
+Create the first immersive company representation using real agents, departments, tasks and events.
+
+### Install
+
+Install the current Vue Flow packages and required style assets.
+
+### Node types
+
+Potential custom nodes:
+
+- Department;
+- Agent;
+- Task/work item;
+- Review gate;
+- Security gate;
+- workflow boundary.
+
+### Behavior
+
+- pan/zoom/select;
+- semantic agent status;
+- task/assignment edges;
+- click opens detail drawer;
+- live SSE state updates;
+- no fake “busy” animation when backend is idle.
+
+### State shown on agent selection
+
+Where available and authorized:
+
+- role;
+- status;
+- task;
+- model;
+- tokens/cost;
+- runtime;
+- iteration;
+- tools;
+- last action;
+- confidence.
+
+### Tests
+
+- node rendering from real DTOs;
+- status change via SSE;
+- selection/deep link;
+- empty company;
+- large department fallback/performance;
+- reduced-motion behavior.
+
+### Common errors
+
+- overloading graph with every event;
+- animations disconnected from backend truth;
+- inaccessible node interaction;
+- storing business state only inside graph node state.
+
+### Acceptance criteria
+
+A user can inspect “who is doing what” through the graph and reach the same authoritative records as Control Center.
+
+---
+
+## PHASE FE-19 — Motion for Vue and semantic simulator animation
+
+### Objective
+
+Add motion after Company Simulator state correctness is established.
+
+### Technology
+
+Motion for Vue as primary motion layer.
+
+### Uses
+
+- agent status transitions;
+- card/panel entrance/exit;
+- drawer transitions;
+- work-state feedback;
+- layout transitions.
+
+### Rules
+
+- motion communicates state change;
+- reduced-motion is honored;
+- no infinite decorative animation consuming resources;
+- animation cannot delay critical security/status information.
+
+### Tests
+
+- state visible with animations disabled;
+- reduced-motion behavior;
+- no layout interaction blocked during transition.
+
+### Acceptance criteria
+
+Animations improve comprehension without becoming the product logic.
+
+---
+
+## PHASE FE-20 — GSAP advanced choreography
+
+### Objective
+
+Add only the simulator sequences that require coordinated timelines beyond normal UI motion.
+
+### Technology
+
+GSAP.
+
+### Candidate uses
+
+- developer → reviewer dossier handoff;
+- multi-agent task packet movement;
+- synchronized department sequence;
+- complex workflow replay.
+
+### Rules
+
+- introduce GSAP only when a concrete sequence cannot be expressed cleanly with existing primitives;
+- lifecycle cleanup is mandatory;
+- reduced-motion fallback is mandatory;
+- no business timing depends on animation timing.
+
+### Tests
+
+- lifecycle cleanup;
+- route leave/unmount;
+- reduced-motion fallback;
+- event interruption/cancellation.
+
+### Acceptance criteria
+
+GSAP remains a specialized layer, not a dependency of ordinary buttons/cards.
+
+---
+
+## PHASE FE-21 — D3 advanced visualization layer
+
+### Objective
+
+Implement custom analytical/relationship visualizations after the underlying data contracts exist.
+
+### Install
+
+Install only the D3 modules actually needed where practical rather than importing an oversized surface without reason.
+
+### Candidate visualizations
+
+- agent heatmap;
+- inter-department flow;
+- complex dependency topology;
+- decision network;
+- memory/RAG topology;
+- Context Intelligence flow.
+
+### Rules
+
+- do not recreate Vue Flow;
+- accessible textual/table fallback for critical information;
+- isolate D3 DOM lifecycle from Vue lifecycle carefully;
+- bounded data volumes and aggregation for large graphs.
+
+### Tests
+
+- deterministic data transforms;
+- mount/update/unmount;
+- resize;
+- empty/large datasets;
+- no event-listener leak.
+
+### Acceptance criteria
+
+Each D3 visualization answers a question that standard ECharts/Vue Flow could not answer sufficiently.
+
+---
+
+## PHASE FE-22 — MinIO file/artifact experience
+
+### Objective
+
+Add secure file/artifact browsing and upload once backend object-storage contracts are available.
+
+### Infrastructure
+
+MinIO runs as S3-compatible object storage. Browser does not receive unrestricted storage credentials.
+
+### Backend integration
+
+FastAPI owns:
+
+- authorization;
+- metadata;
+- presigned URL issuance;
+- object relation to project/task/run;
+- type/size/checksum policy;
+- deletion policy;
+- audit where needed.
+
+### Frontend
+
+- upload manager;
+- drag/drop;
+- progress;
+- retry/cancel semantics;
+- artifact list;
+- safe preview;
+- download;
+- link to provenance (task/run).
+
+### Tests
+
+- authorized upload;
+- forbidden upload;
+- size/type rejection;
+- expired presigned URL;
+- network interruption;
+- object exists but metadata missing / metadata exists but object unavailable;
+- safe filename display.
+
+### Common errors
+
+- S3 root credentials in browser;
+- trusting MIME type supplied by browser;
+- direct rendering of active HTML/SVG without sandbox policy;
+- orphan objects without cleanup strategy.
+
+### Acceptance criteria
+
+Artifacts are traceable, permission-aware and do not route all large bytes through FastAPI unless intentionally chosen.
+
+---
+
+## PHASE FE-23 — Global search
+
+### Objective
+
+Add unified navigation/search across core SynapseOS records.
+
+### Initial backend
+
+FastAPI + PostgreSQL search.
+
+### Frontend integration
+
+- Command Palette integration;
+- dedicated search results page if necessary;
+- entity grouping;
+- keyboard navigation;
+- permission-scoped results;
+- highlighted match snippets only when safe.
+
+### Tests
+
+- project/agent/task/run search;
+- no unauthorized record leakage;
+- fuzzy/partial behavior exactly matches documented backend capability;
+- empty/no-results states;
+- keyboard selection.
+
+### Acceptance criteria
+
+A user can reach important records without manually navigating hierarchy.
+
+### Deliberately out of scope
+
+Meilisearch until justified by measured requirements.
+
+---
+
+## PHASE FE-24 — Sentry frontend observability
+
+### Objective
+
+Capture actionable frontend failures without leaking sensitive SynapseOS data.
+
+### Install/configuration
+
+Install current official Sentry Nuxt integration and configure per environment.
+
+### Capture
+
+- unhandled frontend errors;
+- stack traces/source maps according to secure deployment policy;
+- key performance spans;
+- failed network requests with sanitized metadata;
+- optional session replay only after privacy masking is configured.
+
+### Redaction rules
+
+Never intentionally send:
+
+- authorization headers;
+- API keys;
+- raw prompts;
+- unrestricted tool outputs;
+- raw private file contents;
+- secret form values.
+
+### Tests
+
+- test event arrives in non-production environment;
+- redaction unit tests;
+- environment tagging;
+- source map behavior;
+- replay masking if enabled.
+
+### Acceptance criteria
+
+A frontend exception can be diagnosed from Sentry without exposing secret runtime content.
+
+---
+
+## PHASE FE-25 — OpenTelemetry distributed correlation
+
+### Objective
+
+Correlate frontend requests with backend/runtime traces while preserving privacy.
+
+### Integration
+
+Propagate approved trace context across:
+
+```text
+Nuxt → FastAPI → Orchestrator → Agent → Tool → LLM → Reviewer
+```
+
+### Rules
+
+- do not place prompts/file content in span attributes;
+- bounded attribute cardinality;
+- no secrets;
+- sampling policy appropriate to environment;
+- frontend trace IDs can link Deep Inspect to backend trace views only when authorized.
+
+### Tests
+
+- trace propagation;
+- correlation ID visible where expected;
+- sensitive-field redaction;
+- failed request captured with safe metadata.
+
+### Acceptance criteria
+
+A cross-stack request can be followed end-to-end without turning tracing into a data-exfiltration path.
+
+---
+
+## PHASE FE-26 — Responsive and accessibility hardening
+
+### Objective
+
+Move accessibility/responsiveness from local component checks to full-product validation.
+
+### Work
+
+- desktop/tablet/mobile audit;
+- mobile supervision views;
+- Company Simulator alternate mobile view;
+- keyboard-only walkthrough;
+- focus audit;
+- contrast audit;
+- `prefers-reduced-motion` audit;
+- Playwright + axe critical-route coverage.
+
+### Acceptance criteria
+
+Critical workflows are keyboard-operable, understandable without color/motion, and usable at supported viewport classes.
+
+---
+
+## PHASE FE-27 — CI pipeline for frontend
+
+### Objective
+
+Make frontend quality gates reproducible and branch-protection ready.
+
+### Workflow
+
+Implement `frontend-ci.yml` or equivalent with:
+
+- locked install;
+- lint;
+- strict typecheck;
+- unit tests;
+- component tests;
+- build;
+- selected E2E/accessibility checks;
+- dependency checks.
+
+### Rules
+
+- fail fast on deterministic quality errors;
+- cache dependencies safely;
+- do not hide failures with `continue-on-error` on mandatory gates;
+- CI scripts match local scripts.
+
+### Tests
+
+The workflow itself is validated by a PR with intentional failures corrected before merge.
+
+### Acceptance criteria
+
+A clean checkout can reproduce all mandatory checks.
+
+---
+
+## PHASE FE-28 — Cross-stack E2E and security pipeline
+
+### Objective
+
+Validate real system integration beyond isolated frontend tests.
+
+### Work
+
+- launch test stack;
+- deterministic/fake LLM provider where appropriate;
+- Authentik test identity flow;
+- PostgreSQL migrations;
+- MinIO when file flows are in scope;
+- Playwright critical workflows;
+- security/dependency/image scanning.
+
+### Acceptance criteria
+
+The primary project→task→agent/run→review flow is validated against real HTTP/auth/event boundaries.
+
+---
+
+## PHASE FE-29 — Docker, GHCR and staging deployment
+
+### Objective
+
+Produce immutable deployable frontend artifacts and deploy staging automatically after approved main changes.
+
+### Work
+
+- production Dockerfile;
+- `.dockerignore`;
+- image health strategy;
+- GHCR push;
+- SHA/version tags;
+- Traefik labels/config;
+- staging environment variables;
+- staging smoke tests.
+
+### Acceptance criteria
+
+A merged known-good build produces a traceable image and healthy staging deployment.
+
+---
+
+## PHASE FE-30 — Protected production release + rollback
+
+### Objective
+
+Create explicit, auditable production promotion.
+
+### Work
+
+- protected GitHub environment;
+- approval gate;
+- release/tag policy;
+- immutable artifact promotion;
+- health/smoke tests;
+- documented rollback to known-good image.
+
+### Acceptance criteria
+
+A staging-tested release can be promoted and deliberately rolled back without rebuilding a different artifact.
+
+---
+
+## PHASE FE-31 — Official docs app bootstrap
+
+### Objective
+
+Create `apps/docs` as a polished independent Nuxt documentation app.
+
+### Technology
+
+- Nuxt;
+- Nuxt Content;
+- Nuxt UI;
+- Tailwind;
+- i18n.
+
+### Install
+
+Use current official Nuxt Content and Nuxt UI setup for the chosen Nuxt version.
+
+### Structure
+
+```text
+apps/docs/
+├── content/
+├── components/
+├── layouts/
+├── pages/
+├── public/
+├── i18n/
+└── nuxt.config.ts
+```
+
+### Acceptance criteria
+
+Docs app renders local Markdown/MDC with the SynapseOS design language and builds independently from `apps/web`.
+
+---
+
+## PHASE FE-32 — Docs navigation, search and Command Palette
+
+### Objective
+
+Deliver the modern Linear/GitHub/Vercel-style docs navigation experience.
+
+### Features
+
+- left nav;
+- table of contents;
+- full-text/local content search;
+- `Cmd/Ctrl+K`;
+- keyboard navigation;
+- deep links;
+- previous/next;
+- mobile nav;
+- edit-on-GitHub links.
+
+### Rules
+
+- one search index/source of truth where practical;
+- no Meilisearch until justified;
+- search results respect currently selected docs version/language once those concepts exist.
+
+### Tests
+
+- search;
+- keyboard palette;
+- broken routes;
+- mobile nav;
+- heading deep links.
+
+### Acceptance criteria
+
+A user can navigate the docs primarily through sidebar, search or keyboard.
+
+---
+
+## PHASE FE-33 — Mermaid + rich documentation components
+
+### Objective
+
+Support architecture-grade technical documentation without screenshots for every concept.
+
+### Features
+
+- Mermaid;
+- code blocks;
+- copy button;
+- tabs;
+- callouts;
+- warnings;
+- step components where useful.
+
+### Rules
+
+- Mermaid source remains reviewable text;
+- diagrams have surrounding explanatory text;
+- code samples are tested/linted where feasible;
+- avoid decorative diagrams with no technical purpose.
+
+### Acceptance criteria
+
+Existing architecture/state-machine docs can migrate/render clearly in the official site.
+
+---
+
+## PHASE FE-34 — OpenAPI / Scalar API reference
+
+### Objective
+
+Generate a modern API reference from FastAPI instead of duplicating endpoint documentation manually.
+
+### Integration
+
+```text
+FastAPI openapi.json
+       ↓
+Scalar (or validated equivalent)
+       ↓
+SynapseOS docs shell / API Reference
+```
+
+### Rules
+
+- OpenAPI remains authoritative;
+- docs build should detect invalid/unavailable schema in CI where practical;
+- examples must not contain real secrets;
+- auth instructions clearly distinguish identity from business permission.
+
+### Acceptance criteria
+
+API reference updates when backend OpenAPI changes, with minimal manual duplication.
+
+---
+
+## PHASE FE-35 — Documentation i18n and version readiness
+
+### Objective
+
+Support FR/EN and prepare, without overbuilding, for real release versioning.
+
+### Work
+
+- locale navigation;
+- localized core content;
+- fallback rules;
+- version selector architecture behind a feature that only activates once versions exist;
+- visible current version once stable releases exist.
+
+### Rules
+
+- do not fabricate version history;
+- clearly indicate untranslated/fallback content if needed;
+- versioned docs must remain linkable/bookmarkable.
+
+### Acceptance criteria
+
+Core docs are usable in FR/EN and the architecture can add v1/v2 without redesigning navigation.
+
+---
+
+## PHASE FE-36 — Documentation CI/CD
+
+### Objective
+
+Treat docs as production software.
+
+### Pipeline
+
+- Markdown/MDC lint;
+- links;
+- Nuxt typecheck;
+- build;
+- search/index generation validation;
+- preview/smoke;
+- deploy `docs.synapseos.dev`.
+
+### Acceptance criteria
+
+Broken internal links/build failures block docs deployment.
+
+---
+
+## PHASE FE-37 — Future WebSocket interactive capabilities
+
+### Objective
+
+Introduce WebSocket only after a real bidirectional requirement exists.
+
+### Possible scope
+
+- interactive terminal;
+- direct agent conversation/control;
+- collaborative sessions.
+
+### Required safeguards
+
+- authentication and authorization on connection + commands;
+- workspace scoping;
+- heartbeat/reconnect;
+- backpressure/bounded buffers;
+- audit;
+- Command Runner/ToolExecutor remains authoritative;
+- no raw shell bypass.
+
+### Deliberately deferred
+
+This phase must not be pulled forward just because WebSockets appear “more real-time” than SSE.
+
+---
+
+## PHASE FE-38 — Future Meilisearch migration if justified
+
+### Objective
+
+Improve global search only after PostgreSQL search is demonstrably insufficient.
+
+### Entry criteria
+
+At least one measured need such as:
+
+- unacceptable latency;
+- strong fuzzy ranking requirements;
+- large indexed corpus;
+- autocomplete requirements beyond PostgreSQL solution.
+
+### Work
+
+- index ownership;
+- async synchronization;
+- reindex strategy;
+- deletion/permission propagation;
+- failure/degraded mode;
+- observability.
+
+### Security rule
+
+A search index must never become a side channel exposing records the API would forbid.
+
+---
+
+## PHASE FE-39 — Future preview environments per PR
+
+### Objective
+
+Provide disposable UI review environments after core CI/deployment is stable.
+
+### Example
+
+```text
+PR #142 → preview-142.synapseos.dev
+```
+
+### Requirements
+
+- isolated config;
+- no production secrets;
+- automatic teardown;
+- optional fake/test backend where appropriate;
+- clear preview banner;
+- cost controls.
+
+---
+
+## PHASE FE-40 — Future external notification channels
+
+### Objective
+
+Extend persistent internal notifications into external delivery only after the internal model is stable.
+
+### Candidate channels
+
+- email;
+- Slack;
+- Discord;
+- webhook.
+
+### Rule
+
+External delivery policy belongs on the backend. The Nuxt frontend configures preferences and displays delivery state; it is not the outbound delivery engine.
+
+---
+
+
+## PHASE FE-41 — Public Website / Landing Page
+
+### Objective
+Create a public-facing SynapseOS website that explains the product, demonstrates its differentiators, establishes trust, and routes visitors to the application, documentation, and GitHub repository.
+
+### Why this exists
+The private cockpit and the official documentation do not replace a product website. The landing page is responsible for positioning, conversion, product storytelling, SEO, and public trust.
+
+### Technology
+- Nuxt
+- TypeScript
+- Nuxt UI
+- Tailwind CSS
+- `@nuxtjs/i18n`
+- Motion for Vue for restrained public-page motion
+- GSAP only if a specific synchronized product demonstration genuinely needs it
+
+### Target repository structure
+```text
+apps/
+├── web/       # authenticated SynapseOS cockpit
+├── docs/      # official documentation
+└── website/   # public product website / landing page
+```
+
+Shared packages may be reused only where there is actual shared value:
+```text
+packages/
+├── ui/
+├── icons/
+└── config/
+```
+
+### Required public sections
+- Hero with a concise SynapseOS value proposition.
+- Product problem / why SynapseOS exists.
+- Core capability overview: agents, tasks, tools, skills, permissions, model routing, memory, context intelligence, observability.
+- Interactive or animated product preview.
+- Company Simulator preview.
+- Kanban/task workflow preview.
+- Developer → Reviewer corrective loop example.
+- Security veto / bounded autonomy example.
+- “How it works” sequence: Brief → Plan → Execute → Review → Validate → Deliver.
+- Architecture/trust section explaining local + cloud models, provider neutrality, auditability, bounded autonomy, and permission enforcement.
+- Developer section linking API, CLI when available, docs, and GitHub.
+- Open-source/community section only if that remains part of SynapseOS positioning.
+- CTA areas: Get Started, View Documentation, GitHub.
+
+### Product demonstration rule
+The landing page may contain a compact simulated demo, but it must demonstrate real SynapseOS concepts rather than meaningless decorative AI animation. A representative sequence may show:
+
+```text
+Developer Agent starts task
+→ test fails
+→ corrective iteration
+→ tests pass
+→ Reviewer receives evidence
+→ Reviewer requests changes or approves
+→ workflow reaches final state
+```
+
+The public demonstration may be pre-scripted for marketing performance, but must not misrepresent capabilities as production-ready if they are not actually available.
+
+### SEO and sharing
+- Semantic HTML.
+- Metadata per route.
+- Canonical URLs.
+- Open Graph metadata.
+- Social preview images.
+- Sitemap.
+- `robots.txt`.
+- Structured data where useful and truthful.
+- Strong Core Web Vitals targets.
+- Public pages must remain indexable unless intentionally private.
+
+### Performance rules
+- Do not ship Vue Flow, D3, GSAP, ECharts, or large application-only dependencies to every landing page route unless needed by a specific section.
+- Lazy-load heavy interactive demonstrations.
+- Optimize media and fonts.
+- Respect reduced-motion preferences.
+- Avoid autoplay video with sound.
+
+### Internationalization
+- FR and EN from the first public release.
+- Same canonical concept names as the application/documentation.
+- No hardcoded business strings in reusable components.
+
+### Analytics
+Use privacy-conscious product/web analytics only after the analytics decision in FE-46 is implemented. Marketing analytics must remain separate conceptually from Sentry and OpenTelemetry.
+
+### Tests
+- Component tests for critical interactive sections.
+- Playwright tests for navigation and CTAs.
+- Accessibility tests.
+- Broken-link checks.
+- Metadata/SEO checks where practical.
+- Performance smoke checks for regressions.
+
+### Acceptance criteria
+- Public website is clearly distinct from `apps/web` and `apps/docs`.
+- Visitors can understand what SynapseOS is without authenticating.
+- Product claims match implemented or clearly labeled upcoming capabilities.
+- App, docs, and GitHub are reachable through visible CTAs.
+- FR/EN, desktop, tablet, and mobile layouts work.
+- Keyboard navigation and reduced-motion work.
+- Production build passes independently.
+
+### Deliberately out of scope initially
+- Full CMS.
+- Complex personalization.
+- Marketing automation suite.
+- Heavy animation solely for visual spectacle.
+- Customer portal inside the public website.
+
+### Definition of Done
+The landing page can be deployed independently, is fast and accessible, clearly communicates SynapseOS, and does not duplicate the authenticated application or documentation responsibilities.
+
+---
+
+## PHASE FE-42 — Onboarding & First-Run Experience
+
+### Objective
+Guide a new user from first authentication to a usable SynapseOS workspace without requiring them to understand the entire architecture beforehand.
+
+### Required flow
+A first-run flow should progressively cover, when backend capabilities exist:
+
+```text
+Sign in
+→ create/select organization or workspace
+→ configure identity/profile basics
+→ connect or select an LLM provider
+→ verify provider health
+→ select default model policy
+→ create first project
+→ understand agents/tasks/reviews at a glance
+→ optionally launch a guided first workflow
+```
+
+### Principles
+- Progressive disclosure instead of a 20-step setup wizard.
+- Every setup step must correspond to a real backend state.
+- Provider secrets must never be exposed back to the browser once stored securely.
+- Users must be allowed to leave and resume onboarding.
+- Existing users must not be forced back through first-run screens after completion.
+- “Skip for now” is acceptable only when the omitted setup is genuinely optional.
+
+### UI components
+- Setup checklist.
+- Provider health feedback.
+- Workspace creation form.
+- First-project template or blank-project choice.
+- Contextual coach marks sparingly.
+- “What is this?” links into official documentation.
+
+### State
+Persist onboarding completion/version server-side rather than only in `localStorage`, so the experience remains consistent across devices.
+
+### Tests
+- first login;
+- interrupted onboarding + resume;
+- invalid provider configuration;
+- provider unavailable;
+- permission-limited user;
+- already-configured workspace;
+- keyboard-only flow;
+- FR/EN rendering.
+
+### Acceptance criteria
+A new authorized user can reach a functional first project without needing manual database changes or undocumented configuration.
+
+### Deliberately out of scope initially
+- Gamified onboarding.
+- AI-generated personalized onboarding paths.
+- Mandatory product tours for returning users.
+
+### Definition of Done
+First-run setup is resumable, secure, permission-aware, test-covered, and connected to real backend configuration.
+
+---
+
+## PHASE FE-43 — Account, Organization & Workspace Settings
+
+### Objective
+Provide explicit settings surfaces for personal preferences and organizational administration without mixing them with project execution screens.
+
+### Settings domains
+```text
+Personal
+├── profile
+├── language
+├── theme
+├── timezone
+├── notification preferences
+└── keyboard preferences later
+
+Organization / Workspace
+├── name and metadata
+├── members
+├── roles
+├── invitations if supported
+├── defaults
+├── provider visibility/policies
+└── security/approval policies when authorized
+```
+
+### Authority rules
+Authentik owns authentication identity concerns. SynapseOS owns domain authorization and workspace/project policy. The frontend must not invent roles or permissions independently.
+
+### Sensitive settings
+Provider credentials, security policy changes, permission elevation, and destructive workspace actions require stronger backend validation and confirmation patterns defined in the security section.
+
+### Tests
+- owner/admin/member permission differences;
+- unauthorized route access;
+- language/theme persistence;
+- timezone rendering;
+- update failures and optimistic-state rollback;
+- destructive action confirmation.
+
+### Acceptance criteria
+Settings are grouped predictably, permission-aware, and do not expose secrets.
+
+### Definition of Done
+Users can manage supported personal and organizational preferences through backend-authoritative APIs with complete forbidden/error states.
+
+---
+
+## PHASE FE-44 — Empty, Loading, Error, Offline & Recovery States
+
+### Objective
+Make degraded and incomplete states first-class product behavior rather than afterthoughts.
+
+### Required states
+Every major feature must account for:
+- initial loading;
+- background refresh;
+- empty collection;
+- zero search results;
+- forbidden/permission denied;
+- not found;
+- backend unavailable;
+- provider unavailable;
+- task/agent failed;
+- SSE disconnected;
+- SSE reconnecting;
+- stale/reconciling state;
+- session expired;
+- maintenance/unavailable state;
+- generic unexpected error.
+
+### Public/system pages
+At minimum provide designed experiences for:
+- 403;
+- 404;
+- 500/unexpected failure;
+- maintenance or temporarily unavailable;
+- authentication/session expiration.
+
+### UX rules
+- Never use an endless spinner when an actionable error is known.
+- Empty state must explain what is missing and provide the next valid action when possible.
+- Recovery actions must be explicit: Retry, Reconnect, Refresh, Re-authenticate, View incident, etc.
+- Realtime disconnect must not silently imply the displayed state is still current.
+- Skeletons should preserve layout and avoid excessive motion.
+
+### Tests
+Failure-state coverage is mandatory in component and E2E tests for critical screens.
+
+### Acceptance criteria
+No critical screen has only a success-path design.
+
+### Definition of Done
+Loading, empty, forbidden, disconnected, and error states are deliberately designed and testable across the application.
+
+---
+
+## PHASE FE-45 — Feature Flags & Progressive Delivery
+
+### Objective
+Allow incomplete, experimental, risky, or staged capabilities to be enabled intentionally without long-lived code forks.
+
+### Candidate uses
+- Company Simulator V2.
+- Memory UI.
+- Context Intelligence visualizations.
+- new provider integrations.
+- advanced WebSocket interactions.
+- experimental workflow views.
+
+### Rules
+- Flags must not be used as a substitute for authorization.
+- Security checks remain backend-enforced even when a UI feature is hidden.
+- Prefer server-controlled/environment-controlled flags for operational features.
+- Flag names must be stable and documented.
+- Every temporary flag must have an owner/removal condition.
+- Tests must cover both enabled and disabled behavior for critical flags.
+
+### Initial implementation
+Start with a minimal typed flag layer; do not add a dedicated SaaS feature-flag vendor until operational complexity justifies it.
+
+### Acceptance criteria
+Experimental features can be disabled without code removal and without weakening backend policy.
+
+### Definition of Done
+Feature flags are typed, testable, documented, and cannot grant unauthorized capabilities.
+
+---
+
+## PHASE FE-46 — Product Analytics & Feedback
+
+### Objective
+Measure product usage and collect actionable feedback without conflating analytics with error monitoring or distributed tracing.
+
+### Separation of responsibilities
+```text
+Sentry          → application errors / user-impacting failures
+OpenTelemetry   → technical distributed traces/metrics
+Product analytics → product usage patterns
+Feedback        → explicit user reports/comments
+```
+
+### Privacy principles
+- Data minimization.
+- No provider API keys, secrets, prompt bodies, private source files, raw tool output, or credentials.
+- Prefer event names and bounded metadata over payload capture.
+- Respect applicable consent/privacy requirements.
+- Session replay, if ever enabled, requires strong masking/redaction and a separate explicit decision.
+
+### Useful events
+Examples:
+- project_created;
+- run_started;
+- kanban_view_opened;
+- approval_completed;
+- docs_opened_from_context;
+- onboarding_completed;
+- command_palette_used.
+
+Do not record sensitive task content merely to understand feature usage.
+
+### Feedback entry points
+- Report a bug.
+- Send product feedback.
+- Link to GitHub issue flow where appropriate.
+- Include bounded technical context only after user review/consent where necessary.
+
+### Initial technology decision
+No analytics vendor is mandated by this architecture. Choose a privacy-conscious implementation during this phase based on hosting/product needs at that time.
+
+### Acceptance criteria
+Analytics answers product questions without becoming a sensitive-data sink.
+
+### Definition of Done
+Product analytics and feedback have explicit schemas, privacy boundaries, and tests/redaction safeguards where applicable.
+
+---
+
+## PHASE FE-47 — Usage, Budgets & Billing Readiness
+
+### Objective
+Expose operational usage and budget information now while keeping commercial billing explicitly optional/deferred.
+
+### V1 operational usage
+The UI may surface, when backend data exists:
+- token usage;
+- model/provider usage;
+- estimated/actual provider cost;
+- project cost;
+- agent/run cost;
+- budget thresholds;
+- budget warnings;
+- provider quota/health signals where available.
+
+### Billing boundary
+Operational cost visibility is not the same as SaaS billing. Commercial plans, subscriptions, invoices, payment providers, taxes, and metering for customer billing are deliberately deferred until SynapseOS has a defined commercial model.
+
+### UI
+- usage dashboard;
+- budget progress;
+- cost trends through ECharts;
+- filters by project/agent/provider/time period;
+- warnings before configured limits;
+- links to underlying runs when appropriate.
+
+### Security
+Billing or financial administration, if introduced later, requires separate permissions from ordinary usage visibility.
+
+### Acceptance criteria
+The product can explain its AI/runtime consumption without pretending a commercial billing system already exists.
+
+### Deliberately deferred
+- Stripe or other payment provider integration.
+- subscriptions;
+- plan enforcement;
+- invoices;
+- taxes;
+- seat billing.
+
+### Definition of Done
+Usage/budget UI is operationally useful and commercial billing remains an explicit future decision.
+
+---
+
+## PHASE FE-48 — Public Status, Changelog & Release Experience
+
+### Objective
+Give users a trustworthy public view of service health and product evolution.
+
+### Status experience
+A public status surface may include:
+- SynapseOS API status;
+- authenticated web availability;
+- documentation availability;
+- major managed infrastructure components where relevant;
+- incident timeline;
+- maintenance notices;
+- historical uptime only when data is reliable.
+
+Do not expose internal topology, secrets, or security-sensitive diagnostics.
+
+### Changelog
+Provide a public changelog/release experience covering:
+- new features;
+- fixes;
+- breaking changes;
+- migrations;
+- deprecations;
+- security notices when public disclosure is appropriate;
+- links to detailed docs/release notes.
+
+### Source of truth
+Prefer generating or curating changelog content from versioned release data rather than duplicating release facts in multiple places.
+
+### Acceptance criteria
+Users can distinguish an outage from a local problem and can understand what changed between releases.
+
+### Definition of Done
+Status and release communication have dedicated public surfaces with no leakage of sensitive operational details.
+
+---
+
+## PHASE FE-49 — Data Export / Import & Portability
+
+### Objective
+Provide bounded portability for user-owned/project data and operational reports.
+
+### Candidate exports
+Depending on backend support:
+- project summaries;
+- tasks;
+- decisions;
+- audit reports;
+- run summaries;
+- usage reports;
+- configuration snapshots that exclude secrets;
+- artifacts the user is authorized to access.
+
+### Formats
+Use explicit, documented formats such as JSON/CSV/ZIP/PDF only when they serve a real use case. Export schemas should be versioned when stability matters.
+
+### Import
+Import is more dangerous than export and should be introduced only for well-defined data types with schema validation, size limits, permission checks, and preview/dry-run where practical.
+
+### Security rules
+- No secret export by default.
+- Permissions are revalidated at export time.
+- Large exports use bounded asynchronous/backend flows when required.
+- Audit sensitive export/import operations.
+
+### Tests
+- authorization;
+- large dataset behavior;
+- invalid import schemas;
+- partial failure;
+- redaction;
+- cancellation/timeouts where supported.
+
+### Acceptance criteria
+Authorized users can retrieve supported data without bypassing project/workspace boundaries.
+
+### Definition of Done
+Export/import is schema-defined, bounded, permission-aware, and auditable.
+
+---
+
+## PHASE FE-50 — Legal, Privacy, Security & Public Trust Pages
+
+### Objective
+Provide the public trust and legal surfaces expected from a serious software platform without mixing legal content into product UI.
+
+### Public pages to plan
+- Privacy Policy.
+- Terms of Service / Terms of Use when applicable.
+- Security overview.
+- Responsible disclosure / security contact process when available.
+- Open-source / third-party licenses notices.
+- Cookie/analytics disclosure if applicable.
+- Data handling overview where appropriate.
+
+### Security page
+May explain high-level principles such as:
+- bounded agent autonomy;
+- permission enforcement;
+- auditability;
+- provider-neutral design;
+- secret handling;
+- responsible disclosure.
+
+It must not reveal exploitable internal details.
+
+### Legal content ownership
+Legal text must not be fabricated by engineering as authoritative legal advice. The application provides the technical surface; finalized legal language must be reviewed by the appropriate owner before production use.
+
+### Acceptance criteria
+Public trust pages are discoverable from the website/footer and remain distinct from technical documentation.
+
+### Definition of Done
+Required public trust/legal routes exist, are version-controlled, accessible, and clearly owned for future legal review.
+
+---
+
+## Explicitly deferred product-surface decisions
+
+The following are not forgotten; they are intentionally deferred until a concrete product requirement justifies them:
+
+### PWA / installable application
+- No PWA requirement for V1.
+- Revisit only if offline capability, mobile installation, push notifications, or field use creates real value.
+- Do not add service-worker complexity preemptively.
+
+### White-label / deep theming
+- The design system should remain tokenized and extensible.
+- Full tenant-specific branding, custom domains, logos, or color systems are not a V1 requirement.
+
+### Commercial SaaS billing
+- Usage/cost visibility is planned in FE-47.
+- Subscription/payment infrastructure remains separate and deferred.
+
+### Fully configurable keyboard maps
+- Keyboard-first navigation and Command Palette are required.
+- User-remappable shortcut profiles are future scope.
+
+### External support suite
+- Feedback entry points are planned.
+- A dedicated support/ticketing vendor is not required initially.
+
+---
+
+# 17. Testing strategy by layer
+
+## 17.1 Unit tests — Vitest
+
+Use for:
+
+- pure data transforms;
+- event routing;
+- filter/query serialization;
+- i18n mapping helpers;
+- risk/status formatting;
+- search/result mapping;
+- metric aggregation;
+- redaction utilities;
+- stores/composables with isolated dependencies.
+
+## 17.2 Component tests — Vue Test Utils
+
+Use for:
+
+- task cards;
+- agent cards;
+- drawers;
+- notification center;
+- table controls;
+- forms;
+- status components;
+- accessible command palette behavior;
+- error/loading/empty states.
+
+## 17.3 E2E — Playwright
+
+Critical workflows include:
+
+- Authentik login/session;
+- open/create project as supported;
+- task management;
+- allowed/denied state transition;
+- Kanban move;
+- SSE status update;
+- run/review workflow;
+- security veto;
+- approval flow;
+- provider-down/degraded experience;
+- SSE reconnect;
+- agent blocked;
+- task failed;
+- artifact upload/download once supported;
+- logout/cache reset.
+
+## 17.4 Failure testing is mandatory
+
+Do not test only green paths. Include:
+
+- 401 unauthenticated;
+- 403 unauthorized;
+- 404 stale/deleted entity;
+- 409 conflict/concurrent transition where backend uses it;
+- 422 validation;
+- 5xx backend failure;
+- network offline;
+- SSE disconnected;
+- provider unavailable;
+- command timeout;
+- run cancelled;
+- artifact expired URL;
+- partial metric data.
+
+## 17.5 Accessibility testing
+
+Automate what can be automated with axe/Playwright, but also manually verify:
+
+- keyboard order;
+- focus restoration;
+- drag/drop alternative;
+- screen-reader status text;
+- reduced-motion;
+- high-information tables/drawers.
+
+---
+
+# 18. Performance rules
+
+Performance should be engineered from actual bottlenecks, not premature micro-optimization.
+
+Baseline rules:
+
+- paginate large server collections;
+- virtualize only large list/table cases that need it;
+- do not retain infinite SSE history in memory;
+- lazy-load heavy visualization/terminal code where practical;
+- avoid loading D3/GSAP/xterm on routes that never use them;
+- debounce user search appropriately;
+- cancel obsolete queries where supported;
+- use image/file previews responsibly;
+- aggregate graph data server-side when raw topology is too large;
+- monitor actual Web Vitals/frontend spans through Sentry/OTel.
+
+Company Simulator must remain responsive even when many backend events occur. Prefer event coalescing/aggregation over animating every low-level tool event.
+
+---
+
+# 19. Error and degraded-state UX
+
+SynapseOS must distinguish failure types clearly.
+
+Examples:
+
+```text
+Authentication expired
+→ re-authentication path
+
+Permission denied
+→ explain missing permission/action not allowed
+
+Provider degraded
+→ show affected capability/provider status
+
+SSE disconnected
+→ show live-data degraded state and reconnect
+
+Backend unavailable
+→ global degraded banner + retry
+
+Agent blocked
+→ operational state, not frontend error
+
+Security veto
+→ explicit security state with evidence/link where allowed
+```
+
+Do not collapse all failures into “Something went wrong.”
+
+Never expose raw stack traces to normal end users.
+
+---
+
+# 20. Security-sensitive UI copy and confidence semantics
+
+The interface must not overclaim certainty.
+
+For agent confidence/reputation/reliability:
+
+- label the metric precisely;
+- provide tooltip/help text;
+- avoid “guaranteed”, “safe”, “correct” solely from score;
+- show supporting state/evidence where available;
+- distinguish model self-confidence from deterministic verification outcomes.
+
+A reviewer approval, passing test, security scan, or permission check is a different signal from model confidence.
+
+---
+
+# 21. Deliberately deferred or conditional technologies
+
+The following are **not forgotten**. They are intentionally deferred:
+
+- **Meilisearch** — only when PostgreSQL search is insufficient;
+- **WebSocket** — only for genuine bidirectional real-time interactions;
+- **GSAP broad usage** — only for complex simulator choreography;
+- **virtualization everywhere** — only on measured large-data surfaces;
+- **preview environments** — after stable CI/staging/prod flow;
+- **external notification channels** — after internal notification model;
+- **complex docs versioning** — after real stable release versions;
+- **advanced RAG/Memory visualization** — after backend memory contracts;
+- **Context Intelligence dashboards** — after backend Context Intelligence Layer exists;
+- **interactive arbitrary terminal** — not part of normal V1 and never a direct shell bypass;
+- **Meilisearch for docs** — only after local/content search no longer satisfies needs;
+- **custom authentication** — intentionally rejected in favor of Authentik;
+- **Vuetify** — intentionally not selected as primary UI framework;
+- **Next.js** — intentionally not selected for the main frontend;
+- **fake Company Simulator animation** — explicitly prohibited.
+
+---
+
+# 22. Decision log / ADR index
+
+This section captures the architecture choices in compact form. A future repo may convert each into individual ADR files if desired.
+
+| ID | Decision | Status |
+|---|---|---|
+| ADR-FE-001 | Nuxt/Vue for the main frontend instead of Next.js/React | Accepted |
+| ADR-FE-002 | TypeScript strict | Accepted |
+| ADR-FE-003 | Nuxt UI + Tailwind instead of Vuetify as primary UI layer | Accepted |
+| ADR-FE-004 | Pinia for client/UI state | Accepted |
+| ADR-FE-005 | TanStack Query for server state | Accepted |
+| ADR-FE-006 | REST for commands/CRUD | Accepted |
+| ADR-FE-007 | SSE as primary live event transport | Accepted |
+| ADR-FE-008 | WebSocket only for later genuine bidirectional needs | Accepted / Deferred |
+| ADR-FE-009 | Vue Flow for Company Simulator/workflow graphs | Accepted |
+| ADR-FE-010 | D3 for custom visualizations | Accepted |
+| ADR-FE-011 | ECharts for standard analytics | Accepted |
+| ADR-FE-012 | Motion for Vue as primary animation layer | Accepted |
+| ADR-FE-013 | GSAP only for advanced synchronized simulator sequences | Accepted / Conditional |
+| ADR-FE-014 | Authentik self-hosted via OIDC for authentication | Accepted |
+| ADR-FE-015 | SynapseOS backend Permission Engine remains authorization authority | Accepted |
+| ADR-FE-016 | Orval generates frontend API contracts from FastAPI OpenAPI | Accepted |
+| ADR-FE-017 | Zod + vee-validate for frontend forms | Accepted |
+| ADR-FE-018 | Vitest + Vue Test Utils + Playwright | Accepted |
+| ADR-FE-019 | Sentry + OpenTelemetry observability with strict redaction | Accepted |
+| ADR-FE-020 | xterm.js for technical logs/terminal-style views, never direct shell | Accepted |
+| ADR-FE-021 | Lucide as primary standard icon set + custom SynapseOS domain icons | Accepted |
+| ADR-FE-022 | Nuxt UI Command Palette + keyboard navigation | Accepted |
+| ADR-FE-023 | PostgreSQL/FastAPI global search first | Accepted |
+| ADR-FE-024 | Meilisearch only if later justified | Accepted / Deferred |
+| ADR-FE-025 | Internal Notification Center + Nuxt UI toasts + SSE | Accepted |
+| ADR-FE-026 | External email/Slack/Discord/webhook notifications later | Deferred |
+| ADR-FE-027 | MinIO/S3-compatible object storage + PostgreSQL metadata | Accepted |
+| ADR-FE-028 | Presigned URLs for suitable large browser uploads | Accepted |
+| ADR-FE-029 | TanStack Table for data-heavy grids | Accepted |
+| ADR-FE-030 | Kanban task view | Accepted |
+| ADR-FE-031 | VueDraggable/SortableJS for Kanban DnD | Accepted |
+| ADR-FE-032 | Backend TaskStateMachine controls all task transitions | Accepted |
+| ADR-FE-033 | Kanban + Table + Timeline + Dependency Graph + Company View over same task truth | Accepted |
+| ADR-FE-034 | `@nuxtjs/i18n` from V1, initially FR/EN | Accepted |
+| ADR-FE-035 | Stored backend enums remain canonical/untranslated | Accepted |
+| ADR-FE-036 | Dark-first Linear/Vercel/Supabase/GitLab-inspired design system | Accepted |
+| ADR-FE-037 | Feature-first Nuxt architecture | Accepted |
+| ADR-FE-038 | Separate `apps/web` and `apps/docs`, shared packages only when justified | Accepted |
+| ADR-FE-039 | Zero-trust frontend; backend authoritative | Accepted |
+| ADR-FE-040 | Desktop-first responsive strategy with mobile supervision mode | Accepted |
+| ADR-FE-041 | WCAG 2.2 AA target + reduced motion | Accepted |
+| ADR-FE-042 | Docker + GHCR + Traefik + HTTPS | Accepted |
+| ADR-FE-043 | Development/staging/production isolation | Accepted |
+| ADR-FE-044 | GitHub Actions CI/CD with separated concerns | Accepted |
+| ADR-FE-045 | Staging automatic after valid main flow; production protected | Accepted |
+| ADR-FE-046 | Immutable image tags + rollback | Accepted |
+| ADR-FE-047 | PR preview environments later | Deferred |
+| ADR-FE-048 | Official docs built with Nuxt + Nuxt Content + Nuxt UI + Tailwind | Accepted |
+| ADR-FE-049 | Modern docs Command Palette/search | Accepted |
+| ADR-FE-050 | Mermaid for docs architecture/workflow diagrams | Accepted |
+| ADR-FE-051 | FastAPI OpenAPI → Scalar-style generated API reference | Accepted |
+| ADR-FE-052 | Docs FR/EN and version-ready, no fake version complexity | Accepted |
+| ADR-FE-053 | Dedicated docs CI/CD | Accepted |
+| ADR-FE-054 | Company Simulator animations must map to real runtime state/events | Accepted |
+| ADR-FE-055 | Company View, Control Center and Deep Inspect are distinct UX modes | Accepted |
+| ADR-FE-056 | Daily Briefing derives from real system state/evidence | Accepted |
+
+---
+
+# 23. Implementation checklist template for every future frontend PR
+
+Every implementation PR should answer these questions before merge:
+
+```text
+[ ] What single phase/objective does this PR implement?
+[ ] Which backend contract is authoritative?
+[ ] Which files were added/modified?
+[ ] Which dependency was added and why is it necessary?
+[ ] Was the dependency version locked through the project lockfile?
+[ ] Are any secrets/public runtime values affected?
+[ ] Are permissions enforced by backend, not just hidden in UI?
+[ ] Are loading, empty, error and forbidden states implemented?
+[ ] Are FR/EN strings added where user-facing text changed?
+[ ] Is keyboard access preserved?
+[ ] Does reduced-motion matter for this feature?
+[ ] Are sensitive fields redacted from logs/Sentry/OTel?
+[ ] Are unit/component/E2E tests added at the right level?
+[ ] Did lint, typecheck, tests and production build pass?
+[ ] Is documentation updated?
+[ ] What is deliberately NOT implemented in this PR?
+[ ] Are acceptance criteria demonstrably satisfied?
+```
+
+---
+
+# 24. Common architecture mistakes to prevent globally
+
+1. **Duplicating server state in Pinia.** TanStack Query owns remote cache.
+2. **Implementing task state rules in the Kanban.** Backend `TaskStateMachine` owns transitions.
+3. **Treating hidden buttons as authorization.** Backend Permission Engine owns permission.
+4. **Putting provider API keys into Nuxt public runtime config.** Anything in client bundle is public.
+5. **Using `localStorage` for long-lived sensitive tokens by default.** Prefer a safer server/session architecture.
+6. **Opening multiple SSE streams per component.** Centralize/scoped event connection management.
+7. **Assuming SSE is exactly-once.** Reconcile after reconnect and handle duplicates.
+8. **Using WebSocket just because it sounds more real-time.** Use it only for bidirectional requirements.
+9. **Using GSAP for every animation.** Motion for Vue is primary; GSAP is specialized.
+10. **Using D3 for standard charts.** ECharts owns ordinary analytics.
+11. **Using D3 to rebuild Vue Flow.** Vue Flow owns interactive workflow/org graphs.
+12. **Making the simulator fictional.** Every meaningful visual state maps to real backend data.
+13. **Rendering unbounded logs/events.** Use bounded histories, pagination/stream windows.
+14. **Sending raw prompts/tool outputs to observability.** Redact/minimize.
+15. **Storing large object bytes in PostgreSQL by default.** MinIO/S3 owns binaries; DB owns metadata.
+16. **Uploading to MinIO with root credentials in the browser.** Use authorized presigned flows.
+17. **Translating backend enum values.** Translate presentation labels only.
+18. **Adding Meilisearch too early.** PostgreSQL search first.
+19. **Building docs API reference manually.** Reuse FastAPI OpenAPI.
+20. **Deploying production on every main commit without a gate.** Use protected promotion.
+21. **Using only `latest` Docker tags.** Keep immutable SHA/version tags.
+22. **Claiming accessibility from axe alone.** Manual keyboard/screen-reader validation still required.
+23. **Forcing desktop simulator onto mobile.** Provide a supervision-oriented alternate view.
+24. **Sharing production secrets/data with previews/staging.** Environments stay isolated.
+25. **Extracting shared monorepo packages prematurely.** Extract only real shared code.
+
+---
+
+# 25. Completion audit — conversation decisions cross-check
+
+This section was added specifically to verify that the architecture decisions agreed before writing this document were not lost during restructuring.
+
+| Agreed item | Included in this document | Location |
+|---|---:|---|
+| Nuxt instead of Next.js | ✓ | §4.1, ADR-FE-001 |
+| TypeScript | ✓ | §4.1, FE-1 |
+| Nuxt UI + Tailwind instead of Vuetify | ✓ | §4.2, FE-2 |
+| Pinia + TanStack Query responsibility split | ✓ | §4.3, FE-6/FE-7 |
+| REST + SSE primary + WebSocket only if needed | ✓ | §4.5, FE-10, FE-37 |
+| Vue Flow | ✓ | §4.6, FE-18 |
+| D3 | ✓ | §4.7, FE-21 |
+| Motion for Vue | ✓ | §4.9, FE-19 |
+| GSAP only for complex sequences | ✓ | §4.9, FE-20 |
+| ECharts | ✓ | §4.8, FE-17 |
+| Authentik, Docker/self-hosted, OIDC | ✓ | §4.10, FE-8 |
+| Authentication ≠ authorization | ✓ | §4.10, §9 |
+| Orval from FastAPI OpenAPI | ✓ | §4.4, FE-5 |
+| Zod + vee-validate | ✓ | §4.11, FE-9 |
+| Vitest + Vue Test Utils + Playwright | ✓ | §4.12, §17 |
+| Sentry + OpenTelemetry | ✓ | §4.13, FE-24/FE-25 |
+| No prompts/secrets/raw sensitive output in traces | ✓ | §9.4, FE-24/25 |
+| xterm.js | ✓ | §4.14, FE-16 |
+| Timeline separate from raw terminal/logs | ✓ | §4.14, §14.3, FE-15/16 |
+| Lucide + custom SynapseOS icons | ✓ | §4.15 |
+| Nuxt UI Command Palette | ✓ | §4.16, FE-3 |
+| Cmd/Ctrl+K and proposed keyboard shortcuts | ✓ | §4.16, §10 |
+| PostgreSQL/FastAPI search first | ✓ | §5.1, FE-23 |
+| Meilisearch only later if justified | ✓ | §5.1, FE-38 |
+| Toast + persistent Notification Center + SSE | ✓ | §5.2, FE-11 |
+| Notification severity INFO/WARNING/CRITICAL | ✓ | §5.2 |
+| Email/Slack/Discord/Webhook later | ✓ | §5.2, FE-40 |
+| MinIO S3-compatible storage | ✓ | §5.3, FE-22 |
+| PostgreSQL stores file metadata | ✓ | §5.3, FE-22 |
+| Presigned URLs | ✓ | §5.3, FE-22 |
+| TanStack Table | ✓ | §5.4, FE-12 |
+| Virtualization only when needed | ✓ | §5.4, §18 |
+| Kanban like Trello/Jira | ✓ | §5.5, FE-14 |
+| VueDraggable/SortableJS | ✓ | §5.5, FE-14 |
+| Backend TaskStateMachine remains authoritative | ✓ | §1.2, §5.5, FE-13/14 |
+| Kanban/Table/Timeline/Dependency/Company views | ✓ | §5.5 |
+| `@nuxtjs/i18n` | ✓ | §6, FE-4 |
+| FR + EN | ✓ | §6, docs §13 |
+| Do not translate stored enums | ✓ | §6 |
+| Dark-first design inspired by Linear/Vercel/Supabase/GitLab | ✓ | §3, §7 |
+| Thin borders/minimal shadows/dense readable UI | ✓ | §3, §7 |
+| Semantic agent animations | ✓ | §2.1, FE-18/19 |
+| Available/working/blocked/reviewer/security visual semantics | ✓ | §2.1 |
+| Agent card shows task/model/confidence/iteration/tool etc. | ✓ | §2.1, FE-18 |
+| Daily Briefing from real state | ✓ | §2.1 |
+| Company View + Control Center + Deep Inspect | ✓ | §2 |
+| Feature-first architecture | ✓ | §8 |
+| `apps/web` and `apps/docs` | ✓ | §8.1, §13 |
+| shared packages only when justified | ✓ | §8.1 |
+| CSP/XSS/cookies/CSRF/CORS/security headers | ✓ | §9 |
+| no secrets/localStorage provider keys | ✓ | §9 |
+| terminal never bypasses backend | ✓ | §9.5, FE-16 |
+| LOW/MEDIUM/HIGH/CRITICAL confirmation concept | ✓ | §9.6 |
+| Desktop-first responsive | ✓ | §10 |
+| Mobile supervision experience | ✓ | §10.1 |
+| WCAG 2.2 AA | ✓ | §10.2 |
+| prefers-reduced-motion | ✓ | §10.3 |
+| axe-core + Playwright | ✓ | §10.4, §17.5 |
+| Docker + Docker Compose | ✓ | §11 |
+| GHCR | ✓ | §11, §12 |
+| Traefik preferred reverse proxy | ✓ | §11 |
+| app/api/auth/docs host topology | ✓ | §11.2 |
+| development/staging/production | ✓ | §11.3 |
+| Nuxt private/public runtime config | ✓ | §11.4 |
+| GitHub Actions separated workflows | ✓ | §12.1 |
+| frontend CI exact quality stages | ✓ | §12.2 |
+| backend pipeline remains separate | ✓ | §12.3 |
+| cross-stack E2E with Authentik/MinIO as needed | ✓ | §12.4 |
+| image SHA/version/latest tags | ✓ | §12.5 |
+| automatic staging flow | ✓ | §12.6 |
+| protected production gate | ✓ | §12.7 |
+| rollback | ✓ | §12.8 |
+| preview environments later | ✓ | §12.9, FE-39 |
+| CI secrets protections | ✓ | §12.10 |
+| SynapseOS later displays its own pipeline | ✓ | §12.11 |
+| Official modern docs site | ✓ | §13 |
+| Public Website / Landing Page | ✓ | FE-41 |
+| Separate `apps/website` public surface | ✓ | FE-41 |
+| Interactive product demonstration on landing page | ✓ | FE-41 |
+| Landing SEO/Open Graph/performance/i18n | ✓ | FE-41 |
+| Onboarding / first-run experience | ✓ | FE-42 |
+| Account / organization / workspace settings | ✓ | FE-43 |
+| Empty/loading/error/offline/recovery states | ✓ | FE-44 |
+| 403/404/500/maintenance/session-expired pages | ✓ | FE-44 |
+| Feature flags / progressive delivery | ✓ | FE-45 |
+| Product analytics distinct from Sentry/OTel | ✓ | FE-46 |
+| User feedback entry points | ✓ | FE-46 |
+| Usage and budget visibility | ✓ | FE-47 |
+| Commercial billing explicitly deferred | ✓ | FE-47 |
+| Public status page | ✓ | FE-48 |
+| Changelog / release experience | ✓ | FE-48 |
+| Data export/import portability | ✓ | FE-49 |
+| Legal/privacy/security/trust pages | ✓ | FE-50 |
+| PWA deliberately deferred | ✓ | Explicitly deferred product-surface decisions |
+| White-label deliberately deferred | ✓ | Explicitly deferred product-surface decisions |
+| Configurable keyboard maps deferred | ✓ | Explicitly deferred product-surface decisions |
+| Nuxt Content | ✓ | §13.1, FE-31 |
+| Docs Command Palette | ✓ | §13.5, FE-32 |
+| Docs search | ✓ | §13.9, FE-32 |
+| Mermaid | ✓ | §13.11, FE-33 |
+| OpenAPI → Scalar | ✓ | §13.8, FE-34 |
+| Docs FR/EN | ✓ | §13.1, FE-35 |
+| Docs version-ready | ✓ | §13.10, FE-35 |
+| Product docs vs Engineering docs | ✓ | §13.7 |
+| Docs CI with broken-link checks | ✓ | §13.12, FE-36 |
+| Implementation phases with objective/install/config/files/rules/tests/errors/acceptance/exclusions | ✓ | §16 |
+| One phase = one objective = one PR = one validation | ✓ | document header, §16 |
+| Frontend should wait for sufficiently mature backend | ✓ | §1.1, FE-0 |
+
+**Audit result:** all validated frontend decisions captured in the conversation, including the later product-surface audit (landing page, onboarding, settings, recovery states, feature flags, analytics/feedback, usage/billing readiness, status/changelog, portability, trust/legal pages, and explicit PWA/white-label deferrals), have a corresponding section or explicit deferred entry in this specification.
+
+---
+
+# 26. Final Definition of Done for the frontend architecture specification
+
+This architecture specification is complete when:
+
+- [x] product vision is defined;
+- [x] Company View, Control Center and Deep Inspect are distinguished;
+- [x] validated frontend stack is documented;
+- [x] data/state ownership is documented;
+- [x] API generation strategy is documented;
+- [x] real-time strategy is documented;
+- [x] authentication/authorization boundary is documented;
+- [x] Kanban and task-state rules are documented;
+- [x] storage/search/notification strategies are documented;
+- [x] data visualization and motion responsibilities are documented;
+- [x] security rules are documented;
+- [x] accessibility/responsive strategy is documented;
+- [x] build/deployment architecture is documented;
+- [x] CI/CD is documented;
+- [x] official documentation site is documented;
+- [x] public marketing/landing website is documented;
+- [x] onboarding and account/organization settings are documented;
+- [x] loading/empty/error/offline/recovery states are documented;
+- [x] feature-flag/progressive-delivery strategy is documented;
+- [x] product analytics and feedback boundaries are documented;
+- [x] usage/budget visibility and billing deferral are documented;
+- [x] public status/changelog/release experience is documented;
+- [x] data portability is documented;
+- [x] legal/privacy/security trust surfaces are documented;
+- [x] PWA, white-label and other deferred product surfaces are explicit;
+- [x] deferred technologies are explicit;
+- [x] implementation roadmap is phased;
+- [x] testing strategy includes failure paths;
+- [x] common architecture mistakes are explicit;
+- [x] decisions are indexed in an ADR-style table;
+- [x] a completion audit maps every previously validated decision to this document.
+
+---
+
+# 27. Intended repository integration
+
+When GitHub write access is available, the intended integration is:
+
+```text
+branch: feature/frontend-architecture-roadmap
+base:   the appropriate current backend branch/mainline at the time of integration
+file:   docs/frontend-architecture-roadmap.md
+```
+
+Suggested commit:
+
+```text
+docs(frontend): add complete frontend architecture roadmap
+```
+
+Suggested PR title:
+
+```text
+docs(frontend): define SynapseOS frontend architecture and implementation roadmap
+```
+
+Suggested PR summary:
+
+```text
+- document the validated Nuxt frontend architecture
+- define Company View, Control Center and Deep Inspect UX modes
+- define state/API/realtime/auth/security/storage/search/notification decisions
+- define Kanban and TaskStateMachine integration
+- define testing, observability, accessibility and deployment requirements
+- define GitHub Actions CI/CD and protected production promotion
+- define the official Nuxt Content documentation site
+- provide a phased implementation roadmap and ADR-style decision log
+- keep deferred technologies explicit to avoid premature infrastructure
+```
+
+The branch should be created from the appropriate current integration base, not automatically from an unrelated stale `main` if stacked backend PRs are still the source of truth.
+
+---
+
+_End of specification._

--- a/docs/synapseos v2-agent-governance-extensions.md
+++ b/docs/synapseos v2-agent-governance-extensions.md
@@ -1,0 +1,3594 @@
+# SynapseOS — Strategic Agent Governance Extensions
+
+> **Status:** architecture specification and implementation roadmap
+> **Project:** SynapseOS
+> **Scope:** four strategic backend extensions:
+>
+> 1. Agent Genome
+> 2. Agent Trust Score
+> 3. Autonomy Governor
+> 4. AI Manager
+>
+> **Development rule:** one phase = one clear objective = one PR = one validation.
+
+---
+
+# 1. Purpose
+
+This document formalizes four extensions that turn SynapseOS from an agent runtime into a governed AI workforce platform.
+
+The four extensions form a decision chain:
+
+```mermaid
+flowchart TD
+    T[Task / Mission] --> M[AI Manager]
+    M --> G[Agent Genome]
+    G --> TS[Agent Trust Score]
+    TS --> AG[Autonomy Governor]
+    AG --> E[Execution]
+    E --> R[Results / Review / QA / Security]
+    R --> G
+    R --> TS
+```
+
+The system must answer four different questions:
+
+| Extension | Question |
+|---|---|
+| Agent Genome | What is this agent actually good at? |
+| Agent Trust Score | How much operational trust can we place in this agent? |
+| Autonomy Governor | What is this agent allowed to do for this specific task, right now? |
+| AI Manager | Which agent should do the work, when, and under what coordination? |
+
+These modules must remain independent enough to test separately, but designed to work together.
+
+---
+
+# 2. Cross-cutting principles
+
+## 2.1 Backend authority
+
+No frontend value, prompt instruction, agent self-report, or LLM confidence score may override backend authorization.
+
+The following remain authoritative:
+
+- Permission Engine
+- TaskStateMachine
+- ToolExecutor
+- Security vetoes
+- Workspace isolation
+- Human approval rules
+- Budget and runtime limits
+
+## 2.2 Scores are signals, not truth
+
+Genome scores and Trust Score values are decision inputs only.
+
+They must never be treated as absolute truth.
+
+## 2.3 Explainability
+
+Every routing, promotion, restriction, reassignment, autonomy decision, or manager escalation must be explainable from persisted evidence.
+
+## 2.4 Auditing
+
+Every material decision should emit an append-only audit event.
+
+Examples:
+
+```text
+agent.genome.snapshot_created
+agent.genome.metric_updated
+agent.trust.recomputed
+agent.autonomy.level_changed
+manager.assignment_created
+manager.assignment_rebalanced
+manager.blocker_escalated
+```
+
+## 2.5 Deterministic core before LLM judgment
+
+When a decision can be derived deterministically from system evidence, prefer deterministic code.
+
+LLMs may assist with classification or recommendation, but must not become the sole source of authority for:
+
+- permission decisions
+- trust
+- autonomy
+- security
+- promotions
+- critical assignments
+
+---
+
+# 3. Extension 1 — Agent Genome
+
+## 3.1 Objective
+
+Agent Genome is the persistent, versioned operational profile of an agent.
+
+It measures what an agent has demonstrated it can do, under what conditions, with what quality, efficiency, reliability, and risk profile.
+
+It is not a static résumé.
+
+It evolves from observed execution evidence.
+
+## 3.2 Core idea
+
+```mermaid
+flowchart LR
+    RUN[Agent Runs] --> EV[Evidence]
+    REVIEW[Reviewer] --> EV
+    QA[QA] --> EV
+    SEC[Security] --> EV
+    COST[Cost / Tokens / Time] --> EV
+
+    EV --> G[Agent Genome]
+    G --> MATCH[Capability Matching]
+    MATCH --> NEXT[Future Tasks]
+```
+
+## 3.3 Genome dimensions
+
+Recommended dimensions:
+
+```text
+capability
+technology
+domain
+task_type
+quality
+reliability
+efficiency
+security
+review_acceptance
+tool_usage
+model_performance
+context_efficiency
+failure_patterns
+```
+
+Example:
+
+```text
+Backend Agent #7
+
+Python                 94
+FastAPI                91
+PostgreSQL             88
+Docker                 74
+OAuth                  92
+Security-sensitive     63
+
+Success rate           95%
+Review approval        91%
+QA pass rate           94%
+Median iterations      2.3
+Median token cost      12.4k
+Median duration        74 s
+Tool failure rate      1.8%
+```
+
+## 3.4 Capability model
+
+A capability score should not be a single manually written number.
+
+It should be derived from evidence.
+
+Conceptually:
+
+```text
+capability_score =
+    quality
+    × reliability
+    × evidence_weight
+    × recency_factor
+    × task_similarity
+```
+
+This is conceptual only. Exact formulas should be introduced later through ADR and tested against real run data.
+
+## 3.5 Evidence sources
+
+Trusted evidence sources:
+
+- task completion result
+- Reviewer decision
+- QA result
+- Security result
+- unit/integration test results
+- regression status
+- runtime failures
+- tool-call failures
+- timeouts
+- stagnation
+- retries
+- token usage
+- wall-clock duration
+- human feedback
+- post-delivery reopen/regression
+
+Untrusted or low-trust sources:
+
+- agent self-score
+- LLM saying “I am confident”
+- prompt text claiming expertise
+- unverified free-form output
+
+## 3.6 Proposed entities
+
+### AgentGenome
+
+```text
+id
+agent_id
+current_version_id
+created_at
+updated_at
+```
+
+### AgentGenomeVersion
+
+```text
+id
+agent_genome_id
+version
+status
+created_at
+created_by
+reason
+```
+
+### AgentCapabilityMetric
+
+```text
+id
+genome_version_id
+capability_key
+score
+sample_count
+success_count
+failure_count
+confidence
+last_observed_at
+```
+
+### AgentPerformanceMetric
+
+```text
+id
+genome_version_id
+metric_name
+value
+sample_count
+window
+computed_at
+```
+
+### AgentFailurePattern
+
+```text
+id
+agent_id
+pattern_key
+count
+severity
+last_seen_at
+metadata
+```
+
+## 3.7 Versioning
+
+Genome history must be immutable.
+
+```mermaid
+stateDiagram-v2
+    [*] --> CANDIDATE
+    CANDIDATE --> ACTIVE
+    ACTIVE --> SUPERSEDED
+    ACTIVE --> SUSPENDED
+    SUSPENDED --> ACTIVE
+    SUPERSEDED --> [*]
+```
+
+Old runs must always retain the exact Genome version used.
+
+## 3.8 Capability matching
+
+When a task arrives:
+
+```mermaid
+flowchart TD
+    T[Task] --> RQ[Extract requirements]
+    RQ --> CANDS[Eligible agents]
+    CANDS --> G[Genome comparison]
+    G --> F[Capability fit]
+    F --> M[Manager ranking]
+```
+
+Possible matching factors:
+
+- required technology
+- task type
+- complexity
+- historical success
+- current workload
+- cost profile
+- reviewer acceptance
+- task risk
+
+## 3.9 Genome must not bypass permissions
+
+An agent can have:
+
+```text
+PostgreSQL score = 97
+```
+
+and still be denied access to production DB.
+
+Capability and authorization are separate.
+
+## 3.10 Failure learning
+
+Genome should record failure patterns such as:
+
+```text
+often fails migrations with PostgreSQL enum changes
+high timeout rate on large repository search
+review failures on auth changes
+strong performance on API refactors
+```
+
+This enables future routing decisions.
+
+## 3.11 File structure
+
+```text
+core/genome/
+├── contracts.py
+├── types.py
+├── capabilities.py
+├── metrics.py
+├── evaluator.py
+├── matching.py
+├── versioning.py
+├── policies.py
+└── service.py
+
+infrastructure/genome/
+├── models.py
+├── repositories.py
+└── analytics.py
+
+tests/genome/
+├── test_capabilities.py
+├── test_metrics.py
+├── test_evaluator.py
+├── test_matching.py
+├── test_versioning.py
+└── test_integration.py
+```
+
+## 3.12 Implementation phases
+
+### GEN-1 — Genome contracts and entities
+
+Objective:
+
+- introduce entities
+- no routing impact yet
+
+Acceptance:
+
+- migrations
+- typed models
+- repositories
+- tests
+
+### GEN-2 — Evidence ingestion
+
+Collect evidence from runs, reviews, QA, Security, and runtime metrics.
+
+### GEN-3 — Capability scoring
+
+Create deterministic scoring rules.
+
+### GEN-4 — Performance profiles
+
+Compute:
+
+- success rate
+- review acceptance
+- QA pass rate
+- failure rate
+- median iterations
+- median tokens
+- duration
+
+### GEN-5 — Capability matching
+
+Expose ranking API/service for eligible agents.
+
+### GEN-6 — Failure pattern tracking
+
+Identify recurring failures.
+
+### GEN-7 — Version snapshots
+
+Freeze Genome state per run.
+
+### GEN-8 — AI Manager integration
+
+Manager uses Genome as one input.
+
+## 3.13 Tests
+
+Must cover:
+
+- no evidence
+- sparse evidence
+- contradictory evidence
+- stale evidence
+- high capability but high failure rate
+- equal agents
+- capability not present
+- rollback of Genome version
+- cross-workspace leakage
+- corrupted metric rows
+- agent self-score ignored
+
+## 3.14 Definition of Done
+
+- every run can reference a Genome version
+- capability metrics are evidence-based
+- no self-report determines scores
+- scores are reproducible
+- history is immutable
+- Manager can query Genome
+- Permission Engine remains authoritative
+
+---
+
+# 4. Extension 2 — Agent Trust Score
+
+## 4.1 Objective
+
+Agent Trust Score measures operational trustworthiness.
+
+It answers:
+
+> Given what SynapseOS knows about this agent, how much operational confidence should the system place in it?
+
+Trust is not the same as capability.
+
+An agent can be highly skilled but not sufficiently trustworthy for risky operations.
+
+## 4.2 Trust dimensions
+
+Recommended dimensions:
+
+```text
+identity
+permission hygiene
+reliability
+review history
+security history
+policy compliance
+anomaly history
+rollback rate
+incident history
+audit completeness
+```
+
+## 4.3 Example
+
+```text
+Agent Trust Score: 87 / 100
+
+Identity             100
+Reliability           94
+Review history        90
+Security history      81
+Policy compliance     96
+Anomaly score         77
+Audit completeness    98
+```
+
+## 4.4 Architecture
+
+```mermaid
+flowchart TD
+    ID[Identity evidence] --> T[Trust Engine]
+    REL[Reliability] --> T
+    REV[Review history] --> T
+    SEC[Security findings] --> T
+    POL[Policy compliance] --> T
+    INC[Incidents] --> T
+    AUD[Audit completeness] --> T
+
+    T --> TS[Trust Score]
+    TS --> GOV[Autonomy Governor]
+    TS --> MAN[AI Manager]
+```
+
+## 4.5 Trust must be multi-dimensional
+
+Store both:
+
+```text
+overall_score
+dimension_scores
+```
+
+The overall score is useful for UX and policy thresholds.
+
+The dimension scores are necessary for explainability.
+
+## 4.6 Trust classes
+
+Example:
+
+```text
+90–100  HIGH_TRUST
+70–89   STANDARD_TRUST
+40–69   RESTRICTED_TRUST
+0–39    LOW_TRUST
+```
+
+These thresholds are policy examples, not hard-coded universal truth.
+
+## 4.7 Proposed entities
+
+### AgentTrustSnapshot
+
+```text
+id
+agent_id
+overall_score
+trust_class
+calculated_at
+evidence_window_start
+evidence_window_end
+algorithm_version
+```
+
+### AgentTrustDimension
+
+```text
+id
+trust_snapshot_id
+dimension
+score
+weight
+reason
+```
+
+### AgentTrustEvent
+
+```text
+id
+agent_id
+event_type
+impact
+severity
+source_ref
+created_at
+```
+
+## 4.8 Positive trust signals
+
+Examples:
+
+- repeated successful tasks
+- Reviewer approvals
+- QA passes
+- no security violations
+- policy-compliant tool use
+- clean audit trail
+- stable reliability
+
+## 4.9 Negative signals
+
+Examples:
+
+- repeated permission denials
+- unauthorized tool attempts
+- suspicious command patterns
+- security findings
+- repeated hallucinated completion
+- high rollback rate
+- unexplained missing audit trail
+- recurring destructive mistakes
+
+## 4.10 Trust decay
+
+Trust should not stay permanently high from old success.
+
+Possible concept:
+
+```text
+effective_signal = raw_signal × recency_factor
+```
+
+The decay strategy must be documented in ADR.
+
+## 4.11 Severe events
+
+Some events should cause immediate restriction.
+
+Example:
+
+```text
+critical security violation
+→ trust penalty
+→ Autonomy Governor recomputation
+→ possible suspension/quarantine
+```
+
+```mermaid
+sequenceDiagram
+    participant S as Security
+    participant T as Trust Engine
+    participant G as Autonomy Governor
+    participant A as Agent
+
+    S->>T: critical violation
+    T->>T: recompute trust
+    T->>G: trust changed
+    G->>G: recompute autonomy
+    G-->>A: restricted / suspended
+```
+
+## 4.12 Explainability
+
+Trust API should be able to answer:
+
+```text
+Why is Agent X at 62?
+```
+
+Example:
+
+```text
+-12: repeated reviewer rejection
+-10: security finding
+-6: timeout rate
++8: stable task completion
++5: clean audit trail
+```
+
+## 4.13 File structure
+
+```text
+core/trust/
+├── contracts.py
+├── types.py
+├── scoring.py
+├── dimensions.py
+├── decay.py
+├── policies.py
+├── explanations.py
+└── service.py
+
+infrastructure/trust/
+├── models.py
+├── repositories.py
+└── analytics.py
+
+tests/trust/
+├── test_scoring.py
+├── test_dimensions.py
+├── test_decay.py
+├── test_explanations.py
+├── test_critical_events.py
+└── test_integration.py
+```
+
+## 4.14 Implementation phases
+
+### TRUST-1 — Trust data model
+
+### TRUST-2 — Evidence adapters
+
+### TRUST-3 — Deterministic dimension scores
+
+### TRUST-4 — Overall score and classes
+
+### TRUST-5 — Trust decay
+
+### TRUST-6 — Critical-event handling
+
+### TRUST-7 — Explainability
+
+### TRUST-8 — Governor integration
+
+## 4.15 Tests
+
+Must cover:
+
+- new agent
+- no evidence
+- excellent skill but security violation
+- old success only
+- recent incident
+- repeated permission denials
+- trust recovery
+- deterministic recomputation
+- algorithm versioning
+- audit explanation
+
+## 4.16 Definition of Done
+
+- Trust Score is reproducible
+- every score has evidence
+- no LLM-only trust judgment
+- critical events can restrict autonomy
+- historical snapshots remain available
+- score algorithm is versioned
+
+---
+
+# 5. Extension 3 — Autonomy Governor
+
+## 5.1 Objective
+
+Autonomy Governor determines how much freedom an agent receives for a specific action or task.
+
+Trust answers:
+
+> Can we generally trust this agent?
+
+Governor answers:
+
+> What may this agent do right now, for this task, in this environment?
+
+## 5.2 Why dynamic autonomy
+
+A single static autonomy level is insufficient.
+
+The same agent may safely edit documentation but should not automatically run a production database migration.
+
+## 5.3 Inputs
+
+```mermaid
+flowchart LR
+    G[Genome] --> GOV[Autonomy Governor]
+    T[Trust Score] --> GOV
+    R[Task risk] --> GOV
+    E[Environment] --> GOV
+    P[Permissions] --> GOV
+    S[Security policy] --> GOV
+    C[Cost / budget] --> GOV
+
+    GOV --> D[Autonomy Decision]
+```
+
+## 5.4 Autonomy levels
+
+Recommended model:
+
+```text
+LEVEL_0 — DISABLED
+LEVEL_1 — OBSERVE
+LEVEL_2 — RECOMMEND
+LEVEL_3 — ACT_WITH_APPROVAL
+LEVEL_4 — BOUNDED_AUTONOMY
+LEVEL_5 — HIGH_AUTONOMY
+```
+
+## 5.5 Semantics
+
+### Level 0 — Disabled
+
+Agent cannot act.
+
+### Level 1 — Observe
+
+Can inspect permitted state.
+
+No mutations.
+
+### Level 2 — Recommend
+
+Can propose plans/actions.
+
+Cannot execute them.
+
+### Level 3 — Act with approval
+
+Can prepare actions, but execution requires explicit approval.
+
+### Level 4 — Bounded autonomy
+
+May execute permitted low/medium-risk actions within configured limits.
+
+### Level 5 — High autonomy
+
+Reserved for tightly governed environments and still bounded by hard permissions/security rules.
+
+Level 5 is not “unlimited”.
+
+## 5.6 Decision object
+
+### AutonomyDecision
+
+```text
+agent_id
+task_id
+requested_action
+effective_level
+allowed
+approval_required
+reason_codes
+risk_score
+trust_snapshot_id
+genome_version_id
+policy_version
+expires_at
+```
+
+## 5.7 Risk model
+
+Risk should include:
+
+```text
+action type
+tool risk
+environment
+data sensitivity
+blast radius
+reversibility
+cost
+external side effects
+production impact
+```
+
+Example:
+
+```text
+edit README
+risk = LOW
+
+delete local test file
+risk = MEDIUM
+
+production migration
+risk = CRITICAL
+```
+
+## 5.8 Policy example
+
+```text
+IF environment == production
+AND action == database_migration
+THEN max_autonomy = LEVEL_2
+```
+
+```text
+IF trust < 40
+THEN max_autonomy = LEVEL_1
+```
+
+```text
+IF security_veto == true
+THEN allowed = false
+```
+
+## 5.9 Permission Engine relationship
+
+Governor must not duplicate permissions.
+
+```mermaid
+flowchart TD
+    REQ[Requested action]
+    REQ --> PERM[Permission Engine]
+    PERM -->|denied| STOP[DENY]
+    PERM -->|allowed| GOV[Autonomy Governor]
+    GOV -->|approval needed| AP[Approval Gate]
+    GOV -->|allowed| EXEC[Execute]
+```
+
+Permission Engine answers:
+
+> Is this action ever permitted for this identity?
+
+Governor answers:
+
+> Given current risk and trust, may it execute now without escalation?
+
+## 5.10 Temporary autonomy
+
+Autonomy decisions should often expire.
+
+Example:
+
+```text
+Agent gets LEVEL_4 for Task #182 only
+valid until task completion
+```
+
+Not:
+
+```text
+Agent becomes permanently LEVEL_4 everywhere
+```
+
+## 5.11 Quarantine mode
+
+```text
+QUARANTINED
+```
+
+may be modeled separately or via Level 0 + security state.
+
+Triggers:
+
+- critical incident
+- anomaly
+- compromised credentials
+- suspicious tool use
+- severe policy violation
+
+## 5.12 File structure
+
+```text
+core/autonomy/
+├── contracts.py
+├── types.py
+├── levels.py
+├── risk.py
+├── policies.py
+├── governor.py
+├── explanations.py
+└── service.py
+
+infrastructure/autonomy/
+├── repositories.py
+├── policy_store.py
+└── models.py
+
+tests/autonomy/
+├── test_levels.py
+├── test_risk.py
+├── test_governor.py
+├── test_permissions_integration.py
+├── test_approval.py
+├── test_quarantine.py
+└── test_integration.py
+```
+
+## 5.13 Implementation phases
+
+### GOV-1 — Autonomy levels and contracts
+
+### GOV-2 — Task/action risk classification
+
+### GOV-3 — Policy engine
+
+### GOV-4 — Trust integration
+
+### GOV-5 — Genome integration
+
+### GOV-6 — Approval gate integration
+
+### GOV-7 — Security veto / quarantine
+
+### GOV-8 — Dynamic recomputation
+
+## 5.14 Tests
+
+Must cover:
+
+- low-risk docs task
+- production migration
+- trusted agent
+- low-trust agent
+- permission denied
+- security veto
+- expired decision
+- task changes risk class
+- human approval
+- trust drops during run
+- Genome changes during run
+
+## 5.15 Definition of Done
+
+- no action bypasses Permission Engine
+- every autonomy decision is auditable
+- risk and trust affect effective autonomy
+- security veto always wins
+- temporary scope is enforced
+- approval can be required dynamically
+
+---
+
+# 6. Extension 4 — AI Manager
+
+## 6.1 Objective
+
+AI Manager coordinates the workforce.
+
+It should not be “another agent that just chats”.
+
+Its role is operational:
+
+- assign work
+- select agents
+- balance workload
+- detect blockers
+- monitor deadlines
+- escalate risks
+- reassign work
+- coordinate departments
+- request human approval
+
+## 6.2 Architecture
+
+```mermaid
+flowchart TD
+    P[Project / Brief] --> M[AI Manager]
+    M --> T[Task decomposition / queue]
+    T --> C[Candidate agents]
+    C --> G[Genome]
+    C --> TR[Trust]
+    C --> W[Workload]
+    G --> RANK[Assignment ranking]
+    TR --> RANK
+    W --> RANK
+    RANK --> GOV[Autonomy Governor]
+    GOV --> ASSIGN[Assignment]
+    ASSIGN --> RUN[Execution]
+    RUN --> MON[Manager monitoring]
+    MON -->|blocked| REBAL[Reassign / escalate]
+    MON -->|done| NEXT[Next task]
+```
+
+## 6.3 Manager responsibilities
+
+### Assignment
+
+Select eligible agent.
+
+### Load balancing
+
+Avoid assigning everything to the strongest agent.
+
+### Blocker detection
+
+Detect:
+
+- waiting too long
+- repeated failure
+- dependency blocked
+- reviewer bottleneck
+- provider outage
+- no eligible agent
+
+### Escalation
+
+Escalate when:
+
+- no safe action
+- budget exceeded
+- security issue
+- deadline at risk
+- required human decision
+- trust degraded
+
+### Reassignment
+
+Manager may reassign when policy allows.
+
+## 6.4 Manager is policy-driven
+
+The Manager should combine deterministic rules with optional LLM planning.
+
+Example:
+
+```mermaid
+flowchart LR
+    STATE[Current company state] --> RULES[Deterministic constraints]
+    STATE --> LLM[Optional planning]
+    RULES --> DEC[Manager decision]
+    LLM --> DEC
+    DEC --> VALIDATE[Backend validation]
+    VALIDATE --> EXEC[Execute]
+```
+
+LLM proposal must pass backend validation.
+
+## 6.5 Candidate ranking
+
+Possible ranking inputs:
+
+```text
+capability fit
+trust
+current load
+availability
+task priority
+expected cost
+expected latency
+historical success
+department
+seniority
+autonomy
+```
+
+## 6.6 ManagerDecision
+
+```text
+id
+decision_type
+project_id
+task_id
+selected_agent_id
+alternatives
+reason_codes
+confidence
+evidence
+created_at
+```
+
+Possible decision types:
+
+```text
+ASSIGN
+REASSIGN
+PAUSE
+ESCALATE
+REQUEST_APPROVAL
+DEFER
+CANCEL
+```
+
+## 6.7 Workload model
+
+### AgentWorkload
+
+```text
+agent_id
+active_tasks
+queued_tasks
+estimated_remaining_seconds
+current_run_id
+capacity_score
+updated_at
+```
+
+## 6.8 Blocker detection
+
+```mermaid
+stateDiagram-v2
+    [*] --> HEALTHY
+    HEALTHY --> WARNING
+    WARNING --> BLOCKED
+    BLOCKED --> ESCALATED
+    BLOCKED --> RECOVERED
+    ESCALATED --> RECOVERED
+    RECOVERED --> HEALTHY
+```
+
+Possible blocker signals:
+
+- no progress across N cycles
+- dependency unresolved
+- max retries reached
+- reviewer queue too long
+- provider unavailable
+- security hold
+- approval pending
+- agent unavailable
+
+## 6.9 Department coordination
+
+Future example:
+
+```text
+Engineering Manager
+→ Developer
+→ Reviewer
+→ QA
+→ Security
+→ DevOps
+```
+
+The AI Manager does not need to replace every department lead immediately.
+
+V1 can be a central manager.
+
+Later:
+
+```text
+Company Manager
+├── Engineering Manager
+├── Product Manager
+├── Security Manager
+└── Operations Manager
+```
+
+## 6.10 Human manager integration
+
+The system must support:
+
+```text
+AI Manager recommends
+Human overrides
+AI Manager records override
+Future decisions can use override as evidence
+```
+
+Human override remains auditable.
+
+## 6.11 File structure
+
+```text
+core/manager/
+├── contracts.py
+├── types.py
+├── assignment.py
+├── ranking.py
+├── workload.py
+├── blockers.py
+├── escalation.py
+├── policies.py
+├── explanations.py
+└── service.py
+
+infrastructure/manager/
+├── repositories.py
+├── models.py
+└── analytics.py
+
+tests/manager/
+├── test_assignment.py
+├── test_ranking.py
+├── test_workload.py
+├── test_blockers.py
+├── test_escalation.py
+├── test_human_override.py
+└── test_integration.py
+```
+
+## 6.12 Implementation phases
+
+### MGR-1 — Manager contracts
+
+### MGR-2 — Workload model
+
+### MGR-3 — Deterministic candidate selection
+
+### MGR-4 — Genome-aware ranking
+
+### MGR-5 — Trust-aware ranking
+
+### MGR-6 — Governor integration
+
+### MGR-7 — Blocker detection
+
+### MGR-8 — Reassignment and escalation
+
+### MGR-9 — Human override
+
+### MGR-10 — Optional LLM planning
+
+Only after deterministic guardrails are mature.
+
+## 6.13 Tests
+
+Must cover:
+
+- no eligible agents
+- multiple equally good agents
+- strongest agent overloaded
+- high-capability low-trust agent
+- available lower-capability trusted agent
+- agent failure mid-task
+- reviewer bottleneck
+- provider outage
+- security hold
+- human override
+- deadline pressure
+- cyclic dependency
+- repeated reassignment
+
+## 6.14 Definition of Done
+
+- assignments are explainable
+- Manager uses backend evidence
+- Manager cannot bypass Governor
+- Manager cannot bypass Permission Engine
+- overload is considered
+- blockers trigger defined behavior
+- human override is supported
+- all decisions are audited
+
+---
+
+# 7. Full system interaction
+
+```mermaid
+sequenceDiagram
+    participant U as User
+    participant M as AI Manager
+    participant G as Agent Genome
+    participant T as Trust Engine
+    participant A as Autonomy Governor
+    participant X as Agent Runtime
+    participant R as Reviewer/QA/Security
+
+    U->>M: Create / start task
+    M->>G: Find capability fit
+    G-->>M: Ranked candidates
+    M->>T: Read trust snapshots
+    T-->>M: Trust dimensions
+    M->>A: Evaluate candidate + task
+    A-->>M: Effective autonomy / approval
+    M->>X: Assign safe candidate
+    X->>X: Execute bounded run
+    X->>R: Submit evidence
+    R-->>X: Review outcome
+    X-->>G: Performance evidence
+    X-->>T: Reliability/security evidence
+    G->>G: Update metrics
+    T->>T: Recompute trust
+```
+
+---
+
+# 8. Decision hierarchy
+
+The hierarchy must be explicit.
+
+```text
+Security veto
+    ↓
+Permission Engine
+    ↓
+Autonomy Governor
+    ↓
+AI Manager
+    ↓
+Agent Runtime
+```
+
+Genome and Trust provide signals.
+
+They do not sit above security.
+
+```mermaid
+flowchart TD
+    SEC[Security Veto] --> PERM[Permission Engine]
+    PERM --> GOV[Autonomy Governor]
+    GOV --> MGR[AI Manager]
+    MGR --> RUN[Agent Runtime]
+
+    GEN[Agent Genome] -. signal .-> MGR
+    GEN -. signal .-> GOV
+    TRUST[Trust Score] -. signal .-> MGR
+    TRUST -. signal .-> GOV
+```
+
+---
+
+# 9. Recommended implementation order
+
+The dependency chain is:
+
+```mermaid
+flowchart TD
+    GEN[Agent Genome]
+    TRUST[Agent Trust Score]
+    GOV[Autonomy Governor]
+    MGR[AI Manager]
+
+    GEN --> TRUST
+    TRUST --> GOV
+    GOV --> MGR
+```
+
+Recommended order:
+
+```text
+1. Agent Genome
+2. Agent Trust Score
+3. Autonomy Governor
+4. AI Manager
+```
+
+Why:
+
+- Trust needs reliable historical evidence.
+- Governor needs Trust + permissions + risk.
+- Manager becomes much smarter once Genome, Trust, and Governor already exist.
+
+---
+
+# 10. Suggested backend phase numbering
+
+Do not force these into the existing roadmap until the current scheduled phases are reconciled.
+
+Suggested future identifiers:
+
+```text
+EXT-GEN-01 → EXT-GEN-08
+EXT-TRUST-01 → EXT-TRUST-08
+EXT-GOV-01 → EXT-GOV-08
+EXT-MGR-01 → EXT-MGR-10
+```
+
+This avoids accidentally colliding with existing SynapseOS phase numbers.
+
+---
+
+# 11. Data model overview
+
+```mermaid
+erDiagram
+    AGENT ||--o{ AGENT_GENOME : has
+    AGENT_GENOME ||--o{ AGENT_GENOME_VERSION : versions
+    AGENT_GENOME_VERSION ||--o{ AGENT_CAPABILITY_METRIC : contains
+
+    AGENT ||--o{ AGENT_TRUST_SNAPSHOT : has
+    AGENT_TRUST_SNAPSHOT ||--o{ AGENT_TRUST_DIMENSION : contains
+
+    AGENT ||--o{ AUTONOMY_DECISION : receives
+    TASK ||--o{ AUTONOMY_DECISION : evaluates
+
+    TASK ||--o{ MANAGER_DECISION : drives
+    AGENT ||--o{ MANAGER_DECISION : selected_by
+
+    AGENT_RUN }o--|| AGENT_GENOME_VERSION : uses
+    AGENT_RUN }o--|| TASK : executes
+```
+
+---
+
+# 12. API surface
+
+Conceptual only.
+
+```text
+GET /agents/{agent_id}/genome
+GET /agents/{agent_id}/genome/history
+GET /agents/{agent_id}/capabilities
+
+GET /agents/{agent_id}/trust
+GET /agents/{agent_id}/trust/history
+GET /agents/{agent_id}/trust/explanation
+
+POST /autonomy/evaluate
+GET  /autonomy/decisions/{id}
+
+POST /manager/assign
+POST /manager/reassign
+POST /manager/escalate
+GET  /manager/workload
+GET  /manager/decisions/{id}
+```
+
+All mutations require backend authorization.
+
+---
+
+# 13. Events
+
+Recommended domain events:
+
+```text
+GENOME_EVIDENCE_RECORDED
+GENOME_METRICS_RECOMPUTED
+GENOME_VERSION_CREATED
+
+TRUST_RECOMPUTED
+TRUST_CLASS_CHANGED
+TRUST_CRITICAL_EVENT
+
+AUTONOMY_EVALUATED
+AUTONOMY_LEVEL_CHANGED
+AUTONOMY_APPROVAL_REQUIRED
+AUTONOMY_DENIED
+
+MANAGER_TASK_ASSIGNED
+MANAGER_TASK_REASSIGNED
+MANAGER_BLOCKER_DETECTED
+MANAGER_ESCALATION_CREATED
+MANAGER_HUMAN_OVERRIDE
+```
+
+---
+
+# 14. Security properties
+
+## 14.1 No self-promotion
+
+An agent must not:
+
+- edit its own Genome directly
+- edit its Trust Score directly
+- elevate its own autonomy
+- assign itself high-risk work by bypassing Manager
+
+## 14.2 Integrity
+
+Genome, Trust, and Governor decisions must rely on authoritative backend data.
+
+## 14.3 Audit
+
+Every material change must include:
+
+```text
+actor
+source
+timestamp
+reason
+evidence refs
+policy/algorithm version
+```
+
+## 14.4 Rollback
+
+Genome version changes and policy changes must be reversible.
+
+---
+
+# 15. Observability
+
+Metrics examples:
+
+```text
+synapse.genome.capability_score
+synapse.genome.success_rate
+synapse.genome.review_acceptance
+synapse.genome.median_iterations
+
+synapse.trust.overall_score
+synapse.trust.dimension_score
+synapse.trust.class_changes
+
+synapse.autonomy.level
+synapse.autonomy.denials
+synapse.autonomy.approvals_required
+
+synapse.manager.assignment_latency
+synapse.manager.reassignments
+synapse.manager.blockers
+synapse.manager.escalations
+```
+
+---
+
+# 16. Frontend projections
+
+These backend extensions should later surface in the Nuxt Control Center.
+
+## Agent page
+
+```text
+Agent Genome
+Capabilities
+Performance
+Trust Score
+Current autonomy
+Current workload
+Recent manager decisions
+```
+
+## Company Simulator
+
+Possible visual states:
+
+```text
+high trust → normal status
+restricted trust → warning badge
+quarantined → blocked visual
+manager reassignment → animated task transfer
+approval required → pending gate
+```
+
+## Manager dashboard
+
+```text
+Team load
+Blocked tasks
+Agents at risk
+Trust degradation
+Assignments
+Reassignments
+SLA risk
+```
+
+---
+
+# 17. Example scenario
+
+Task:
+
+```text
+Implement OAuth2 authorization code flow.
+```
+
+Candidate agents:
+
+```text
+Agent A
+OAuth capability: 92
+Trust: 94
+Load: 70%
+
+Agent B
+OAuth capability: 75
+Trust: 97
+Load: 20%
+
+Agent C
+OAuth capability: 95
+Trust: 42
+Load: 10%
+```
+
+Manager reasoning:
+
+```mermaid
+flowchart TD
+    T[OAuth task] --> G[Genome ranking]
+    G --> A[Agent A: 92]
+    G --> B[Agent B: 75]
+    G --> C[Agent C: 95]
+
+    A --> TR[Trust evaluation]
+    B --> TR
+    C --> TR
+
+    TR --> GOV[Autonomy Governor]
+    GOV --> SEL[Select safe assignment]
+```
+
+Possible outcome:
+
+```text
+Selected: Agent A
+Reason:
+- strong OAuth capability
+- high trust
+- acceptable workload
+- task risk compatible with autonomy policy
+```
+
+Agent C is not selected despite the best capability score because Trust is too low.
+
+---
+
+# 18. Example dynamic autonomy scenario
+
+Same agent:
+
+```text
+Trust: 96
+Genome: Senior backend
+```
+
+Task 1:
+
+```text
+Update README
+→ risk LOW
+→ effective autonomy LEVEL_4
+```
+
+Task 2:
+
+```text
+Production DB migration
+→ risk CRITICAL
+→ effective autonomy LEVEL_2
+→ human approval required
+```
+
+This is intentional.
+
+---
+
+# 19. Example trust degradation
+
+```mermaid
+sequenceDiagram
+    participant A as Agent
+    participant S as Security
+    participant T as Trust Engine
+    participant G as Governor
+    participant M as Manager
+
+    A->>S: suspicious action detected
+    S->>T: critical finding
+    T->>T: recompute score 91 -> 48
+    T->>G: trust changed
+    G->>G: autonomy LEVEL_4 -> LEVEL_1
+    G->>M: restrictions updated
+    M->>M: reassign risky tasks
+```
+
+---
+
+# 20. Example manager blocker handling
+
+```mermaid
+flowchart TD
+    A[Task running] --> B{Progress?}
+    B -->|yes| C[Continue]
+    B -->|no| D{Threshold reached?}
+    D -->|no| C
+    D -->|yes| E[Blocker detected]
+    E --> F{Recoverable?}
+    F -->|yes| G[Reassign / provider switch / retry policy]
+    F -->|no| H[Escalate human/security]
+```
+
+---
+
+# 21. Testing strategy
+
+## 21.1 Unit
+
+Each scoring and policy function independently.
+
+## 21.2 Integration
+
+Use real PostgreSQL where persistence/integrity matters.
+
+## 21.3 Workflow
+
+```text
+Task
+→ Manager
+→ Genome
+→ Trust
+→ Governor
+→ Agent
+→ Reviewer
+→ metrics
+→ Genome/Trust update
+```
+
+## 21.4 Failure paths
+
+Mandatory:
+
+- no candidate
+- permission denied
+- security veto
+- low trust
+- stale Genome
+- trust recomputation failure
+- invalid risk class
+- Manager decision conflict
+- human override
+- concurrent assignment race
+
+---
+
+# 22. Concurrency and consistency
+
+Potential races:
+
+```text
+two managers assign same agent
+trust changes while task starts
+autonomy expires mid-run
+Genome version changes during run
+```
+
+Rules:
+
+- snapshot Genome at run start
+- snapshot Trust at decision time
+- persist AutonomyDecision
+- use DB constraints/transactions for assignment
+- never mutate past snapshots
+
+---
+
+# 23. Non-goals
+
+For V1 of these four extensions:
+
+Do not implement:
+
+- self-modifying model weights
+- unsupervised autonomous promotion
+- opaque reinforcement learning
+- unlimited autonomy
+- black-box trust scoring
+- manager bypass of permissions
+- fully decentralized manager hierarchy
+- automatic production privileges
+
+---
+
+# 24. Acceptance matrix
+
+| Capability | Required |
+|---|---|
+| Genome evidence-based | Yes |
+| Trust explainable | Yes |
+| Governor task-specific | Yes |
+| Manager workload-aware | Yes |
+| Permission Engine authoritative | Yes |
+| Security veto authoritative | Yes |
+| Human override supported | Yes |
+| Audit events | Yes |
+| Versioned algorithms/policies | Yes |
+| Deterministic tests | Yes |
+
+---
+
+# 25. Final architecture
+
+```mermaid
+flowchart TB
+    USER[User / Product / Workflow]
+
+    USER --> MAN[AI Manager]
+
+    MAN --> GEN[Agent Genome]
+    MAN --> TRUST[Agent Trust Score]
+
+    GEN --> GOV[Autonomy Governor]
+    TRUST --> GOV
+
+    PERM[Permission Engine] --> GOV
+    RISK[Task / Tool Risk] --> GOV
+    SEC[Security Veto] --> GOV
+
+    GOV --> RUN[Agent Runtime]
+    RUN --> TOOLS[ToolExecutor / Command Runner]
+    RUN --> REV[Reviewer / QA / Security]
+
+    REV --> GEN
+    REV --> TRUST
+
+    RUN --> AUDIT[Audit / Metrics]
+    MAN --> AUDIT
+    GOV --> AUDIT
+    TRUST --> AUDIT
+    GEN --> AUDIT
+```
+
+---
+
+# 26. Final implementation order
+
+```text
+Agent Genome
+     ↓
+Agent Trust Score
+     ↓
+Autonomy Governor
+     ↓
+AI Manager
+```
+
+This order is deliberate.
+
+Genome creates the evidence model.
+
+Trust interprets reliability and governance evidence.
+
+Governor converts trust + risk + permissions into actionable autonomy.
+
+AI Manager then uses all three to coordinate the company intelligently.
+
+---
+
+# 27. Final design rule
+
+The four extensions together should produce:
+
+```text
+What can the agent do well?
+        ↓
+Agent Genome
+
+Can we trust it operationally?
+        ↓
+Agent Trust Score
+
+What may it do right now?
+        ↓
+Autonomy Governor
+
+What should it work on?
+        ↓
+AI Manager
+```
+
+SynapseOS should therefore evolve from:
+
+```text
+agents executing tasks
+```
+
+toward:
+
+```text
+a governed AI workforce with measurable capability,
+operational trust, dynamic autonomy, and intelligent management
+```
+
+without sacrificing:
+
+- security
+- auditability
+- deterministic enforcement
+- provider neutrality
+- reversibility
+- bounded execution
+- human authority
+
+---
+
+# 28. 2026-09 Architecture Update — Continuous Runtime Governance
+
+This update integrates recent enterprise-agent lessons into the four existing SynapseOS extensions without creating a fifth extension.
+
+The main architectural change is:
+
+> **Autonomy must be continuously re-evaluated during execution, not decided only once at run start.**
+
+The four-extension model remains:
+
+```text
+Agent Genome
+     ↓
+Agent Trust Score
+     ↓
+Autonomy Governor
+     ↓
+AI Manager
+```
+
+The new runtime feedback loop is:
+
+```mermaid
+flowchart TD
+    GEN[Agent Genome]
+    TRUST[Agent Trust Score]
+    GOV[Autonomy Governor]
+    MGR[AI Manager]
+    RUN[Agent Runtime]
+    TEL[Runtime Telemetry]
+
+    GEN --> TRUST
+    TRUST --> GOV
+    GOV --> MGR
+    MGR --> RUN
+    RUN --> TEL
+
+    TEL --> TRUST
+    TEL --> GOV
+    TEL --> MGR
+    TEL --> GEN
+```
+
+## 28.1 Agent Genome — Behavioral Baseline
+
+Agent Genome must not only describe capabilities and historical performance.
+
+It should also maintain a **behavioral baseline** describing how an agent normally behaves.
+
+### New Genome dimensions
+
+```text
+normal_tool_patterns
+normal_data_access_patterns
+normal_command_profiles
+normal_task_duration
+normal_token_usage
+normal_iteration_count
+normal_provider_usage
+normal_workspace_scope
+normal_failure_patterns
+```
+
+Example:
+
+```text
+Backend Agent #7
+
+Normal behavior:
+- read repository files
+- run pytest
+- run Ruff
+- edit Python source
+- create Git commits
+
+Unusual behavior:
+- bulk database export
+- access unrelated workspace
+- delete large directory tree
+- request credentials
+```
+
+The goal is not to block all unusual behavior. The goal is to give Trust Score and Autonomy Governor an evidence-based signal when runtime behavior deviates from the agent's established profile.
+
+### Behavioral deviation event
+
+```text
+AgentBehaviorDeviation
+
+agent_id
+run_id
+task_id
+behavior_type
+expected_pattern
+observed_pattern
+severity
+confidence
+evidence_refs
+created_at
+```
+
+```mermaid
+flowchart LR
+    HIST[Historical runs] --> BASE[Behavioral Baseline]
+    RUN[Current runtime behavior] --> DET[Deviation Detector]
+    BASE --> DET
+    DET --> EVT[Behavior Deviation Event]
+    EVT --> TRUST[Runtime Trust]
+    EVT --> GOV[Autonomy Re-evaluation]
+```
+
+### New Genome implementation phase
+
+#### GEN-9 — Behavioral baseline
+
+Objective:
+- derive bounded expected behavior from historical evidence;
+- never treat the baseline as a hard security policy;
+- expose deviation signals to Trust and Governor.
+
+Acceptance criteria:
+- baseline is versioned;
+- deviation detection is explainable;
+- new agents can operate with an explicit cold-start policy;
+- deviation alone never grants or revokes backend permissions;
+- critical deviations can trigger Governor re-evaluation.
+
+---
+
+# 29. Agent Trust Score — Historical Trust + Runtime Trust
+
+The Trust model must now distinguish between long-term reputation and current execution trust.
+
+## 29.1 Historical Trust
+
+Historical Trust is based on durable evidence:
+
+```text
+reliability
+review history
+QA history
+security history
+policy compliance
+incident history
+audit completeness
+rollback rate
+```
+
+## 29.2 Runtime Trust
+
+Runtime Trust reflects what is happening **during the current run**.
+
+Signals can include:
+
+```text
+unexpected tool use
+repeated permission denials
+scope drift
+unusual data access
+unexpected destructive action
+command profile deviation
+rapid failure bursts
+abnormal token growth
+unusual cost escalation
+security anomaly
+```
+
+## 29.3 Effective Trust
+
+Conceptually:
+
+```text
+Effective Trust = Historical Trust adjusted by Runtime Trust signals
+```
+
+The exact formula must be versioned and introduced through ADR. Do not hard-code one irreversible formula before enough run data exists.
+
+Example:
+
+```text
+Historical Trust: 94
+
+Runtime signals:
+- unusual bulk read: -8
+- repeated denied action: -12
+- unexpected tool category: -7
+
+Effective Trust: 67
+```
+
+```mermaid
+stateDiagram-v2
+    [*] --> BASELINE
+    BASELINE --> DEGRADED
+    DEGRADED --> RESTRICTED
+    RESTRICTED --> QUARANTINED
+    DEGRADED --> RECOVERED
+    RESTRICTED --> RECOVERED
+    RECOVERED --> BASELINE
+```
+
+### New data model
+
+```text
+AgentRuntimeTrustSnapshot
+
+id
+agent_id
+run_id
+historical_trust_snapshot_id
+runtime_score
+effective_score
+state
+reason_codes
+calculated_at
+expires_at
+algorithm_version
+```
+
+### New implementation phases
+
+#### TRUST-9 — Runtime Trust engine
+Compute run-scoped trust from current execution evidence.
+
+#### TRUST-10 — Trust degradation and recovery
+Support temporary degradation and bounded recovery.
+
+#### TRUST-11 — Runtime Trust explanations
+Every effective trust change must explain what changed, why, which events caused it, and how long it applies.
+
+---
+
+# 30. Autonomy Governor — Inline Action-Level Governance
+
+The Autonomy Governor must no longer be designed only as a pre-run gate. It must support **continuous action-level evaluation**.
+
+## 30.1 Previous model
+
+```text
+Task starts
+↓
+evaluate autonomy
+↓
+run
+```
+
+## 30.2 New model
+
+```text
+Task starts
+↓
+initial autonomy decision
+↓
+agent proposes action
+↓
+re-evaluate action
+↓
+ALLOW / APPROVAL / REDACT / DENY
+↓
+execute
+↓
+observe runtime signals
+↓
+recompute if necessary
+```
+
+```mermaid
+sequenceDiagram
+    participant A as Agent
+    participant P as Permission Engine
+    participant G as Autonomy Governor
+    participant T as Trust Engine
+    participant E as ToolExecutor
+
+    A->>P: request action
+    P-->>A: identity permission result
+
+    alt Permission denied
+        P-->>A: DENY
+    else Permission allowed
+        P->>G: evaluate action
+        G->>T: effective runtime trust
+        T-->>G: trust snapshot
+        G->>G: scope + risk + cost + environment
+
+        alt Allowed
+            G->>E: ALLOW
+            E-->>A: result
+        else Approval required
+            G-->>A: APPROVAL_REQUIRED
+        else Sensitive output
+            G-->>A: REDACT / constrain
+        else Unsafe
+            G-->>A: DENY
+        end
+    end
+```
+
+## 30.3 Action decisions
+
+Extend `AutonomyDecision` with:
+
+```text
+run_id
+action_id
+tool_name
+requested_scope
+data_sensitivity
+estimated_cost
+runtime_trust_snapshot_id
+decision
+reason_codes
+```
+
+Decision enum:
+
+```text
+ALLOW
+ALLOW_WITH_LIMITS
+APPROVAL_REQUIRED
+REDACT
+DENY
+QUARANTINE
+```
+
+## 30.4 Scope / intent guard
+
+The Governor should detect whether an action still belongs to the authorized task scope.
+
+Example:
+
+```text
+Task: fix authentication test
+Agent proposes: export full customer database
+→ scope mismatch
+→ DENY or APPROVAL_REQUIRED
+```
+
+This must be based on explicit task scope, tool metadata, workspace policy, and deterministic constraints wherever possible. An LLM-based semantic classifier may later assist, but must not be the only enforcement mechanism.
+
+## 30.5 Cost-aware autonomy
+
+Cost becomes a governance signal.
+
+New inputs:
+
+```text
+run_budget
+spent_budget
+estimated_action_cost
+remaining_budget
+provider_price_class
+```
+
+Example policy:
+
+```text
+IF estimated_action_cost > remaining_budget
+THEN DENY or REQUEST_APPROVAL
+```
+
+```mermaid
+flowchart TD
+    ACT[Proposed action] --> EST[Estimate cost]
+    EST --> REM[Remaining budget]
+    REM --> POL[Cost policy]
+    POL -->|within budget| SAFE[Continue governance]
+    POL -->|near budget| WARN[Warn / cheaper route]
+    POL -->|over budget| AP[Approval or deny]
+```
+
+## 30.6 Dynamic autonomy downgrade
+
+Example:
+
+```text
+Run starts
+Trust = 94
+Autonomy = LEVEL_4
+
+unexpected bulk data access
+↓
+Runtime Trust = 72
+
+Governor:
+LEVEL_4 → LEVEL_3
+
+second serious anomaly
+↓
+Runtime Trust = 48
+
+Governor:
+LEVEL_3 → LEVEL_1
+revoke write execution
+request Manager reassignment
+```
+
+```mermaid
+flowchart LR
+    TEL[Runtime telemetry] --> TRUST[Runtime Trust]
+    TRUST --> GOV[Autonomy Governor]
+    GOV --> LVL[Effective autonomy]
+    LVL --> EXEC[Allowed capabilities]
+```
+
+## 30.7 New implementation phases
+
+#### GOV-9 — Per-action evaluation
+Every sensitive tool call can be independently evaluated.
+
+#### GOV-10 — Scope / intent guard
+Detect actions unrelated to the authorized mission.
+
+#### GOV-11 — Runtime Trust integration
+Allow autonomy to change during an active run.
+
+#### GOV-12 — Economic governance
+Use budget and projected cost as decision inputs.
+
+#### GOV-13 — Runtime downgrade and quarantine
+Support immediate bounded reduction in privileges.
+
+---
+
+# 31. AI Manager — Cost-Aware and Trust-Aware Runtime Coordination
+
+AI Manager should not only assign tasks at the beginning. It must react when runtime conditions change.
+
+## 31.1 New Manager signals
+
+```text
+runtime trust degradation
+autonomy downgrade
+budget pressure
+provider cost increase
+provider outage
+unexpected task duration
+agent anomaly
+security hold
+```
+
+## 31.2 Trust-triggered reassignment
+
+```mermaid
+sequenceDiagram
+    participant A as Agent
+    participant T as Trust Engine
+    participant G as Governor
+    participant M as AI Manager
+    participant B as Backup Agent
+
+    A->>T: runtime anomalies observed
+    T->>G: effective trust degraded
+    G->>G: autonomy LEVEL_4 -> LEVEL_1
+    G->>M: agent no longer eligible
+    M->>M: find replacement
+    M->>B: reassign task
+```
+
+## 31.3 Cost-aware routing
+
+Example:
+
+```text
+Task budget: $0.50
+Remaining: $0.16
+
+Candidate routes:
+Qwen local   expected cost: $0.00
+Groq         expected cost: $0.05
+GPT          expected cost: $0.14
+Claude       expected cost: $0.26
+```
+
+The route selector must use measurable historical evidence whenever possible, not hand-written quality assumptions.
+
+## 31.4 Manager objective function
+
+Conceptually:
+
+```text
+maximize:
+    task success
+    quality
+    safety
+
+subject to:
+    permissions
+    autonomy
+    trust
+    budget
+    deadline
+    capacity
+```
+
+## 31.5 New Manager decisions
+
+```text
+SWITCH_PROVIDER
+DOWNGRADE_ROUTE
+REASSIGN_TRUST_DEGRADED
+REASSIGN_BUDGET_PRESSURE
+PAUSE_FOR_APPROVAL
+QUARANTINE_AGENT
+```
+
+## 31.6 New implementation phases
+
+#### MGR-11 — Runtime Trust monitoring
+Manager subscribes to meaningful trust changes.
+
+#### MGR-12 — Trust-triggered reassignment
+Reassign when an agent becomes ineligible.
+
+#### MGR-13 — Cost-aware routing
+Compare compliant execution routes.
+
+#### MGR-14 — Budget pressure handling
+Pause, switch route, or request approval.
+
+#### MGR-15 — Runtime coordination loop
+Manager reacts to meaningful execution-state changes without blind polling.
+
+---
+
+# 32. Updated Four-Extension Architecture
+
+```mermaid
+flowchart TB
+    TASK[Task] --> MGR[AI Manager]
+
+    MGR --> GEN[Agent Genome]
+    MGR --> TRUST[Agent Trust Score]
+
+    GEN --> GOV[Autonomy Governor]
+    TRUST --> GOV
+
+    PERM[Permission Engine] --> GOV
+    RISK[Task / Tool Risk] --> GOV
+    BUD[Cost / Resource Budget] --> GOV
+    SEC[Security Veto] --> GOV
+
+    GOV --> RUN[Agent Runtime]
+    RUN --> TOOL[ToolExecutor]
+    TOOL --> TEL[Runtime Telemetry]
+
+    TEL --> TRUST
+    TEL --> GEN
+    TEL --> GOV
+    TEL --> MGR
+
+    GOV -->|downgrade / deny| MGR
+    MGR -->|reassign / switch route| RUN
+```
+
+---
+
+# 33. Updated Responsibility Matrix
+
+| Extension | Core responsibility | New runtime responsibility |
+|---|---|---|
+| Agent Genome | capability and performance profile | behavioral baseline |
+| Agent Trust Score | historical operational trust | runtime trust |
+| Autonomy Governor | task-specific autonomy | per-action continuous governance |
+| AI Manager | assignment and coordination | trust/cost-aware runtime adaptation |
+
+---
+
+# 34. Updated Implementation Order
+
+The core dependency order remains unchanged:
+
+```text
+Agent Genome
+     ↓
+Agent Trust Score
+     ↓
+Autonomy Governor
+     ↓
+AI Manager
+```
+
+Recommended sequence:
+
+```text
+GEN-1 → GEN-8
+TRUST-1 → TRUST-8
+GOV-1 → GOV-8
+MGR-1 → MGR-10
+
+then runtime extensions:
+
+GEN-9
+TRUST-9 → TRUST-11
+GOV-9 → GOV-13
+MGR-11 → MGR-15
+```
+
+---
+
+# 35. Updated End-to-End Scenario
+
+Task:
+
+```text
+Refactor authentication service.
+```
+
+Initial evaluation:
+
+```text
+Developer Agent #7
+Genome fit: 93
+Historical Trust: 94
+Autonomy: LEVEL_4
+Budget: $0.40
+```
+
+Execution:
+
+```text
+Iteration 1: read auth module → allowed
+Iteration 2: run tests → allowed
+Iteration 3: edit auth.py → allowed
+Iteration 4: attempt bulk customer export → behavioral deviation
+```
+
+Runtime response:
+
+```text
+Runtime Trust: 94 → 68
+Autonomy: LEVEL_4 → LEVEL_3
+bulk export: DENIED
+```
+
+Next anomaly:
+
+```text
+attempt production credential access
+```
+
+Response:
+
+```text
+Runtime Trust: 68 → 39
+Autonomy: LEVEL_3 → LEVEL_1
+write tools suspended
+AI Manager notified
+task reassigned
+security incident created
+```
+
+The system responds before the entire run has to fail catastrophically.
+
+---
+
+# 36. Updated Design Principle
+
+The four extensions are not only a linear pre-execution pipeline. They form a **continuous governance loop**:
+
+```text
+Measure capability
+        ↓
+Establish trust
+        ↓
+Grant bounded autonomy
+        ↓
+Assign work
+        ↓
+Observe runtime behavior
+        ↓
+Re-evaluate trust
+        ↓
+Adjust autonomy
+        ↓
+Reassign / continue / escalate
+        ↺
+```
+
+The defining principle is:
+
+> **Autonomy is leased, scoped, observable, and revocable — never permanently granted.**
+
+This principle should guide the implementation of Agent Genome, Agent Trust Score, Autonomy Governor, and AI Manager across SynapseOS.
+
+---
+
+# 37. 2026-09 Architecture Update — Execution Graph & Cost Attribution
+
+Recent enterprise-agent deployments reinforce the need to make runtime causality and per-agent cost visible as first-class governance data.
+
+This update does **not** create a fifth strategic extension. It enriches the existing four.
+
+## 37.1 Execution Graph
+
+Every meaningful run should be reconstructable as a causal graph:
+
+```mermaid
+flowchart LR
+    T[Task] --> P[Prompt / Plan]
+    P --> A[Agent]
+    A --> S[Skill]
+    A --> TL[Tool]
+    TL --> C[Command / API]
+    C --> FX[Side Effect]
+    FX --> V[Verification]
+```
+
+The graph must make it possible to answer:
+
+- which task caused an action;
+- which agent acted;
+- under which Genome version;
+- with which Trust snapshot;
+- under which autonomy decision;
+- which skill/tool/command/API was used;
+- what side effect occurred;
+- what evidence verified the result.
+
+### ExecutionGraphNode
+
+```text
+id
+run_id
+node_type
+source_ref
+timestamp
+metadata_digest
+```
+
+### ExecutionGraphEdge
+
+```text
+id
+run_id
+from_node_id
+to_node_id
+relation
+created_at
+```
+
+Suggested relations:
+
+```text
+TRIGGERED
+PLANNED
+DELEGATED
+INVOKED
+PRODUCED
+VERIFIED
+BLOCKED
+ESCALATED
+```
+
+## 37.2 Cost Attribution
+
+Cost should be attributable to the work that caused it.
+
+```text
+Project
+└── Task
+    └── Agent Run
+        ├── provider calls
+        ├── reviewer calls
+        ├── tool execution
+        ├── retries
+        └── total cost
+```
+
+### AgentCostAttribution
+
+```text
+run_id
+project_id
+task_id
+agent_id
+genome_version_id
+provider_id
+input_tokens
+output_tokens
+provider_cost
+tool_cost
+retry_cost
+total_cost
+calculated_at
+```
+
+### Extension impact
+
+```text
+Agent Genome
+└── cost / efficiency profile
+
+Agent Trust Score
+└── execution-graph evidence
+
+Autonomy Governor
+└── action-level runtime enforcement
+
+AI Manager
+├── cost-aware assignment
+└── route selection under budget
+```
+
+### New implementation phases
+
+```text
+GEN-11 — Cost / efficiency profile
+GOV-16 — Execution graph enforcement hooks
+MGR-20 — Cost attribution
+MGR-21 — Cost-aware assignment policy
+```
+
+---
+
+# 38. Automatic Containment & Kill Switch
+
+Manual suspension is insufficient for autonomous systems. SynapseOS needs a bounded automatic containment path for critical runtime events.
+
+## 38.1 Distinction
+
+```text
+Manual Kill Switch
+→ explicit human/admin decision
+
+Automatic Containment
+→ backend policy triggered by critical runtime evidence
+```
+
+## 38.2 Containment flow
+
+```mermaid
+flowchart TD
+    TEL[Runtime Telemetry] --> DET[Critical Anomaly]
+    DET --> TRUST[Runtime Trust]
+    TRUST --> GOV[Autonomy Governor]
+    GOV --> Q[QUARANTINE]
+    Q --> REV[Revoke temporary capabilities]
+    Q --> CAN[Cancel pending cancellable actions]
+    Q --> FREEZE[Freeze affected workspace scope]
+    Q --> EVID[Preserve evidence / Execution Graph]
+    Q --> MGR[Notify AI Manager]
+    MGR --> REASSIGN[Reassign or escalate]
+```
+
+## 38.3 Required containment properties
+
+- fail closed for critical security events;
+- preserve audit and forensic evidence;
+- no destructive cleanup that destroys evidence;
+- revoke temporary credentials/capabilities;
+- prevent new tool calls;
+- terminate or isolate child processes according to policy;
+- notify Manager and Security;
+- make recovery an explicit action.
+
+### New phase
+
+```text
+GOV-14 — Automatic Containment & Kill Switch
+```
+
+---
+
+# 39. Outcome Integrity — Protection Against Metric Gaming
+
+Agent systems must distinguish between satisfying a measurable proxy and actually satisfying the task objective.
+
+## 39.1 Core principle
+
+```text
+Metric success != Task success
+```
+
+Examples:
+
+```text
+Tests pass: YES
+Reviewer approves: YES
+Acceptance criteria met: PARTIAL
+User objective met: NO
+Outcome integrity risk: HIGH
+```
+
+## 39.2 Architecture
+
+```mermaid
+flowchart TD
+    OBJ[Task Objective] --> AC[Acceptance Criteria]
+    AC --> RUN[Agent Execution]
+    RUN --> MET[Measured Result]
+    MET --> VER[Independent Verification]
+    VER --> OUT[Outcome Integrity]
+```
+
+## 39.3 Agent Genome additions
+
+```text
+objective_alignment_rate
+metric_gaming_incidents
+acceptance_criteria_escape_rate
+post_completion_reopen_rate
+```
+
+## 39.4 AI Manager additions
+
+Manager must not close a task only because local metrics are green.
+
+A completion gate can require:
+
+```text
+backend state valid
+acceptance criteria verified
+review complete
+QA complete where required
+security complete where required
+objective integrity acceptable
+```
+
+### New phases
+
+```text
+GEN-12 — Outcome Integrity Metrics
+MGR-22 — Outcome Integrity Completion Gate
+```
+
+---
+
+# 40. Agent Identity & Delegation Chain
+
+An `agent_id` alone is not sufficient authority provenance for a multi-agent system.
+
+SynapseOS should model who delegated authority to whom, for what scope, and for how long.
+
+## 40.1 Delegation chain
+
+```mermaid
+flowchart LR
+    H[Human / System Principal] -->|delegates| M[AI Manager]
+    M -->|delegates| A[Agent A]
+    A -->|delegates subset| B[Agent B]
+    B -->|invokes| T[Tool]
+```
+
+A child delegation must never silently exceed its parent authority.
+
+## 40.2 DelegationGrant
+
+```text
+id
+principal_id
+delegator_agent_id
+delegate_agent_id
+task_id
+project_id
+allowed_scope
+allowed_capabilities
+issued_at
+expires_at
+revoked_at
+parent_delegation_id
+```
+
+## 40.3 Invariant
+
+```text
+child_scope ⊆ parent_scope
+```
+
+and:
+
+```text
+child_capabilities ⊆ parent_capabilities
+```
+
+## 40.4 Runtime audit example
+
+```text
+Action: DELETE resource
+Agent: Security-Agent-7
+Acting for: AI Manager
+Original authority: human/project owner
+Task: SEC-184
+Delegated scope: repository:test-project
+Trust at execution: 91
+Autonomy: LEVEL_3
+Credential lifetime: 4 min
+```
+
+### Extension impact
+
+```text
+Agent Genome
+└── historical access / delegation profile
+
+Agent Trust Score
+└── identity and delegation integrity
+
+Autonomy Governor
+└── delegated-authority validation
+
+AI Manager
+└── explicit delegation chain
+```
+
+### New phases
+
+```text
+TRUST-13 — Delegation Integrity Signals
+GOV-17 — Delegated Authority Validation
+MGR-23 — Delegation Chain Management
+```
+
+---
+
+# 41. Multi-Agent Communication Graph & Collusion Risk
+
+A multi-agent organization needs governance over communication, not only tool execution.
+
+Individually acceptable agents can collectively produce unsafe behavior.
+
+## 41.1 Communication graph
+
+```mermaid
+flowchart LR
+    A[Agent A] -->|delegates| B[Agent B]
+    B -->|shares result| C[Agent C]
+    C -->|invokes| T[Tool]
+    B -->|external message| X[External Channel]
+    X --> D{Authorized?}
+    D -->|yes| OK[Continue]
+    D -->|no| GOV[Governor Decision]
+```
+
+## 41.2 CommunicationEvent
+
+```text
+id
+sender_agent_id
+recipient_agent_id
+task_id
+project_id
+purpose
+channel
+data_classification
+delegation_id
+authorized_scope
+message_digest
+created_at
+```
+
+A digest can preserve evidence without permanently retaining all message content.
+
+## 41.3 Collaboration baseline
+
+Agent Genome should learn normal collaboration patterns:
+
+```text
+normal_peers
+normal_channels
+normal_message_frequency
+normal_delegation_patterns
+normal_data_classes_shared
+```
+
+## 41.4 Trust signals
+
+```text
+UNAUTHORIZED_PEER_COMMUNICATION
+COORDINATED_POLICY_VIOLATION
+REPEATED_SHARED_WORKAROUND
+SUSPICIOUS_INFORMATION_PROPAGATION
+UNAUTHORIZED_EXTERNAL_CHANNEL
+```
+
+## 41.5 Communication policy invariant
+
+> An agent may not create or use a new coordination channel unless that channel is explicitly permitted for the task, data class, and delegation scope.
+
+### New phases
+
+```text
+GEN-10 — Collaboration Behavioral Baseline
+TRUST-12 — Collusion & Coordination Risk
+GOV-15 — Communication Policy Enforcement
+MGR-16 — Multi-Agent Coordination Graph
+```
+
+---
+
+# 42. Agent Incident Registry & Forensic Reconstruction
+
+An agent failure must be representable as an incident, not only a generic error log.
+
+## 42.1 Incident lifecycle
+
+```mermaid
+flowchart TD
+    DET[Anomaly Detected] --> CON[Containment]
+    CON --> INC[Incident Created]
+    INC --> FREEZE[Freeze Evidence]
+    FREEZE --> RCA[Root Cause Analysis]
+    RCA --> IMP[Impact Assessment]
+    IMP --> FIX[Corrective Actions]
+    FIX --> CLOSE[Close / Monitor]
+```
+
+## 42.2 AgentIncident
+
+```text
+incident_id
+severity
+status
+agent_id
+run_id
+task_id
+project_id
+trigger
+first_detected_at
+contained_at
+trust_before
+trust_after
+autonomy_before
+autonomy_after
+affected_resources
+execution_graph_ref
+delegation_chain_ref
+communication_graph_ref
+policy_violations
+security_findings
+root_cause
+business_impact
+corrective_actions
+closed_at
+```
+
+## 42.3 Forensic timeline
+
+Example:
+
+```text
+14:03 task assigned
+14:04 Genome v17 / Trust 93 / Autonomy L4
+14:06 Tool X called
+14:07 Agent B delegated
+14:08 Agent B attempts out-of-scope action
+14:08 Runtime Trust 93 -> 61
+14:09 Governor L4 -> L2
+14:09 second prohibited attempt
+14:09 automatic containment
+14:10 Manager reassigns task
+```
+
+## 42.4 Required questions
+
+A forensic report should answer:
+
+- What happened?
+- Why did it happen?
+- Which agents were involved?
+- Which authority was active?
+- Which data/resources were affected?
+- Which control failed or succeeded?
+- How did SynapseOS contain the event?
+- What corrective action prevents recurrence?
+
+### New phases
+
+```text
+MGR-17 — Agent Incident Registry
+MGR-18 — Forensic Reconstruction
+MGR-19 — Incident / Misalignment Reporting
+```
+
+---
+
+# 43. Agent Lifecycle, Credential Leases & Orphan Detection
+
+Agents, credentials, sessions, and capabilities must have explicit lifecycles.
+
+## 43.1 Credential lease model
+
+Prefer temporary leases over permanent credentials.
+
+```text
+agent_id + task_id + scope + capabilities + TTL
+```
+
+## 43.2 Lifecycle
+
+```mermaid
+stateDiagram-v2
+    [*] --> PROVISIONED
+    PROVISIONED --> ACTIVE
+    ACTIVE --> PAUSED
+    PAUSED --> ACTIVE
+    ACTIVE --> RETIRING
+    PAUSED --> RETIRING
+    RETIRING --> RETIRED
+    RETIRED --> [*]
+```
+
+Credentials should be revoked when an agent is paused, retired, quarantined, or no longer needs the scope.
+
+## 43.3 Orphan detection
+
+Detect:
+
+```text
+inactive agent + active credential
+retired agent + open session
+completed task + active delegation
+expired project + active tool capability
+abandoned run + child process or lease
+```
+
+## 43.4 CredentialLease
+
+```text
+id
+agent_id
+task_id
+scope
+capabilities
+issued_at
+expires_at
+last_used_at
+revoked_at
+revocation_reason
+```
+
+### Extension impact
+
+```text
+Agent Genome
+└── lifecycle / historical access profile
+
+Agent Trust Score
+└── stale credential incidents
+
+Autonomy Governor
+├── just-in-time authorization
+└── credential lease validation
+
+AI Manager
+├── provision
+├── pause
+├── retire
+└── orphan detection
+```
+
+### New phases
+
+```text
+GOV-18 — Credential Lease Validation
+MGR-24 — Agent Lifecycle Manager
+MGR-25 — Orphan Agent / Credential Detection
+```
+
+---
+
+# 44. Adaptive Context Optimization
+
+This capability remains a supporting runtime architecture, not one of the four governance extensions.
+
+The relevant opportunity is to make context optimization adaptive using run telemetry.
+
+## 44.1 Feedback loop
+
+```mermaid
+flowchart TD
+    RUN[Run Telemetry] --> USE[Context Usefulness Analysis]
+    USE --> OPT[Context Optimizer]
+    OPT --> HIST[Compress History]
+    OPT --> MEM[Select Memory]
+    OPT --> TOOL[Expose Relevant Tools]
+    OPT --> BUD[Apply Token Budget]
+    HIST --> NEXT[Next Turn]
+    MEM --> NEXT
+    TOOL --> NEXT
+    BUD --> NEXT
+```
+
+## 44.2 Genome signals
+
+```text
+context_efficiency_profile
+useful_context_ratio
+average_tokens_per_success
+irrelevant_retrieval_rate
+tool_selection_efficiency
+```
+
+## 44.3 Manager role
+
+AI Manager may choose a context strategy:
+
+```text
+FULL
+COMPRESSED
+RETRIEVAL_ONLY
+MEMORY_ASSISTED
+```
+
+### Supporting phases
+
+```text
+CTX-1 — Context Telemetry
+CTX-2 — Context Budgeting
+CTX-3 — Dynamic Tool Exposure
+CTX-4 — Adaptive Memory Selection
+CTX-5 — Learned Context Policy
+```
+
+---
+
+# 45. Agent Component Trust Registry
+
+Agents will eventually depend on externally supplied skills, MCP servers, playbooks, and other executable components.
+
+These components should be treated as a supply-chain risk.
+
+## 45.1 Component types
+
+```text
+AGENT_PACKAGE
+SKILL
+MCP_SERVER
+PLAYBOOK
+TOOL_PLUGIN
+MODEL_ADAPTER
+```
+
+## 45.2 Trust pipeline
+
+```mermaid
+flowchart TD
+    C[Agent / Skill / MCP / Playbook] --> P[Provenance Check]
+    P --> S[Static Inspection]
+    S --> PA[Permission Analysis]
+    PA --> TEST[Security Tests]
+    TEST --> MAN[Trust Manifest]
+    MAN --> DEC{Classification}
+    DEC -->|safe| APP[APPROVED]
+    DEC -->|limited| RES[RESTRICTED]
+    DEC -->|unsafe| Q[QUARANTINED]
+```
+
+## 45.3 ComponentTrustManifest
+
+```text
+component_id
+component_type
+name
+version
+source_repository
+publisher
+signature
+checksum
+requested_capabilities
+network_access
+filesystem_access
+data_access
+security_findings
+last_scan_at
+trust_level
+scan_policy_version
+```
+
+## 45.4 Governor integration
+
+Before execution:
+
+```text
+requested component
+→ registry lookup
+→ trust classification
+→ capability policy
+→ ALLOW / RESTRICT / DENY
+```
+
+An unapproved component must not silently become available because an agent discovered it dynamically.
+
+### Extension impact
+
+```text
+Agent Genome
+└── component usage history / success profile
+
+Agent Trust Score
+└── risky component usage signals
+
+Autonomy Governor
+└── component trust enforcement
+
+AI Manager
+└── choose only approved components in assignment plans
+```
+
+### New phases
+
+```text
+GEN-13 — Component Usage Profile
+TRUST-14 — Component Risk Signals
+GOV-19 — Component Trust Enforcement
+MGR-26 — Trusted Component Selection
+SEC-COMP-1 — Agent Component Trust Registry
+SEC-COMP-2 — Skill / MCP / Playbook Scanner
+```
+
+---
+
+# 46. Independent Sentinel Agents
+
+Multi-agent systems can benefit from independent observer agents whose job is to challenge suspicious results and coordination patterns.
+
+Sentinels produce **signals**, not authority.
+
+## 46.1 Sentinel role
+
+```mermaid
+flowchart TD
+    DEV[Developer Agents] --> EVID[Shared Evidence]
+    REV[Reviewer Agents] --> EVID
+    RES[Research Agents] --> EVID
+    EVID --> SENT[Sentinel Agent]
+    SENT --> SIG[Risk Signals]
+    SIG --> TRUST[Trust Score]
+    SIG --> GOV[Autonomy Governor]
+    SIG --> MGR[AI Manager]
+```
+
+## 46.2 Sentinel signals
+
+```text
+MISLEADING_RESULT
+SUSPICIOUS_COORDINATION
+EVALUATION_GAMING
+POLICY_EVASION
+MEMORY_POISONING
+COLLUSION_PATTERN
+UNEXPLAINED_RESULT_SHIFT
+```
+
+## 46.3 Independence requirements
+
+A Sentinel should:
+
+- have a distinct identity;
+- have read-only access by default;
+- not share the same mutable scratchpad as the agent it evaluates;
+- not be allowed to directly elevate/revoke permissions;
+- reference evidence;
+- be independently auditable;
+- be bounded by cost/time/tool limits.
+
+## 46.4 Decision relationship
+
+```text
+Sentinel signal
+     ↓
+Trust Engine
+     ↓
+Autonomy Governor
+     ↓
+AI Manager
+```
+
+No direct:
+
+```text
+Sentinel -> delete / suspend / grant permission
+```
+
+unless a future explicit security policy authorizes a deterministic containment action.
+
+### New phases
+
+```text
+TRUST-15 — Sentinel Evidence Ingestion
+MGR-27 — Sentinel Agent Coordination
+MGR-28 — Independent Peer-Audit Workflow
+```
+
+---
+
+# 47. Consolidated Updated Roadmap
+
+The strategic core remains exactly four extensions:
+
+```text
+Agent Genome
+     ↓
+Agent Trust Score
+     ↓
+Autonomy Governor
+     ↓
+AI Manager
+```
+
+The research-driven additions are integrated as capabilities under those four extensions.
+
+## Agent Genome
+
+```text
+GEN-1  Contracts and entities
+GEN-2  Evidence ingestion
+GEN-3  Capability scoring
+GEN-4  Performance profiles
+GEN-5  Capability matching
+GEN-6  Failure patterns
+GEN-7  Version snapshots
+GEN-8  Manager integration
+GEN-9  Behavioral baseline
+GEN-10 Collaboration baseline
+GEN-11 Cost / efficiency profile
+GEN-12 Outcome integrity metrics
+GEN-13 Component usage profile
+```
+
+## Agent Trust Score
+
+```text
+TRUST-1  Trust model
+TRUST-2  Evidence adapters
+TRUST-3  Dimension scores
+TRUST-4  Overall score/classes
+TRUST-5  Trust decay
+TRUST-6  Critical events
+TRUST-7  Explainability
+TRUST-8  Governor integration
+TRUST-9  Runtime Trust engine
+TRUST-10 Degradation and recovery
+TRUST-11 Runtime explanations
+TRUST-12 Collusion / coordination risk
+TRUST-13 Delegation integrity
+TRUST-14 Component risk signals
+TRUST-15 Sentinel evidence ingestion
+```
+
+## Autonomy Governor
+
+```text
+GOV-1  Levels and contracts
+GOV-2  Task/action risk
+GOV-3  Policy engine
+GOV-4  Trust integration
+GOV-5  Genome integration
+GOV-6  Approval gates
+GOV-7  Security veto / quarantine
+GOV-8  Dynamic recomputation
+GOV-9  Per-action evaluation
+GOV-10 Scope / intent guard
+GOV-11 Runtime Trust integration
+GOV-12 Economic governance
+GOV-13 Runtime downgrade / quarantine
+GOV-14 Automatic containment / kill switch
+GOV-15 Communication policy enforcement
+GOV-16 Execution Graph enforcement hooks
+GOV-17 Delegated authority validation
+GOV-18 Credential lease validation
+GOV-19 Component Trust enforcement
+```
+
+## AI Manager
+
+```text
+MGR-1  Manager contracts
+MGR-2  Workload model
+MGR-3  Candidate selection
+MGR-4  Genome-aware ranking
+MGR-5  Trust-aware ranking
+MGR-6  Governor integration
+MGR-7  Blocker detection
+MGR-8  Reassignment/escalation
+MGR-9  Human override
+MGR-10 Optional LLM planning
+MGR-11 Runtime Trust monitoring
+MGR-12 Trust-triggered reassignment
+MGR-13 Cost-aware routing
+MGR-14 Budget pressure handling
+MGR-15 Runtime coordination loop
+MGR-16 Multi-Agent Coordination Graph
+MGR-17 Agent Incident Registry
+MGR-18 Forensic Reconstruction
+MGR-19 Incident / Misalignment Reporting
+MGR-20 Cost attribution
+MGR-21 Cost-aware assignment policy
+MGR-22 Outcome Integrity Completion Gate
+MGR-23 Delegation Chain Management
+MGR-24 Agent Lifecycle Manager
+MGR-25 Orphan Agent / Credential Detection
+MGR-26 Trusted Component Selection
+MGR-27 Sentinel Agent Coordination
+MGR-28 Independent Peer-Audit Workflow
+```
+
+Supporting non-core capabilities:
+
+```text
+CTX-*       Adaptive Context Optimization
+SEC-COMP-* Agent Component Scanner / Trust Registry
+```
+
+---
+
+# 48. Updated Global Architecture
+
+```mermaid
+flowchart TB
+    USER[User / Project / Workflow] --> MGR[AI Manager]
+
+    MGR --> GEN[Agent Genome]
+    MGR --> TRUST[Agent Trust Score]
+
+    GEN --> GOV[Autonomy Governor]
+    TRUST --> GOV
+
+    PERM[Permission Engine] --> GOV
+    SEC[Security Veto] --> GOV
+    RISK[Task / Action Risk] --> GOV
+    BUD[Budget] --> GOV
+    DELEG[Delegation Chain] --> GOV
+    COMP[Component Trust Registry] --> GOV
+
+    GOV --> RUN[Agent Runtime]
+    RUN --> TOOL[ToolExecutor / Command Runner]
+    RUN --> COMMS[Agent Communication Graph]
+    RUN --> EXECG[Execution Graph]
+
+    TOOL --> TEL[Runtime Telemetry]
+    COMMS --> TEL
+    EXECG --> TEL
+
+    TEL --> TRUST
+    TEL --> GEN
+    TEL --> GOV
+    TEL --> MGR
+
+    SENT[Sentinel Agents] --> TRUST
+    SENT --> MGR
+
+    GOV -->|contain / downgrade| MGR
+    MGR -->|reassign / escalate| RUN
+    MGR --> INC[Incident Registry]
+    INC --> FORENSIC[Forensic Reconstruction]
+```
+
+---
+
+# 49. Updated Global Invariants
+
+1. **Capability is not authority.** A high Genome score never grants permission.
+2. **Trust is not permanent.** Trust can degrade and recover from runtime evidence.
+3. **Autonomy is leased.** It is scoped, observable, expirable, and revocable.
+4. **Delegation cannot amplify authority.** Child scope must remain within parent scope.
+5. **Communication is governed.** Inter-agent and external channels are explicit capabilities.
+6. **Components are untrusted by default until policy says otherwise.** Skills/MCP/playbooks require provenance and trust evaluation.
+7. **Sentinels produce evidence, not unilateral authority.**
+8. **Outcome integrity outranks proxy metrics.** Passing a benchmark does not necessarily complete the business objective.
+9. **Every material action is reconstructable.** The Execution Graph preserves causality.
+10. **Critical runtime evidence can trigger containment.** Security veto remains authoritative.
+11. **Credentials are leased, not assumed permanent.** Lifecycle completion should revoke stale access.
+12. **Cost is attributable.** Manager decisions can reason about quality, safety, latency, and budget together.


### PR DESCRIPTION
## Summary
- update Phase 40 to Nuxt 4 and make the frontend architecture roadmap mandatory
- add the approved frontend architecture specification
- register the deferred V2 governance architecture for Agent Genome, Agent Trust Score, Autonomy Governor, and AI Manager
- preserve the security and permission authority hierarchy and reserve the EXT phase families

## Validation
- git diff --check
- verified referenced documentation paths exist
- verified Markdown code fences are balanced
- verified README.md is unchanged

## Scope
Documentation only. No V1 or V2 implementation is included.