### PR TITLE
feat(escalation): add deterministic escalation engine

### DIFF
--- a/SYNAPSEOS_DEVELOPMENT_CHECKLIST.md
+++ b/SYNAPSEOS_DEVELOPMENT_CHECKLIST.md
@@ -1901,12 +1901,21 @@ Permettre à un agent de reconnaître ses limites.
 
 ## Conditions
 
-- [ ] faible confiance
-- [ ] manque de compétence
-- [ ] permissions insuffisantes
-- [ ] conflit
-- [ ] boucle stagnante
-- [ ] décision critique
+- [x] faible confiance
+- [x] manque de compétence
+- [x] permissions insuffisantes (critical denial)
+- [x] conflit (unresolved contradiction)
+- [x] boucle stagnante (maximum iterations)
+- [x] décision critique (irreversible or high-risk)
+
+## Implementation plan
+
+- [x] Define bounded immutable escalation contracts and approved targets
+- [x] Select one deterministic escalation trigger with explicit precedence
+- [x] Create one clear escalation action for the receiving authority
+- [x] Emit one sanitized audit event for every escalation
+- [x] Keep audit and task sinks injected with no implicit persistence or retry
+- [x] Verify unit tests, full tests, Ruff, formatting, and strict mypy
 
 ## Prompt Claude Code — Phase 29
 

--- a/core/escalation/__init__.py
+++ b/core/escalation/__init__.py
@@ -1,0 +1,31 @@
+"""Phase 29 deterministic escalation contracts and engine."""
+
+from core.enums import ToolRiskLevel
+from core.escalation.engine import EscalationEngine
+from core.escalation.types import (
+    EscalationAction,
+    EscalationAuditEvent,
+    EscalationAuditSink,
+    EscalationRequest,
+    EscalationResult,
+    EscalationTarget,
+    EscalationTaskSink,
+    EscalationTrigger,
+    InMemoryEscalationAuditSink,
+    InMemoryEscalationTaskSink,
+)
+
+__all__ = [
+    "EscalationAction",
+    "EscalationAuditEvent",
+    "EscalationAuditSink",
+    "EscalationEngine",
+    "EscalationRequest",
+    "EscalationResult",
+    "EscalationTarget",
+    "EscalationTaskSink",
+    "EscalationTrigger",
+    "InMemoryEscalationAuditSink",
+    "InMemoryEscalationTaskSink",
+    "ToolRiskLevel",
+]

