### PR TITLE
feat(registry): add deterministic agent matching

### DIFF
--- a/SYNAPSEOS_DEVELOPMENT_CHECKLIST.md
+++ b/SYNAPSEOS_DEVELOPMENT_CHECKLIST.md
@@ -1846,15 +1846,25 @@ Ajouter tests avec plusieurs exemples de cahiers des charges.
 
 Affecter les meilleurs agents aux tâches.
 
+## Implementation plan
+
+- [x] Define immutable registry and matching contracts with strict bounds
+- [x] Persist explicit agent capabilities independently of projects
+- [x] Read bounded candidate snapshots from PostgreSQL without assignment side effects
+- [x] Reject unavailable, incapable, under-permissioned, or under-autonomy candidates
+- [x] Rank eligible candidates deterministically by expertise, reputation, reliability, seniority, and task cost
+- [x] Return bounded scores and explanations without changing agents or permissions
+- [x] Verify unit, PostgreSQL, migration, Ruff, format, and mypy checks
+
 ## Critères
 
-- [ ] expertise
-- [ ] reputation
-- [ ] disponibilité
-- [ ] séniorité
-- [ ] permissions
-- [ ] risque
-- [ ] coût
+- [x] expertise
+- [x] reputation
+- [x] disponibilité
+- [x] séniorité
+- [x] permissions
+- [x] risque
+- [x] coût
 
 ## Prompt Claude Code — Phase 28
 

--- a/alembic/versions/20260910_0006_agent_capabilities.py
+++ b/alembic/versions/20260910_0006_agent_capabilities.py
@@ -1,0 +1,73 @@
+"""Add company-level agent capabilities for Phase 28.
+
+Revision ID: 20260910_0006
+Revises: 20260909_0005
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+from alembic import op
+
+revision: str = "20260910_0006"
+down_revision: str | Sequence[str] | None = "20260909_0005"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "agent_capabilities",
+        sa.Column("agent_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("capability", sa.String(length=128), nullable=False),
+        sa.Column("expertise_score", sa.Numeric(precision=5, scale=4), nullable=False),
+        sa.Column("active", sa.Boolean(), nullable=False),
+        sa.Column("id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.CheckConstraint(
+            "capability ~ '^[a-z0-9][a-z0-9._:-]{0,127}$'",
+            name=op.f("ck_agent_capabilities_capability_identifier"),
+        ),
+        sa.CheckConstraint(
+            "expertise_score BETWEEN 0 AND 1",
+            name=op.f("ck_agent_capabilities_expertise_score_range"),
+        ),
+        sa.ForeignKeyConstraint(
+            ["agent_id"],
+            ["agents.id"],
+            ondelete="RESTRICT",
+            name=op.f("fk_agent_capabilities_agent_id_agents"),
+        ),
+        sa.PrimaryKeyConstraint("id", name=op.f("pk_agent_capabilities")),
+    )
+    op.create_index(
+        "ix_agent_capabilities_active_lookup",
+        "agent_capabilities",
+        ["agent_id", "active", "capability"],
+        unique=False,
+    )
+    op.create_index(
+        "uq_agent_capabilities_agent_capability",
+        "agent_capabilities",
+        ["agent_id", "capability"],
+        unique=True,
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("agent_capabilities")

--- a/core/agent_registry/__init__.py
+++ b/core/agent_registry/__init__.py
@@ -1,0 +1,28 @@
+"""Phase 28 agent registry and deterministic matching."""
+
+from core.agent_registry.matcher import AgentMatcher
+from core.agent_registry.registry import AgentRegistry, AgentRegistrySource
+from core.agent_registry.types import (
+    AgentCandidate,
+    AgentCapabilitySnapshot,
+    AgentCostEstimate,
+    AgentMatchingRequest,
+    AgentMatchingResult,
+    AgentMatchScore,
+    RankedAgentMatch,
+    RejectedAgentMatch,
+)
+
+__all__ = [
+    "AgentCandidate",
+    "AgentCapabilitySnapshot",
+    "AgentCostEstimate",
+    "AgentMatcher",
+    "AgentRegistry",
+    "AgentRegistrySource",
+    "AgentMatchingRequest",
+    "AgentMatchingResult",
+    "AgentMatchScore",
+    "RankedAgentMatch",
+    "RejectedAgentMatch",
+]

--- a/core/agent_registry/matcher.py
+++ b/core/agent_registry/matcher.py
@@ -1,0 +1,196 @@
+"""Deterministic Phase 28 agent matching."""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import Sequence
+from decimal import ROUND_HALF_UP, Decimal
+
+from core.agent_registry.types import (
+    AgentCandidate,
+    AgentMatchingRequest,
+    AgentMatchingResult,
+    AgentMatchScore,
+    RankedAgentMatch,
+    RejectedAgentMatch,
+)
+from core.enums import AgentSeniority, AgentStatus, ToolRiskLevel
+
+_MAX_CANDIDATES = 100
+_QUANTUM = Decimal("0.0001")
+_EXPERTISE_WEIGHT = Decimal("0.35")
+_REPUTATION_WEIGHT = Decimal("0.20")
+_RELIABILITY_WEIGHT = Decimal("0.20")
+_SENIORITY_WEIGHT = Decimal("0.10")
+_COST_WEIGHT = Decimal("0.15")
+_SENIORITY_RANK = {
+    AgentSeniority.TRAINEE: 0,
+    AgentSeniority.JUNIOR: 1,
+    AgentSeniority.ENGINEER: 2,
+    AgentSeniority.SENIOR: 3,
+    AgentSeniority.STAFF: 4,
+    AgentSeniority.PRINCIPAL: 5,
+}
+_RISK_AUTONOMY = {
+    ToolRiskLevel.LOW: 0,
+    ToolRiskLevel.MEDIUM: 1,
+    ToolRiskLevel.HIGH: 2,
+    ToolRiskLevel.CRITICAL: 3,
+}
+
+
+class AgentMatcher:
+    """Rank trusted candidate snapshots without assigning or mutating agents."""
+
+    def match(
+        self,
+        request: AgentMatchingRequest,
+        candidates: Sequence[AgentCandidate],
+    ) -> AgentMatchingResult:
+        canonical_request = _canonical_request(request)
+        canonical_candidates = _canonical_candidates(candidates)
+        costs = {
+            estimate.agent_id: estimate.normalized_cost
+            for estimate in canonical_request.cost_estimates
+        }
+        matches: list[RankedAgentMatch] = []
+        rejections: list[RejectedAgentMatch] = []
+
+        for candidate in canonical_candidates:
+            reasons = _rejection_reasons(canonical_request, candidate, costs)
+            if reasons:
+                rejections.append(RejectedAgentMatch(agent_id=candidate.agent_id, reasons=reasons))
+                continue
+            matches.append(_ranked_match(canonical_request, candidate, costs[candidate.agent_id]))
+
+        matches.sort(key=lambda item: (-item.score, item.agent.agent_id.int))
+        rejections.sort(key=lambda item: item.agent_id.int)
+        return AgentMatchingResult(
+            workstream_id=canonical_request.workstream.id,
+            matches=tuple(matches[: canonical_request.limit]),
+            rejections=tuple(rejections),
+        )
+
+
+def _canonical_request(request: AgentMatchingRequest) -> AgentMatchingRequest:
+    if type(request) is not AgentMatchingRequest:
+        raise ValueError("invalid agent matching request")
+    return AgentMatchingRequest.model_validate(
+        request.model_dump(mode="python", warnings=False),
+        strict=True,
+    )
+
+
+def _canonical_candidates(candidates: Sequence[AgentCandidate]) -> tuple[AgentCandidate, ...]:
+    if not isinstance(candidates, (list, tuple)) or len(candidates) > _MAX_CANDIDATES:
+        raise ValueError("agent candidates must be a bounded sequence")
+    retained = tuple(
+        AgentCandidate.model_validate(
+            candidate.model_dump(mode="python", warnings=False),
+            strict=True,
+        )
+        if type(candidate) is AgentCandidate
+        else _reject_candidate()
+        for candidate in candidates
+    )
+    identifiers = tuple(candidate.agent_id for candidate in retained)
+    if len(identifiers) != len(set(identifiers)):
+        raise ValueError("agent candidates must be unique")
+    return retained
+
+
+def _reject_candidate() -> AgentCandidate:
+    raise ValueError("invalid agent candidate")
+
+
+def _rejection_reasons(
+    request: AgentMatchingRequest,
+    candidate: AgentCandidate,
+    costs: dict[uuid.UUID, Decimal],
+) -> tuple[str, ...]:
+    reasons: list[str] = []
+    if candidate.status is not AgentStatus.AVAILABLE:
+        reasons.append("Agent is not available.")
+
+    available_capabilities = {capability.name.casefold() for capability in candidate.capabilities}
+    missing_capabilities = sorted(
+        required
+        for required in request.workstream.required_capabilities
+        if required.casefold() not in available_capabilities
+    )
+    if missing_capabilities:
+        reasons.append(f"Missing required capabilities: {', '.join(missing_capabilities)}.")
+
+    missing_permissions = sorted(
+        (
+            permission
+            for permission in request.required_permissions
+            if permission not in candidate.active_permissions
+        ),
+        key=lambda permission: permission.value,
+    )
+    if missing_permissions:
+        reasons.append(
+            "Missing required permissions: "
+            + ", ".join(permission.value for permission in missing_permissions)
+            + "."
+        )
+
+    if candidate.autonomy_level < _RISK_AUTONOMY[request.risk_level]:
+        reasons.append(f"Autonomy level is below the {request.risk_level.value} risk requirement.")
+    if _SENIORITY_RANK[candidate.seniority] < _SENIORITY_RANK[request.minimum_seniority]:
+        reasons.append(f"Seniority is below the {request.minimum_seniority.value} requirement.")
+    if candidate.agent_id not in costs:
+        reasons.append("No task cost estimate was supplied.")
+    return tuple(reasons)
+
+
+def _ranked_match(
+    request: AgentMatchingRequest,
+    candidate: AgentCandidate,
+    normalized_cost: Decimal,
+) -> RankedAgentMatch:
+    capabilities = {capability.name.casefold(): capability for capability in candidate.capabilities}
+    expertise = _quantize(
+        sum(
+            (
+                capabilities[name.casefold()].expertise
+                for name in request.workstream.required_capabilities
+            ),
+            start=Decimal("0"),
+        )
+        / len(request.workstream.required_capabilities)
+    )
+    breakdown = AgentMatchScore(
+        expertise=expertise,
+        reputation=candidate.reputation,
+        reliability=candidate.reliability,
+        seniority_fit=_seniority_fit(candidate.seniority),
+        cost_efficiency=_quantize(Decimal("1") - normalized_cost),
+    )
+    score = _quantize(
+        breakdown.expertise * _EXPERTISE_WEIGHT
+        + breakdown.reputation * _REPUTATION_WEIGHT
+        + breakdown.reliability * _RELIABILITY_WEIGHT
+        + breakdown.seniority_fit * _SENIORITY_WEIGHT
+        + breakdown.cost_efficiency * _COST_WEIGHT
+    )
+    return RankedAgentMatch(
+        agent=candidate,
+        score=score,
+        breakdown=breakdown,
+        explanation=(
+            "All required capabilities are active.",
+            "All required permissions are active for the project scope.",
+            f"Autonomy level satisfies {request.risk_level.value} risk.",
+        ),
+    )
+
+
+def _quantize(value: Decimal) -> Decimal:
+    return value.quantize(_QUANTUM, rounding=ROUND_HALF_UP)
+
+
+def _seniority_fit(seniority: AgentSeniority) -> Decimal:
+    maximum_rank = max(_SENIORITY_RANK.values())
+    return _quantize(Decimal(_SENIORITY_RANK[seniority]) / Decimal(maximum_rank))

--- a/core/agent_registry/registry.py
+++ b/core/agent_registry/registry.py
@@ -1,0 +1,59 @@
+"""Read-only Phase 28 company agent registry boundary."""
+
+from __future__ import annotations
+
+import uuid
+from typing import Protocol
+
+from core.agent_registry.types import AgentCandidate
+
+_MAX_CANDIDATES = 100
+
+
+class AgentRegistrySource(Protocol):
+    """Trusted source of bounded company-agent snapshots."""
+
+    def list_candidates(
+        self,
+        *,
+        project_id: uuid.UUID,
+        limit: int,
+    ) -> tuple[AgentCandidate, ...]: ...
+
+
+class AgentRegistry:
+    """Validate snapshots from a read-only registry source."""
+
+    def __init__(self, source: AgentRegistrySource) -> None:
+        self._source = source
+
+    def list_candidates(
+        self,
+        *,
+        project_id: uuid.UUID,
+        limit: int = 100,
+    ) -> tuple[AgentCandidate, ...]:
+        if type(project_id) is not uuid.UUID:
+            raise ValueError("project_id must be a UUID")
+        if type(limit) is not int or not 1 <= limit <= _MAX_CANDIDATES:
+            raise ValueError("registry limit must be between 1 and 100")
+        raw_candidates = self._source.list_candidates(project_id=project_id, limit=limit)
+        if type(raw_candidates) is not tuple or len(raw_candidates) > limit:
+            raise ValueError("registry source returned an invalid candidate collection")
+        candidates = tuple(
+            AgentCandidate.model_validate(
+                candidate.model_dump(mode="python", warnings=False),
+                strict=True,
+            )
+            if type(candidate) is AgentCandidate
+            else _reject_candidate()
+            for candidate in raw_candidates
+        )
+        identifiers = tuple(candidate.agent_id for candidate in candidates)
+        if len(identifiers) != len(set(identifiers)):
+            raise ValueError("registry source returned duplicate agents")
+        return tuple(sorted(candidates, key=lambda candidate: candidate.agent_id.int))
+
+
+def _reject_candidate() -> AgentCandidate:
+    raise ValueError("registry source returned an invalid candidate")

--- a/core/agent_registry/types.py
+++ b/core/agent_registry/types.py
@@ -1,0 +1,125 @@
+"""Immutable Phase 28 registry and matching contracts."""
+
+from __future__ import annotations
+
+import uuid
+from decimal import Decimal
+from typing import Annotated, Self
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+
+from core.domain_decomposition import DomainWorkstream
+from core.enums import AgentSeniority, AgentStatus, Permission, ToolRiskLevel
+
+Identifier = Annotated[str, Field(pattern=r"^[a-z0-9][a-z0-9._:-]{0,127}$")]
+Score = Annotated[Decimal, Field(ge=Decimal("0"), le=Decimal("1"), max_digits=5, decimal_places=4)]
+
+
+class _ImmutableModel(BaseModel):
+    model_config = ConfigDict(frozen=True, extra="forbid", strict=True)
+
+
+class AgentCapabilitySnapshot(_ImmutableModel):
+    """One active capability and its measured expertise."""
+
+    name: Identifier
+    expertise: Score
+
+
+class AgentCandidate(_ImmutableModel):
+    """Bounded trusted agent snapshot consumed by the matcher."""
+
+    agent_id: uuid.UUID
+    slug: Identifier
+    seniority: AgentSeniority
+    status: AgentStatus
+    autonomy_level: Annotated[int, Field(ge=0, le=5)]
+    reputation: Score
+    reliability: Score
+    capabilities: Annotated[tuple[AgentCapabilitySnapshot, ...], Field(max_length=64)]
+    active_permissions: Annotated[tuple[Permission, ...], Field(max_length=64)]
+
+    @field_validator("capabilities", "active_permissions", mode="before")
+    @classmethod
+    def copy_sequences(cls, value: object) -> object:
+        if isinstance(value, (list, tuple)):
+            return tuple(value)
+        return value
+
+    @model_validator(mode="after")
+    def require_unique_members(self) -> Self:
+        capability_names = tuple(capability.name.casefold() for capability in self.capabilities)
+        if len(capability_names) != len(set(capability_names)):
+            raise ValueError("candidate capabilities must be unique")
+        if len(self.active_permissions) != len(set(self.active_permissions)):
+            raise ValueError("candidate permissions must be unique")
+        return self
+
+
+class AgentCostEstimate(_ImmutableModel):
+    """Task-local normalized cost; zero is cheapest and one is most expensive."""
+
+    agent_id: uuid.UUID
+    normalized_cost: Score
+
+
+class AgentMatchingRequest(_ImmutableModel):
+    """Explicit constraints for one workstream matching decision."""
+
+    project_id: uuid.UUID
+    workstream: DomainWorkstream
+    required_permissions: Annotated[tuple[Permission, ...], Field(max_length=32)]
+    minimum_seniority: AgentSeniority
+    risk_level: ToolRiskLevel
+    cost_estimates: Annotated[tuple[AgentCostEstimate, ...], Field(max_length=100)]
+    limit: Annotated[int, Field(ge=1, le=100)] = 10
+
+    @field_validator("required_permissions", "cost_estimates", mode="before")
+    @classmethod
+    def copy_sequences(cls, value: object) -> object:
+        if isinstance(value, (list, tuple)):
+            return tuple(value)
+        return value
+
+    @model_validator(mode="after")
+    def require_unique_members(self) -> Self:
+        if len(self.required_permissions) != len(set(self.required_permissions)):
+            raise ValueError("required permissions must be unique")
+        cost_ids = tuple(estimate.agent_id for estimate in self.cost_estimates)
+        if len(cost_ids) != len(set(cost_ids)):
+            raise ValueError("cost estimates must identify unique agents")
+        return self
+
+
+class AgentMatchScore(_ImmutableModel):
+    """Deterministic score inputs retained for explainability."""
+
+    expertise: Score
+    reputation: Score
+    reliability: Score
+    seniority_fit: Score
+    cost_efficiency: Score
+
+
+class RankedAgentMatch(_ImmutableModel):
+    """Eligible candidate, score, and deterministic explanation."""
+
+    agent: AgentCandidate
+    score: Score
+    breakdown: AgentMatchScore
+    explanation: Annotated[tuple[str, ...], Field(min_length=1, max_length=8)]
+
+
+class RejectedAgentMatch(_ImmutableModel):
+    """Ineligible candidate with bounded fail-closed reasons."""
+
+    agent_id: uuid.UUID
+    reasons: Annotated[tuple[str, ...], Field(min_length=1, max_length=8)]
+
+
+class AgentMatchingResult(_ImmutableModel):
+    """Bounded Phase 28 matching result without assignment side effects."""
+
+    workstream_id: Identifier
+    matches: Annotated[tuple[RankedAgentMatch, ...], Field(max_length=100)]
+    rejections: Annotated[tuple[RejectedAgentMatch, ...], Field(max_length=100)]

--- a/infrastructure/agent_registry/__init__.py
+++ b/infrastructure/agent_registry/__init__.py
@@ -1,0 +1,5 @@
+"""Phase 28 PostgreSQL agent registry adapter."""
+
+from infrastructure.agent_registry.sqlalchemy import SQLAlchemyAgentRegistrySource
+
+__all__ = ["SQLAlchemyAgentRegistrySource"]

--- a/infrastructure/agent_registry/sqlalchemy.py
+++ b/infrastructure/agent_registry/sqlalchemy.py
@@ -1,0 +1,162 @@
+"""Bounded read-only SQLAlchemy agent registry source."""
+
+from __future__ import annotations
+
+import uuid
+from collections import defaultdict
+from collections.abc import Callable
+from datetime import UTC, datetime
+
+from sqlalchemy import Select, or_, select
+from sqlalchemy.exc import SQLAlchemyError
+from sqlalchemy.orm import Session
+
+from core.agent_registry import AgentCandidate, AgentCapabilitySnapshot
+from core.enums import Permission
+from infrastructure.database.models import Agent, AgentCapability, AgentPermission
+
+_MAX_CANDIDATES = 100
+_MAX_CAPABILITIES_PER_AGENT = 64
+_MAX_PERMISSIONS_PER_AGENT = 64
+
+
+class AgentRegistryUnavailableError(RuntimeError):
+    """Sanitized registry persistence failure."""
+
+    def __init__(self) -> None:
+        super().__init__("Agent registry is unavailable.")
+
+
+class SQLAlchemyAgentRegistrySource:
+    """Project active capabilities and grants without mutating the session."""
+
+    def __init__(
+        self,
+        session: Session,
+        *,
+        clock: Callable[[], datetime] = lambda: datetime.now(UTC),
+    ) -> None:
+        self._session = session
+        self._clock = clock
+
+    def list_candidates(
+        self,
+        *,
+        project_id: uuid.UUID,
+        limit: int,
+    ) -> tuple[AgentCandidate, ...]:
+        if type(project_id) is not uuid.UUID:
+            raise ValueError("project_id must be a UUID")
+        if type(limit) is not int or not 1 <= limit <= _MAX_CANDIDATES:
+            raise ValueError("registry limit must be between 1 and 100")
+        now = self._clock()
+        if now.tzinfo is None or now.utcoffset() is None:
+            raise ValueError("registry clock must return an aware datetime")
+        try:
+            with self._session.no_autoflush:
+                agents = tuple(self._session.scalars(_agent_query(limit)))
+                if not agents:
+                    return ()
+                agent_ids = tuple(agent.id for agent in agents)
+                capabilities = tuple(
+                    self._session.scalars(_capability_query(agent_ids, len(agent_ids)))
+                )
+                permissions = tuple(
+                    self._session.scalars(
+                        _permission_query(agent_ids, project_id, now, len(agent_ids))
+                    )
+                )
+        except SQLAlchemyError:
+            raise AgentRegistryUnavailableError() from None
+        _require_bounded_relations(capabilities, permissions, len(agents))
+        return _build_candidates(agents, capabilities, permissions)
+
+
+def _agent_query(limit: int) -> Select[tuple[Agent]]:
+    return select(Agent).order_by(Agent.id).limit(limit)
+
+
+def _capability_query(
+    agent_ids: tuple[uuid.UUID, ...],
+    agent_count: int,
+) -> Select[tuple[AgentCapability]]:
+    return (
+        select(AgentCapability)
+        .where(AgentCapability.agent_id.in_(agent_ids), AgentCapability.active.is_(True))
+        .order_by(AgentCapability.agent_id, AgentCapability.capability)
+        .limit(agent_count * _MAX_CAPABILITIES_PER_AGENT + 1)
+    )
+
+
+def _permission_query(
+    agent_ids: tuple[uuid.UUID, ...],
+    project_id: uuid.UUID,
+    now: datetime,
+    agent_count: int,
+) -> Select[tuple[AgentPermission]]:
+    return (
+        select(AgentPermission)
+        .where(
+            AgentPermission.agent_id.in_(agent_ids),
+            or_(AgentPermission.project_id.is_(None), AgentPermission.project_id == project_id),
+            AgentPermission.revoked_at.is_(None),
+            or_(AgentPermission.expires_at.is_(None), AgentPermission.expires_at > now),
+        )
+        .order_by(AgentPermission.agent_id, AgentPermission.permission)
+        .limit(agent_count * _MAX_PERMISSIONS_PER_AGENT + 1)
+    )
+
+
+def _require_bounded_relations(
+    capabilities: tuple[AgentCapability, ...],
+    permissions: tuple[AgentPermission, ...],
+    agent_count: int,
+) -> None:
+    if len(capabilities) > agent_count * _MAX_CAPABILITIES_PER_AGENT:
+        raise AgentRegistryUnavailableError()
+    if len(permissions) > agent_count * _MAX_PERMISSIONS_PER_AGENT:
+        raise AgentRegistryUnavailableError()
+    capability_counts: dict[uuid.UUID, int] = defaultdict(int)
+    permission_counts: dict[uuid.UUID, int] = defaultdict(int)
+    for capability in capabilities:
+        capability_counts[capability.agent_id] += 1
+    for permission in permissions:
+        permission_counts[permission.agent_id] += 1
+    if any(count > _MAX_CAPABILITIES_PER_AGENT for count in capability_counts.values()):
+        raise AgentRegistryUnavailableError()
+    if any(count > _MAX_PERMISSIONS_PER_AGENT for count in permission_counts.values()):
+        raise AgentRegistryUnavailableError()
+
+
+def _build_candidates(
+    agents: tuple[Agent, ...],
+    capabilities: tuple[AgentCapability, ...],
+    permissions: tuple[AgentPermission, ...],
+) -> tuple[AgentCandidate, ...]:
+    capabilities_by_agent: dict[uuid.UUID, list[AgentCapabilitySnapshot]] = defaultdict(list)
+    permissions_by_agent: dict[uuid.UUID, set[Permission]] = defaultdict(set)
+    for capability in capabilities:
+        capabilities_by_agent[capability.agent_id].append(
+            AgentCapabilitySnapshot(
+                name=capability.capability,
+                expertise=capability.expertise_score,
+            )
+        )
+    for permission in permissions:
+        permissions_by_agent[permission.agent_id].add(permission.permission)
+    return tuple(
+        AgentCandidate(
+            agent_id=agent.id,
+            slug=agent.slug,
+            seniority=agent.seniority,
+            status=agent.status,
+            autonomy_level=agent.autonomy_level,
+            reputation=agent.reputation_score,
+            reliability=agent.reliability_score,
+            capabilities=tuple(capabilities_by_agent[agent.id]),
+            active_permissions=tuple(
+                sorted(permissions_by_agent[agent.id], key=lambda permission: permission.value)
+            ),
+        )
+        for agent in agents
+    )

--- a/infrastructure/database/models/__init__.py
+++ b/infrastructure/database/models/__init__.py
@@ -3,12 +3,18 @@
 from infrastructure.database.models.execution import AgentRun, Decision, ToolCall
 from infrastructure.database.models.history import AgentScore, AuditEvent
 from infrastructure.database.models.memory import MemoryEntry
-from infrastructure.database.models.organization import Agent, AgentPermission, Project
+from infrastructure.database.models.organization import (
+    Agent,
+    AgentCapability,
+    AgentPermission,
+    Project,
+)
 from infrastructure.database.models.pull_requests import Approval, PullRequest, PullRequestReview
 from infrastructure.database.models.work import Task, TaskDependency
 
 __all__ = [
     "Agent",
+    "AgentCapability",
     "AgentPermission",
     "AgentRun",
     "AgentScore",

--- a/infrastructure/database/models/organization.py
+++ b/infrastructure/database/models/organization.py
@@ -7,7 +7,17 @@ from datetime import datetime
 from decimal import Decimal
 from typing import TYPE_CHECKING
 
-from sqlalchemy import CheckConstraint, DateTime, Enum, ForeignKey, Index, Numeric, String, Text
+from sqlalchemy import (
+    Boolean,
+    CheckConstraint,
+    DateTime,
+    Enum,
+    ForeignKey,
+    Index,
+    Numeric,
+    String,
+    Text,
+)
 from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
@@ -62,6 +72,7 @@ class Agent(UUIDPrimaryKeyMixin, TimestampMixin, Base):
     runs: Mapped[list[AgentRun]] = relationship(back_populates="agent")
     decisions: Mapped[list[Decision]] = relationship(back_populates="agent")
     scores: Mapped[list[AgentScore]] = relationship(back_populates="agent")
+    capabilities: Mapped[list[AgentCapability]] = relationship(back_populates="agent")
     permissions: Mapped[list[AgentPermission]] = relationship(back_populates="agent")
     authored_pull_requests: Mapped[list[PullRequest]] = relationship(
         back_populates="author", foreign_keys="PullRequest.author_agent_id"
@@ -72,6 +83,32 @@ class Agent(UUIDPrimaryKeyMixin, TimestampMixin, Base):
     pull_request_approvals: Mapped[list[Approval]] = relationship(
         back_populates="approver", foreign_keys="Approval.approver_agent_id"
     )
+
+
+class AgentCapability(UUIDPrimaryKeyMixin, TimestampMixin, Base):
+    """A current company-level capability declaration for one reusable agent."""
+
+    __tablename__ = "agent_capabilities"
+    __table_args__ = (
+        CheckConstraint("expertise_score BETWEEN 0 AND 1", name="expertise_score_range"),
+        CheckConstraint(
+            "capability ~ '^[a-z0-9][a-z0-9._:-]{0,127}$'",
+            name="capability_identifier",
+        ),
+        Index("uq_agent_capabilities_agent_capability", "agent_id", "capability", unique=True),
+        Index("ix_agent_capabilities_active_lookup", "agent_id", "active", "capability"),
+    )
+
+    agent_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("agents.id", ondelete="RESTRICT"),
+        nullable=False,
+    )
+    capability: Mapped[str] = mapped_column(String(128), nullable=False)
+    expertise_score: Mapped[Decimal] = mapped_column(Numeric(5, 4), nullable=False)
+    active: Mapped[bool] = mapped_column(Boolean, default=True, nullable=False)
+
+    agent: Mapped[Agent] = relationship(back_populates="capabilities")
 
 
 class Project(UUIDPrimaryKeyMixin, TimestampMixin, Base):

--- a/tests/agent_registry/__init__.py
+++ b/tests/agent_registry/__init__.py
@@ -1,0 +1,1 @@
+"""Phase 28 agent registry and matching tests."""

--- a/tests/agent_registry/test_matcher.py
+++ b/tests/agent_registry/test_matcher.py
@@ -1,0 +1,223 @@
+"""Deterministic Phase 28 agent matching tests."""
+
+from __future__ import annotations
+
+import uuid
+from decimal import Decimal
+
+import pytest
+from pydantic import ValidationError
+
+from core.agent_registry import (
+    AgentCandidate,
+    AgentCapabilitySnapshot,
+    AgentCostEstimate,
+    AgentMatcher,
+    AgentMatchingRequest,
+)
+from core.domain_decomposition import DomainWorkstream, WorkstreamScope
+from core.enums import AgentSeniority, AgentStatus, Permission, ToolRiskLevel
+
+
+def _workstream() -> DomainWorkstream:
+    return DomainWorkstream(
+        id="payments",
+        name="Payments",
+        scope_kind=WorkstreamScope.DOMAIN,
+        purpose="Own payment processing and reconciliation.",
+        source_domains=("Payments",),
+        responsibilities=("Process payments", "Reconcile transactions"),
+        required_capabilities=("backend-engineering", "payment-security"),
+        dependencies=(),
+    )
+
+
+def _candidate(
+    *,
+    agent_id: uuid.UUID,
+    slug: str,
+    expertise: Decimal,
+    status: AgentStatus = AgentStatus.AVAILABLE,
+    autonomy_level: int = 2,
+    permissions: tuple[Permission, ...] = (Permission.FILESYSTEM_READ,),
+    capabilities: tuple[str, ...] = ("backend-engineering", "payment-security"),
+    reputation: Decimal = Decimal("0.8000"),
+    reliability: Decimal = Decimal("0.8000"),
+    seniority: AgentSeniority = AgentSeniority.SENIOR,
+) -> AgentCandidate:
+    return AgentCandidate(
+        agent_id=agent_id,
+        slug=slug,
+        seniority=seniority,
+        status=status,
+        autonomy_level=autonomy_level,
+        reputation=reputation,
+        reliability=reliability,
+        capabilities=tuple(
+            AgentCapabilitySnapshot(name=name, expertise=expertise) for name in capabilities
+        ),
+        active_permissions=permissions,
+    )
+
+
+def _request(*costs: AgentCostEstimate, limit: int = 10) -> AgentMatchingRequest:
+    return AgentMatchingRequest(
+        project_id=uuid.uuid4(),
+        workstream=_workstream(),
+        required_permissions=(Permission.FILESYSTEM_READ,),
+        minimum_seniority=AgentSeniority.ENGINEER,
+        risk_level=ToolRiskLevel.HIGH,
+        cost_estimates=costs,
+        limit=limit,
+    )
+
+
+def test_matcher_ranks_eligible_agents_deterministically_with_explanations() -> None:
+    strong_id = uuid.UUID("00000000-0000-0000-0000-000000000001")
+    frugal_id = uuid.UUID("00000000-0000-0000-0000-000000000002")
+    strong = _candidate(
+        agent_id=strong_id,
+        slug="strong-agent",
+        expertise=Decimal("0.9500"),
+        reputation=Decimal("0.9000"),
+        reliability=Decimal("0.9000"),
+    )
+    frugal = _candidate(
+        agent_id=frugal_id,
+        slug="frugal-agent",
+        expertise=Decimal("0.7000"),
+    )
+    request = _request(
+        AgentCostEstimate(agent_id=strong_id, normalized_cost=Decimal("0.7000")),
+        AgentCostEstimate(agent_id=frugal_id, normalized_cost=Decimal("0.1000")),
+    )
+
+    first = AgentMatcher().match(request, (frugal, strong))
+    second = AgentMatcher().match(request, (strong, frugal))
+
+    assert [match.agent.agent_id for match in first.matches] == [strong_id, frugal_id]
+    assert first == second
+    assert first.matches[0].score == Decimal("0.7975")
+    assert first.matches[0].breakdown.expertise == Decimal("0.9500")
+    assert first.matches[0].breakdown.cost_efficiency == Decimal("0.3000")
+    assert first.matches[0].explanation == (
+        "All required capabilities are active.",
+        "All required permissions are active for the project scope.",
+        "Autonomy level satisfies HIGH risk.",
+    )
+    assert first.rejections == ()
+
+
+@pytest.mark.parametrize(
+    ("candidate", "cost", "reason"),
+    [
+        (
+            _candidate(
+                agent_id=uuid.UUID("00000000-0000-0000-0000-000000000011"),
+                slug="busy",
+                expertise=Decimal("0.9000"),
+                status=AgentStatus.WORKING,
+            ),
+            Decimal("0.2000"),
+            "Agent is not available.",
+        ),
+        (
+            _candidate(
+                agent_id=uuid.UUID("00000000-0000-0000-0000-000000000012"),
+                slug="incapable",
+                expertise=Decimal("0.9000"),
+                capabilities=("backend-engineering",),
+            ),
+            Decimal("0.2000"),
+            "Missing required capabilities: payment-security.",
+        ),
+        (
+            _candidate(
+                agent_id=uuid.UUID("00000000-0000-0000-0000-000000000013"),
+                slug="untrusted",
+                expertise=Decimal("0.9000"),
+                permissions=(),
+            ),
+            Decimal("0.2000"),
+            "Missing required permissions: filesystem.read.",
+        ),
+        (
+            _candidate(
+                agent_id=uuid.UUID("00000000-0000-0000-0000-000000000014"),
+                slug="under-authorized",
+                expertise=Decimal("0.9000"),
+                autonomy_level=1,
+            ),
+            Decimal("0.2000"),
+            "Autonomy level is below the HIGH risk requirement.",
+        ),
+    ],
+)
+def test_matcher_rejects_ineligible_candidates(
+    candidate: AgentCandidate,
+    cost: Decimal,
+    reason: str,
+) -> None:
+    request = _request(AgentCostEstimate(agent_id=candidate.agent_id, normalized_cost=cost))
+
+    result = AgentMatcher().match(request, (candidate,))
+
+    assert result.matches == ()
+    assert result.rejections[0].agent_id == candidate.agent_id
+    assert reason in result.rejections[0].reasons
+
+
+def test_matcher_requires_explicit_cost_and_returns_only_the_requested_limit() -> None:
+    first_id = uuid.UUID("00000000-0000-0000-0000-000000000021")
+    second_id = uuid.UUID("00000000-0000-0000-0000-000000000022")
+    first = _candidate(agent_id=first_id, slug="first", expertise=Decimal("0.8000"))
+    second = _candidate(agent_id=second_id, slug="second", expertise=Decimal("0.7000"))
+    request = _request(
+        AgentCostEstimate(agent_id=first_id, normalized_cost=Decimal("0.2000")),
+        limit=1,
+    )
+
+    result = AgentMatcher().match(request, (second, first))
+
+    assert len(result.matches) == 1
+    assert result.matches[0].agent.agent_id == first_id
+    assert result.rejections[0].reasons == ("No task cost estimate was supplied.",)
+
+
+def test_seniority_changes_ranking_between_otherwise_equal_eligible_agents() -> None:
+    engineer_id = uuid.UUID("00000000-0000-0000-0000-000000000031")
+    principal_id = uuid.UUID("00000000-0000-0000-0000-000000000032")
+    engineer = _candidate(
+        agent_id=engineer_id,
+        slug="engineer-agent",
+        expertise=Decimal("0.8000"),
+        seniority=AgentSeniority.ENGINEER,
+    )
+    principal = _candidate(
+        agent_id=principal_id,
+        slug="principal-agent",
+        expertise=Decimal("0.8000"),
+        seniority=AgentSeniority.PRINCIPAL,
+    )
+    request = _request(
+        AgentCostEstimate(agent_id=engineer_id, normalized_cost=Decimal("0.2000")),
+        AgentCostEstimate(agent_id=principal_id, normalized_cost=Decimal("0.2000")),
+    )
+
+    result = AgentMatcher().match(request, (engineer, principal))
+
+    assert [match.agent.agent_id for match in result.matches] == [principal_id, engineer_id]
+    assert result.matches[0].breakdown.seniority_fit == Decimal("1.0000")
+    assert result.matches[1].breakdown.seniority_fit == Decimal("0.4000")
+
+
+def test_matching_contracts_are_bounded_and_immutable() -> None:
+    agent_id = uuid.uuid4()
+    candidate = _candidate(agent_id=agent_id, slug="bounded", expertise=Decimal("0.8000"))
+    with pytest.raises(ValidationError):
+        candidate.slug = "changed"  # type: ignore[misc]
+    with pytest.raises(ValidationError):
+        _request(
+            AgentCostEstimate(agent_id=agent_id, normalized_cost=Decimal("0.1000")),
+            limit=101,
+        )

--- a/tests/database/test_agent_registry.py
+++ b/tests/database/test_agent_registry.py
@@ -1,0 +1,299 @@
+"""Real-PostgreSQL Phase 28 agent registry tests."""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime, timedelta
+from decimal import Decimal
+from unittest.mock import patch
+
+import pytest
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm import Session
+
+from core.agent_registry import AgentCostEstimate, AgentMatcher, AgentMatchingRequest, AgentRegistry
+from core.domain_decomposition import DomainWorkstream, WorkstreamScope
+from core.enums import (
+    AgentSeniority,
+    AgentStatus,
+    AuditActorType,
+    Permission,
+    ToolRiskLevel,
+)
+from infrastructure.agent_registry import SQLAlchemyAgentRegistrySource
+from infrastructure.database.models import Agent, AgentCapability, AgentPermission, Project
+
+
+def _agent(*, slug: str, status: AgentStatus = AgentStatus.AVAILABLE) -> Agent:
+    return Agent(
+        name=slug.replace("-", " ").title(),
+        slug=slug,
+        role="Backend Engineer",
+        department="engineering",
+        seniority=AgentSeniority.SENIOR,
+        status=status,
+        autonomy_level=2,
+        reputation_score=Decimal("0.8100"),
+        reliability_score=Decimal("0.9200"),
+    )
+
+
+def _grant(
+    *,
+    agent: Agent,
+    permission: Permission,
+    now: datetime,
+    project: Project | None = None,
+    expires_at: datetime | None = None,
+    revoked_at: datetime | None = None,
+) -> AgentPermission:
+    return AgentPermission(
+        agent=agent,
+        project=project,
+        permission=permission,
+        granted_by_actor_type=AuditActorType.HUMAN,
+        granted_by_actor_id="platform-admin",
+        reason="Phase 28 registry fixture",
+        expires_at=expires_at if expires_at is not None else now + timedelta(days=1),
+        revoked_at=revoked_at,
+    )
+
+
+def test_registry_reads_bounded_company_agents_with_active_project_authority(
+    db_session: Session,
+) -> None:
+    now = datetime(2030, 9, 10, 12, 0, tzinfo=UTC)
+    project = Project(name="Registry project")
+    other_project = Project(name="Other project")
+    available = _agent(slug="available-agent")
+    busy = _agent(slug="busy-agent", status=AgentStatus.WORKING)
+    db_session.add_all([project, other_project, available, busy])
+    db_session.flush()
+    db_session.add_all(
+        [
+            AgentCapability(
+                agent=available,
+                capability="backend-engineering",
+                expertise_score=Decimal("0.9000"),
+            ),
+            AgentCapability(
+                agent=available,
+                capability="payment-security",
+                expertise_score=Decimal("0.8500"),
+            ),
+            AgentCapability(
+                agent=available,
+                capability="inactive-capability",
+                expertise_score=Decimal("1.0000"),
+                active=False,
+            ),
+            AgentCapability(
+                agent=busy,
+                capability="backend-engineering",
+                expertise_score=Decimal("0.7000"),
+            ),
+            _grant(agent=available, permission=Permission.FILESYSTEM_READ, now=now),
+            _grant(
+                agent=available,
+                project=project,
+                permission=Permission.FILESYSTEM_READ,
+                now=now,
+            ),
+            _grant(
+                agent=available,
+                project=project,
+                permission=Permission.GIT_READ,
+                now=now,
+            ),
+            _grant(
+                agent=available,
+                project=other_project,
+                permission=Permission.NETWORK_ACCESS,
+                now=now,
+            ),
+            _grant(
+                agent=available,
+                permission=Permission.DATABASE_READ,
+                now=now,
+                expires_at=now - timedelta(seconds=1),
+            ),
+            _grant(
+                agent=available,
+                permission=Permission.TESTS_EXECUTE,
+                now=now,
+                revoked_at=now,
+            ),
+        ]
+    )
+    db_session.flush()
+    source = SQLAlchemyAgentRegistrySource(db_session, clock=lambda: now)
+    registry = AgentRegistry(source)
+
+    with (
+        patch.object(db_session, "commit", side_effect=AssertionError("commit is forbidden")),
+        patch.object(db_session, "rollback", side_effect=AssertionError("rollback is forbidden")),
+        patch.object(db_session, "close", side_effect=AssertionError("close is forbidden")),
+    ):
+        candidates = registry.list_candidates(project_id=project.id, limit=10)
+
+    assert {candidate.slug for candidate in candidates} == {"available-agent", "busy-agent"}
+    available_candidate = {candidate.slug: candidate for candidate in candidates}["available-agent"]
+    assert [item.name for item in available_candidate.capabilities] == [
+        "backend-engineering",
+        "payment-security",
+    ]
+    assert [item.expertise for item in available_candidate.capabilities] == [
+        Decimal("0.9000"),
+        Decimal("0.8500"),
+    ]
+    assert available_candidate.active_permissions == (
+        Permission.FILESYSTEM_READ,
+        Permission.GIT_READ,
+    )
+    assert available_candidate.reputation == Decimal("0.8100")
+    assert available_candidate.reliability == Decimal("0.9200")
+
+
+def test_agent_capabilities_are_company_scoped_and_database_constrained(
+    db_session: Session,
+) -> None:
+    agent = _agent(slug=f"capability-agent-{uuid.uuid4().hex}")
+    db_session.add(agent)
+    db_session.flush()
+    db_session.add(
+        AgentCapability(
+            agent=agent,
+            capability="backend-engineering",
+            expertise_score=Decimal("0.5000"),
+        )
+    )
+    db_session.flush()
+
+    db_session.add(
+        AgentCapability(
+            agent=agent,
+            capability="backend-engineering",
+            expertise_score=Decimal("0.6000"),
+        )
+    )
+    with pytest.raises(IntegrityError):
+        db_session.flush()
+
+
+@pytest.mark.parametrize(
+    ("capability", "expertise"),
+    [
+        ("Backend Engineering", Decimal("0.5000")),
+        ("backend-engineering", Decimal("1.0001")),
+        ("backend-engineering", Decimal("-0.0001")),
+    ],
+)
+def test_agent_capability_identifiers_and_expertise_are_database_constrained(
+    db_session: Session,
+    capability: str,
+    expertise: Decimal,
+) -> None:
+    agent = _agent(slug=f"invalid-capability-agent-{uuid.uuid4().hex}")
+    db_session.add(agent)
+    db_session.flush()
+    db_session.add(
+        AgentCapability(
+            agent=agent,
+            capability=capability,
+            expertise_score=expertise,
+        )
+    )
+
+    with pytest.raises(IntegrityError):
+        db_session.flush()
+
+
+def test_postgresql_registry_snapshots_feed_matcher_without_assignment(
+    db_session: Session,
+) -> None:
+    now = datetime(2030, 9, 10, 12, 0, tzinfo=UTC)
+    project = Project(name="Matching project")
+    available = _agent(slug="matching-agent")
+    busy = _agent(slug="occupied-agent", status=AgentStatus.WORKING)
+    db_session.add_all([project, available, busy])
+    db_session.flush()
+    for agent in (available, busy):
+        db_session.add_all(
+            [
+                AgentCapability(
+                    agent=agent,
+                    capability="backend-engineering",
+                    expertise_score=Decimal("0.9000"),
+                ),
+                AgentCapability(
+                    agent=agent,
+                    capability="payment-security",
+                    expertise_score=Decimal("0.9000"),
+                ),
+                _grant(
+                    agent=agent,
+                    permission=Permission.FILESYSTEM_READ,
+                    now=now,
+                ),
+            ]
+        )
+    db_session.flush()
+    candidates = AgentRegistry(
+        SQLAlchemyAgentRegistrySource(db_session, clock=lambda: now)
+    ).list_candidates(project_id=project.id)
+    workstream = DomainWorkstream(
+        id="payments",
+        name="Payments",
+        scope_kind=WorkstreamScope.DOMAIN,
+        purpose="Own payment processing.",
+        source_domains=("Payments",),
+        responsibilities=("Process payments",),
+        required_capabilities=("backend-engineering", "payment-security"),
+        dependencies=(),
+    )
+    request = AgentMatchingRequest(
+        project_id=project.id,
+        workstream=workstream,
+        required_permissions=(Permission.FILESYSTEM_READ,),
+        minimum_seniority=AgentSeniority.ENGINEER,
+        risk_level=ToolRiskLevel.HIGH,
+        cost_estimates=tuple(
+            AgentCostEstimate(agent_id=candidate.agent_id, normalized_cost=Decimal("0.2000"))
+            for candidate in candidates
+        ),
+    )
+
+    result = AgentMatcher().match(request, candidates)
+
+    assert [match.agent.agent_id for match in result.matches] == [available.id]
+    assert result.rejections[0].agent_id == busy.id
+    assert result.rejections[0].reasons == ("Agent is not available.",)
+    assert available.status is AgentStatus.AVAILABLE
+    assert busy.status is AgentStatus.WORKING
+
+
+def test_registry_reads_never_autoflush_pending_session_changes(db_session: Session) -> None:
+    now = datetime(2030, 9, 10, 12, 0, tzinfo=UTC)
+    project = Project(name="No autoflush project")
+    agent = _agent(slug="no-autoflush-agent")
+    persisted = AgentCapability(
+        agent=agent,
+        capability="backend-engineering",
+        expertise_score=Decimal("0.8000"),
+    )
+    db_session.add_all([project, agent, persisted])
+    db_session.flush()
+    pending_duplicate = AgentCapability(
+        agent=agent,
+        capability="backend-engineering",
+        expertise_score=Decimal("0.9000"),
+    )
+    db_session.add(pending_duplicate)
+
+    candidates = AgentRegistry(
+        SQLAlchemyAgentRegistrySource(db_session, clock=lambda: now)
+    ).list_candidates(project_id=project.id)
+
+    assert [candidate.agent_id for candidate in candidates] == [agent.id]
+    assert candidates[0].capabilities[0].expertise == Decimal("0.8000")
+    assert pending_duplicate in db_session.new


### PR DESCRIPTION
## Summary
- add bounded agent registry and deterministic capability matching
- persist company-scoped agent capabilities with PostgreSQL migration
- enforce permission, autonomy, availability, seniority, risk, and cost gates
- add unit and real-PostgreSQL integration coverage

## Validation
- 1995 tests passed
- Ruff passed
- mypy strict passed
- Ruff format check passed

Phase 29 is not included.