--- a/core/escalation/engine.py
+++ b/core/escalation/engine.py
@@ -1,0 +1,117 @@
+"""Deterministic, side-effect-bounded Phase 29 escalation engine."""
+
+from __future__ import annotations
+
+import uuid
+
+from core.enums import ToolRiskLevel
+from core.escalation.types import (
+    EscalationAction,
+    EscalationAuditEvent,
+    EscalationAuditSink,
+    EscalationRequest,
+    EscalationResult,
+    EscalationTarget,
+    EscalationTaskSink,
+    EscalationTrigger,
+)
+
+_TRIGGER_RULES: tuple[tuple[EscalationTrigger, EscalationTarget], ...] = (
+    (EscalationTrigger.CRITICAL_PERMISSION_DENIED, EscalationTarget.SECURITY),
+    (EscalationTrigger.IRREVERSIBLE_DECISION, EscalationTarget.FINANCE),
+    (EscalationTrigger.HIGH_RISK, EscalationTarget.SECURITY),
+    (EscalationTrigger.UNRESOLVED_CONTRADICTION, EscalationTarget.ARCHITECTURE_REVIEW),
+    (EscalationTrigger.INSUFFICIENT_EXPERTISE, EscalationTarget.SENIOR_AGENT),
+    (EscalationTrigger.LOW_CONFIDENCE, EscalationTarget.HUMAN),
+    (EscalationTrigger.MAX_ITERATIONS, EscalationTarget.PM),
+)
+
+
+class EscalationEngine:
+    """Evaluate bounded evidence and emit at most one escalation."""
+
+    def __init__(self, audit_sink: EscalationAuditSink, task_sink: EscalationTaskSink) -> None:
+        self._audit_sink = audit_sink
+        self._task_sink = task_sink
+
+    def evaluate(self, request: EscalationRequest) -> EscalationResult:
+        """Stop at the first applicable rule and emit its audit/action pair."""
+        if type(request) is not EscalationRequest:
+            raise ValueError("invalid escalation request")
+        trigger_target = _first_trigger(request)
+        if trigger_target is None:
+            return EscalationResult(triggered=False)
+
+        trigger, target = trigger_target
+        action = EscalationAction(
+            id=uuid.uuid4(),
+            project_id=request.project_id,
+            task_id=request.task_id,
+            target=target,
+            trigger=trigger,
+            title=_title(trigger),
+            instructions=_instructions(request, trigger, target),
+        )
+        audit_event = EscalationAuditEvent(
+            id=uuid.uuid4(),
+            project_id=request.project_id,
+            task_id=request.task_id,
+            agent_id=request.agent_id,
+            trigger=trigger,
+            target=target,
+            reason=request.summary,
+            metadata=(
+                ("confidence", str(request.confidence)),
+                ("risk_level", request.risk_level.value),
+            ),
+        )
+        self._audit_sink.record(audit_event)
+        self._task_sink.create(action)
+        return EscalationResult(
+            triggered=True,
+            trigger=trigger,
+            target=target,
+            action=action,
+            audit_event=audit_event,
+        )
+
+
+def _first_trigger(
+    request: EscalationRequest,
+) -> tuple[EscalationTrigger, EscalationTarget] | None:
+    conditions = {
+        EscalationTrigger.CRITICAL_PERMISSION_DENIED: request.permission_denied
+        and request.permission_denial_is_critical,
+        EscalationTrigger.IRREVERSIBLE_DECISION: request.irreversible_decision,
+        EscalationTrigger.HIGH_RISK: request.risk_level
+        in {ToolRiskLevel.HIGH, ToolRiskLevel.CRITICAL},
+        EscalationTrigger.UNRESOLVED_CONTRADICTION: request.contradiction_unresolved,
+        EscalationTrigger.INSUFFICIENT_EXPERTISE: request.expertise < request.required_expertise,
+        EscalationTrigger.LOW_CONFIDENCE: request.confidence < request.minimum_confidence,
+        EscalationTrigger.MAX_ITERATIONS: request.iterations >= request.max_iterations,
+    }
+    return next(
+        ((trigger, target) for trigger, target in _TRIGGER_RULES if conditions[trigger]),
+        None,
+    )
+
+
+def _title(trigger: EscalationTrigger) -> str:
+    return {
+        EscalationTrigger.CRITICAL_PERMISSION_DENIED: "Review critical permission denial",
+        EscalationTrigger.IRREVERSIBLE_DECISION: "Approve irreversible decision",
+        EscalationTrigger.HIGH_RISK: "Review high-risk operation",
+        EscalationTrigger.UNRESOLVED_CONTRADICTION: "Resolve unresolved contradiction",
+        EscalationTrigger.INSUFFICIENT_EXPERTISE: "Review insufficient expertise",
+        EscalationTrigger.LOW_CONFIDENCE: "Review blocked agent decision",
+        EscalationTrigger.MAX_ITERATIONS: "Review stagnating agent task",
+    }[trigger]
+
+
+def _instructions(
+    request: EscalationRequest, trigger: EscalationTrigger, target: EscalationTarget
+) -> str:
+    return (
+        f"{target.value} must review the {trigger.value.lower().replace('_', ' ')} "
+        f"for task {request.task_id}. The agent must not continue until this action is resolved."
+    )

--- a/core/escalation/types.py
+++ b/core/escalation/types.py
@@ -1,0 +1,168 @@
+"""Immutable contracts for the Phase 29 escalation boundary."""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import Sequence
+from decimal import Decimal
+from enum import StrEnum
+from typing import Annotated, Protocol
+
+from pydantic import AfterValidator, BaseModel, ConfigDict, Field, field_validator, model_validator
+
+from core.enums import ToolRiskLevel
+
+
+def _nonblank(value: str) -> str:
+    value = value.strip()
+    if not value:
+        raise ValueError("text must not be blank")
+    return value
+
+
+Score = Annotated[Decimal, Field(ge=Decimal("0"), le=Decimal("1"), allow_inf_nan=False)]
+BoundedText = Annotated[str, Field(min_length=1, max_length=255), AfterValidator(_nonblank)]
+
+
+class EscalationTarget(StrEnum):
+    """Authority that must receive the next decision or action."""
+
+    HUMAN = "HUMAN"
+    SENIOR_AGENT = "SENIOR_AGENT"
+    SECURITY = "SECURITY"
+    ARCHITECTURE_REVIEW = "ARCHITECTURE_REVIEW"
+    PM = "PM"
+    FINANCE = "FINANCE"
+
+
+class EscalationTrigger(StrEnum):
+    """Bounded signals that require an agent to stop and escalate."""
+
+    LOW_CONFIDENCE = "LOW_CONFIDENCE"
+    INSUFFICIENT_EXPERTISE = "INSUFFICIENT_EXPERTISE"
+    CRITICAL_PERMISSION_DENIED = "CRITICAL_PERMISSION_DENIED"
+    MAX_ITERATIONS = "MAX_ITERATIONS"
+    UNRESOLVED_CONTRADICTION = "UNRESOLVED_CONTRADICTION"
+    IRREVERSIBLE_DECISION = "IRREVERSIBLE_DECISION"
+    HIGH_RISK = "HIGH_RISK"
+
+
+class EscalationRequest(BaseModel):
+    """Bounded evidence used to determine whether escalation is required."""
+
+    model_config = ConfigDict(
+        frozen=True,
+        extra="forbid",
+        strict=True,
+        hide_input_in_errors=True,
+        revalidate_instances="always",
+    )
+
+    project_id: uuid.UUID
+    task_id: uuid.UUID
+    agent_id: uuid.UUID
+    summary: BoundedText
+    confidence: Score
+    minimum_confidence: Score
+    expertise: Score
+    required_expertise: Score
+    permission_denied: bool
+    permission_denial_is_critical: bool
+    iterations: int = Field(ge=0, le=1000)
+    max_iterations: int = Field(ge=1, le=1000)
+    contradiction_unresolved: bool
+    irreversible_decision: bool
+    risk_level: ToolRiskLevel
+
+    @field_validator("summary")
+    @classmethod
+    def normalize_summary(cls, value: str) -> str:
+        return _nonblank(value)
+
+    @model_validator(mode="after")
+    def validate_iteration_order(self) -> EscalationRequest:
+        if self.iterations > self.max_iterations:
+            raise ValueError("iterations must not exceed max_iterations")
+        return self
+
+
+class EscalationAction(BaseModel):
+    """One explicit bounded task/action created for an escalation."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid", strict=True)
+
+    id: uuid.UUID
+    project_id: uuid.UUID
+    task_id: uuid.UUID
+    target: EscalationTarget
+    trigger: EscalationTrigger
+    title: BoundedText
+    instructions: BoundedText
+
+
+class EscalationAuditEvent(BaseModel):
+    """Sanitized immutable audit evidence for one escalation decision."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid", strict=True)
+
+    id: uuid.UUID
+    project_id: uuid.UUID
+    task_id: uuid.UUID
+    agent_id: uuid.UUID
+    trigger: EscalationTrigger
+    target: EscalationTarget
+    reason: BoundedText
+    metadata: tuple[tuple[str, str], ...] = Field(max_length=8)
+
+    @field_validator("metadata")
+    @classmethod
+    def validate_metadata(cls, value: Sequence[tuple[str, str]]) -> tuple[tuple[str, str], ...]:
+        if len({key for key, _ in value}) != len(value):
+            raise ValueError("escalation metadata keys must be unique")
+        if any(not key or len(key) > 64 or len(item) > 255 for key, item in value):
+            raise ValueError("escalation metadata must be bounded")
+        return tuple(value)
+
+
+class EscalationResult(BaseModel):
+    """Result of one escalation evaluation."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid", strict=True)
+
+    triggered: bool
+    trigger: EscalationTrigger | None = None
+    target: EscalationTarget | None = None
+    action: EscalationAction | None = None
+    audit_event: EscalationAuditEvent | None = None
+
+
+class EscalationAuditSink(Protocol):
+    """Append one sanitized escalation audit event."""
+
+    def record(self, event: EscalationAuditEvent) -> None: ...
+
+
+class EscalationTaskSink(Protocol):
+    """Create one explicit escalation action."""
+
+    def create(self, action: EscalationAction) -> None: ...
+
+
+class InMemoryEscalationAuditSink:
+    """Small deterministic sink used by unit tests and local composition."""
+
+    def __init__(self) -> None:
+        self.events: list[EscalationAuditEvent] = []
+
+    def record(self, event: EscalationAuditEvent) -> None:
+        self.events.append(event)
+
+
+class InMemoryEscalationTaskSink:
+    """Small deterministic action sink used by unit tests."""
+
+    def __init__(self) -> None:
+        self.actions: list[EscalationAction] = []
+
+    def create(self, action: EscalationAction) -> None:
+        self.actions.append(action)

--- a/tests/escalation/__init__.py
+++ b/tests/escalation/__init__.py
@@ -1,0 +1,1 @@
+"""Phase 29 escalation tests."""

--- a/tests/escalation/test_engine.py
+++ b/tests/escalation/test_engine.py
@@ -1,0 +1,136 @@
+"""Tests for the deterministic Phase 29 escalation engine."""
+
+from __future__ import annotations
+
+import uuid
+from decimal import Decimal
+
+import pytest
+from pydantic import ValidationError
+
+from core.escalation import (
+    EscalationAuditEvent,
+    EscalationEngine,
+    EscalationRequest,
+    EscalationTarget,
+    EscalationTrigger,
+    InMemoryEscalationAuditSink,
+    InMemoryEscalationTaskSink,
+    ToolRiskLevel,
+)
+
+
+def _request(**overrides: object) -> EscalationRequest:
+    values: dict[str, object] = {
+        "project_id": uuid.UUID("00000000-0000-0000-0000-000000000001"),
+        "task_id": uuid.UUID("00000000-0000-0000-0000-000000000002"),
+        "agent_id": uuid.UUID("00000000-0000-0000-0000-000000000003"),
+        "summary": "The agent cannot safely continue.",
+        "confidence": Decimal("0.40"),
+        "minimum_confidence": Decimal("0.60"),
+        "expertise": Decimal("0.80"),
+        "required_expertise": Decimal("0.80"),
+        "permission_denied": False,
+        "permission_denial_is_critical": False,
+        "iterations": 1,
+        "max_iterations": 5,
+        "contradiction_unresolved": False,
+        "irreversible_decision": False,
+        "risk_level": ToolRiskLevel.LOW,
+    }
+    values.update(overrides)
+    return EscalationRequest.model_validate(values)
+
+
+def test_low_confidence_creates_audited_human_action() -> None:
+    audit = InMemoryEscalationAuditSink()
+    tasks = InMemoryEscalationTaskSink()
+
+    result = EscalationEngine(audit, tasks).evaluate(_request())
+
+    assert result.trigger == EscalationTrigger.LOW_CONFIDENCE
+    assert result.target == EscalationTarget.HUMAN
+    assert result.action is not None
+    assert result.action.title == "Review blocked agent decision"
+    assert result.action.task_id == uuid.UUID("00000000-0000-0000-0000-000000000002")
+    assert audit.events == [result.audit_event]
+    assert tasks.actions == [result.action]
+
+
+def test_critical_permission_denial_takes_security_precedence() -> None:
+    result = EscalationEngine(InMemoryEscalationAuditSink(), InMemoryEscalationTaskSink()).evaluate(
+        _request(
+            confidence=Decimal("0.90"),
+            permission_denied=True,
+            permission_denial_is_critical=True,
+        )
+    )
+
+    assert result.trigger == EscalationTrigger.CRITICAL_PERMISSION_DENIED
+    assert result.target == EscalationTarget.SECURITY
+
+
+@pytest.mark.parametrize(
+    ("overrides", "trigger", "target"),
+    [
+        (
+            {"expertise": Decimal("0.20")},
+            EscalationTrigger.INSUFFICIENT_EXPERTISE,
+            EscalationTarget.SENIOR_AGENT,
+        ),
+        ({"iterations": 5}, EscalationTrigger.MAX_ITERATIONS, EscalationTarget.PM),
+        (
+            {"contradiction_unresolved": True},
+            EscalationTrigger.UNRESOLVED_CONTRADICTION,
+            EscalationTarget.ARCHITECTURE_REVIEW,
+        ),
+        (
+            {"irreversible_decision": True},
+            EscalationTrigger.IRREVERSIBLE_DECISION,
+            EscalationTarget.FINANCE,
+        ),
+        (
+            {"risk_level": ToolRiskLevel.HIGH},
+            EscalationTrigger.HIGH_RISK,
+            EscalationTarget.SECURITY,
+        ),
+    ],
+)
+def test_each_limit_has_a_deterministic_target(
+    overrides: dict[str, object], trigger: EscalationTrigger, target: EscalationTarget
+) -> None:
+    result = EscalationEngine(InMemoryEscalationAuditSink(), InMemoryEscalationTaskSink()).evaluate(
+        _request(confidence=Decimal("0.90"), **overrides)
+    )
+
+    assert result.trigger == trigger
+    assert result.target == target
+
+
+def test_no_trigger_does_not_create_action_or_audit() -> None:
+    audit = InMemoryEscalationAuditSink()
+    tasks = InMemoryEscalationTaskSink()
+
+    result = EscalationEngine(audit, tasks).evaluate(_request(confidence=Decimal("0.90")))
+
+    assert result.trigger is None
+    assert result.action is None
+    assert result.audit_event is None
+    assert audit.events == []
+    assert tasks.actions == []
+
+
+def test_inputs_and_emitted_metadata_are_bounded_and_immutable() -> None:
+    audit = InMemoryEscalationAuditSink()
+    tasks = InMemoryEscalationTaskSink()
+    request = _request(summary=" bounded ")
+
+    result = EscalationEngine(audit, tasks).evaluate(request)
+
+    assert request.summary == "bounded"
+    assert isinstance(result.audit_event, EscalationAuditEvent)
+    assert result.audit_event is not None
+    assert len(result.audit_event.reason) <= 255
+    assert result.action is not None
+    with pytest.raises(ValidationError):
+        result.action.title = "changed"  # type: ignore[misc]


### PR DESCRIPTION
## Summary
- add bounded immutable escalation contracts and approved targets
- select deterministic escalation triggers with explicit precedence
- create clear escalation actions and sanitized audit events
- keep sinks injected with no implicit persistence or retry

## Validation
- 2004 tests passed
- Ruff and strict mypy passed
- formatting and diff checks passed

Phase 30 is not included.