### PR TITLE
feat(mcp): add bounded registry and router

### DIFF
--- a/SYNAPSEOS_DEVELOPMENT_CHECKLIST.md
+++ b/SYNAPSEOS_DEVELOPMENT_CHECKLIST.md
@@ -1998,13 +1998,24 @@ Permettre la découverte et l'utilisation contrôlée de serveurs MCP.
 
 ## Checklist
 
-- [ ] MCPServer registry
-- [ ] capabilities
-- [ ] permissions
-- [ ] health
-- [ ] routing
-- [ ] audit
-- [ ] allowlist
+- [x] MCPServer registry
+- [x] capabilities
+- [x] permissions
+- [x] health
+- [x] routing
+- [x] audit
+- [x] allowlist
+
+## Implementation plan
+
+- [x] Define immutable MCP server and capability contracts
+- [x] Register only explicit, bounded, allowlisted server definitions
+- [x] Discover capabilities through permission and health filters
+- [x] Route capability requests without exposing server identity to callers
+- [x] Enforce per-server timeout limits and propagate cancellation safely
+- [x] Emit metadata-only audit events for success and failure outcomes
+- [x] Provide deterministic mock client and audit sink tests
+- [x] Verify full tests, Ruff, formatting, and strict mypy
 
 ## Prompt Claude Code — Phase 31
 

--- a/core/mcp/__init__.py
+++ b/core/mcp/__init__.py
@@ -1,0 +1,29 @@
+"""Phase 31 bounded MCP registry and router."""
+
+from core.mcp.types import (
+    MCPAuditEvent,
+    MCPCapability,
+    MCPHealthStatus,
+    MCPInvocationRequest,
+    MCPInvocationResult,
+    MCPRegistry,
+    MCPRouter,
+    MCPRouterError,
+    MCPServerDefinition,
+    RecordingMCPAuditSink,
+    RecordingMCPClient,
+)
+
+__all__ = [
+    "MCPCapability",
+    "MCPAuditEvent",
+    "MCPHealthStatus",
+    "MCPInvocationRequest",
+    "MCPInvocationResult",
+    "MCPRegistry",
+    "MCPRouter",
+    "MCPRouterError",
+    "MCPServerDefinition",
+    "RecordingMCPAuditSink",
+    "RecordingMCPClient",
+]

--- a/core/mcp/types.py
+++ b/core/mcp/types.py
@@ -1,0 +1,228 @@
+"""Bounded MCP registry, routing, permission, and audit contracts."""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Mapping, Sequence
+from enum import StrEnum
+from typing import Protocol
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+
+from core.enums import Permission
+
+MAX_MCP_SERVERS = 128
+MAX_MCP_CAPABILITIES = 256
+MAX_ARGUMENTS = 32
+
+
+class MCPRouterError(RuntimeError):
+    """Safe, non-sensitive MCP routing failure."""
+
+
+class MCPHealthStatus(StrEnum):
+    UNKNOWN = "UNKNOWN"
+    HEALTHY = "HEALTHY"
+    UNHEALTHY = "UNHEALTHY"
+    DISABLED = "DISABLED"
+
+
+class MCPCapability(BaseModel):
+    """One allowlisted capability exposed by an MCP server."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid", strict=True)
+
+    name: str = Field(pattern=r"^[a-z0-9][a-z0-9._:-]{0,127}$")
+    description: str = Field(min_length=1, max_length=255)
+    required_permissions: frozenset[Permission] = Field(max_length=16)
+
+
+class MCPServerDefinition(BaseModel):
+    """Explicitly registered MCP server metadata; no connection is implicit."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid", strict=True)
+
+    server_id: str = Field(pattern=r"^[a-z0-9][a-z0-9._:-]{0,127}$")
+    display_name: str = Field(min_length=1, max_length=255)
+    allowlisted: bool
+    status: MCPHealthStatus
+    required_permissions: frozenset[Permission] = Field(max_length=16)
+    capabilities: tuple[MCPCapability, ...] = Field(min_length=1, max_length=128)
+    timeout_seconds: float = Field(gt=0.0, le=30.0)
+
+    @field_validator("capabilities", mode="before")
+    @classmethod
+    def copy_capabilities(cls, value: object) -> object:
+        return tuple(value) if isinstance(value, (list, tuple)) else value
+
+    @model_validator(mode="after")
+    def require_unique_capabilities(self) -> MCPServerDefinition:
+        names = tuple(item.name for item in self.capabilities)
+        if len(names) != len(set(names)):
+            raise ValueError("MCP capability names must be unique")
+        return self
+
+
+class MCPInvocationRequest(BaseModel):
+    """Bounded capability request independent of a concrete MCP server."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid", strict=True)
+
+    capability: str = Field(pattern=r"^[a-z0-9][a-z0-9._:-]{0,127}$")
+    granted_permissions: frozenset[Permission] = Field(max_length=32)
+    arguments: dict[str, str | int | float | bool | None] = Field(max_length=MAX_ARGUMENTS)
+    timeout_seconds: float = Field(gt=0.0, le=30.0)
+
+
+class MCPInvocationResult(BaseModel):
+    """Bounded provider output returned by the router."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid", strict=True)
+
+    output: dict[str, object] = Field(max_length=64)
+    duration_ms: float = Field(ge=0.0, le=30_000.0)
+
+
+class MCPAuditEvent(BaseModel):
+    """Metadata-only audit event for one routed MCP call."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid", strict=True)
+
+    capability: str
+    server_id: str
+    result: str
+
+
+class MCPClient(Protocol):
+    async def invoke(
+        self,
+        capability: str,
+        arguments: Mapping[str, str | int | float | bool | None],
+        timeout_seconds: float,
+    ) -> MCPInvocationResult: ...
+
+
+class MCPAuditSink(Protocol):
+    def record(self, event: MCPAuditEvent) -> None: ...
+
+
+class RecordingMCPClient:
+    """Mock MCP client for deterministic tests."""
+
+    def __init__(self, output: dict[str, object]) -> None:
+        self.output = dict(output)
+        self.calls: list[tuple[str, dict[str, str | int | float | bool | None], float]] = []
+
+    async def invoke(
+        self,
+        capability: str,
+        arguments: Mapping[str, str | int | float | bool | None],
+        timeout_seconds: float,
+    ) -> MCPInvocationResult:
+        self.calls.append((capability, dict(arguments), timeout_seconds))
+        return MCPInvocationResult(output=self.output, duration_ms=1.0)
+
+
+class RecordingMCPAuditSink:
+    """Mock audit sink for deterministic tests."""
+
+    def __init__(self) -> None:
+        self.events: list[MCPAuditEvent] = []
+
+    def record(self, event: MCPAuditEvent) -> None:
+        self.events.append(event)
+
+
+class MCPRegistry:
+    """Allowlist-only registry for explicit MCP server definitions."""
+
+    def __init__(self, servers: Sequence[MCPServerDefinition]) -> None:
+        if len(servers) > MAX_MCP_SERVERS:
+            raise ValueError("MCP server registry is bounded")
+        if any(type(server) is not MCPServerDefinition for server in servers):
+            raise ValueError("MCP server definition is invalid")
+        if len({server.server_id for server in servers}) != len(servers):
+            raise ValueError("MCP server identifiers must be unique")
+        self._servers = {server.server_id: server for server in servers}
+
+    def discover(self, permissions: frozenset[Permission]) -> tuple[str, ...]:
+        names = [
+            capability.name
+            for server in self._servers.values()
+            if server.allowlisted
+            and server.status is MCPHealthStatus.HEALTHY
+            and server.required_permissions.issubset(permissions)
+            for capability in server.capabilities
+            if capability.required_permissions.issubset(permissions)
+        ]
+        return tuple(sorted(set(names)))
+
+    def resolve(
+        self, capability: str, permissions: frozenset[Permission]
+    ) -> tuple[MCPServerDefinition, MCPCapability]:
+        candidates = [
+            (server, item)
+            for server in self._servers.values()
+            if server.allowlisted
+            and server.status is MCPHealthStatus.HEALTHY
+            and server.required_permissions.issubset(permissions)
+            for item in server.capabilities
+            if item.name == capability and item.required_permissions.issubset(permissions)
+        ]
+        if len(candidates) != 1:
+            raise MCPRouterError("MCP capability is unavailable.")
+        return candidates[0]
+
+
+class MCPRouter:
+    """Route capability requests through allowlisted, healthy MCP definitions."""
+
+    def __init__(
+        self,
+        registry: MCPRegistry,
+        clients: Mapping[str, MCPClient],
+        audit_sink: MCPAuditSink,
+    ) -> None:
+        self._registry = registry
+        self._clients = dict(clients)
+        self._audit_sink = audit_sink
+
+    async def invoke(self, request: MCPInvocationRequest) -> MCPInvocationResult:
+        if type(request) is not MCPInvocationRequest:
+            raise MCPRouterError("MCP request is invalid.")
+        server, capability = self._registry.resolve(request.capability, request.granted_permissions)
+        timeout = min(request.timeout_seconds, server.timeout_seconds)
+        client = self._clients.get(server.server_id)
+        if client is None:
+            raise MCPRouterError("MCP server client is unavailable.")
+        try:
+            result = await asyncio.wait_for(
+                client.invoke(capability.name, request.arguments, timeout), timeout=timeout
+            )
+        except TimeoutError:
+            self._audit_sink.record(
+                MCPAuditEvent(
+                    capability=capability.name,
+                    server_id=server.server_id,
+                    result="TIMED_OUT",
+                )
+            )
+            raise MCPRouterError("MCP capability timed out.") from None
+        except Exception as error:
+            del error
+            self._audit_sink.record(
+                MCPAuditEvent(
+                    capability=capability.name,
+                    server_id=server.server_id,
+                    result="FAILED",
+                )
+            )
+            raise MCPRouterError("MCP capability failed.") from None
+        self._audit_sink.record(
+            MCPAuditEvent(
+                capability=capability.name,
+                server_id=server.server_id,
+                result="SUCCEEDED",
+            )
+        )
+        return result

--- a/tests/mcp/__init__.py
+++ b/tests/mcp/__init__.py
@@ -1,0 +1,1 @@
+"""Phase 31 MCP registry tests."""

--- a/tests/mcp/test_registry.py
+++ b/tests/mcp/test_registry.py
@@ -1,0 +1,112 @@
+"""Tests for the bounded Phase 31 MCP registry and router."""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+import pytest
+
+from core.enums import Permission
+from core.mcp import (
+    MCPCapability,
+    MCPHealthStatus,
+    MCPInvocationRequest,
+    MCPRegistry,
+    MCPRouter,
+    MCPRouterError,
+    MCPServerDefinition,
+    RecordingMCPAuditSink,
+    RecordingMCPClient,
+)
+
+
+def _server(
+    *,
+    server_id: str = "git-server",
+    allowlisted: bool = True,
+    status: MCPHealthStatus = MCPHealthStatus.HEALTHY,
+) -> MCPServerDefinition:
+    return MCPServerDefinition(
+        server_id=server_id,
+        display_name="Git MCP",
+        allowlisted=allowlisted,
+        status=status,
+        required_permissions=frozenset({Permission.GIT_READ}),
+        capabilities=(
+            MCPCapability(
+                name="repository.read",
+                description="Read repository metadata.",
+                required_permissions=frozenset({Permission.GIT_READ}),
+            ),
+        ),
+        timeout_seconds=10.0,
+    )
+
+
+def _request() -> MCPInvocationRequest:
+    return MCPInvocationRequest(
+        capability="repository.read",
+        granted_permissions=frozenset({Permission.GIT_READ}),
+        arguments={"path": "src"},
+        timeout_seconds=3.0,
+    )
+
+
+def test_registry_discovers_only_allowlisted_healthy_capabilities() -> None:
+    registry = MCPRegistry((_server(), _server(server_id="unknown-server", allowlisted=False)))
+
+    discovered = registry.discover(frozenset({Permission.GIT_READ}))
+
+    assert discovered == ("repository.read",)
+
+
+def test_router_resolves_capability_without_exposing_server_identity() -> None:
+    client = RecordingMCPClient({"files": ["README.md"]})
+    audit = RecordingMCPAuditSink()
+    router = MCPRouter(MCPRegistry((_server(),)), {"git-server": client}, audit)
+
+    result = asyncio.run(router.invoke(_request()))
+
+    assert result.output == {"files": ["README.md"]}
+    assert client.calls == [("repository.read", {"path": "src"}, 3.0)]
+    assert audit.events[0].capability == "repository.read"
+
+
+@pytest.mark.parametrize(
+    "server",
+    [_server(allowlisted=False), _server(status=MCPHealthStatus.UNHEALTHY)],
+)
+def test_router_denies_unknown_or_unhealthy_servers(server: MCPServerDefinition) -> None:
+    router = MCPRouter(
+        MCPRegistry((server,)),
+        {"git-server": RecordingMCPClient({})},
+        RecordingMCPAuditSink(),
+    )
+
+    with pytest.raises(MCPRouterError):
+        asyncio.run(router.invoke(_request()))
+
+
+def test_router_denies_missing_permission_without_calling_client() -> None:
+    client = RecordingMCPClient({})
+    router = MCPRouter(MCPRegistry((_server(),)), {"git-server": client}, RecordingMCPAuditSink())
+
+    with pytest.raises(MCPRouterError):
+        asyncio.run(
+            router.invoke(_request().model_copy(update={"granted_permissions": frozenset()}))
+        )
+
+    assert client.calls == []
+
+
+def test_router_clamps_timeout_to_registered_server_limit(tmp_path: Path) -> None:
+    del tmp_path
+    server = _server()
+    client = RecordingMCPClient({})
+    request = _request().model_copy(update={"timeout_seconds": 30.0})
+    router = MCPRouter(MCPRegistry((server,)), {"git-server": client}, RecordingMCPAuditSink())
+
+    asyncio.run(router.invoke(request))
+
+    assert client.calls[0][2] == 10.0


### PR DESCRIPTION
## Summary
- define immutable MCP server and capability contracts
- add allowlist, health, permission, and bounded discovery filtering
- route capability requests through explicit registered clients
- enforce timeout limits and metadata-only audit events
- add deterministic mock client and audit coverage

## Validation
- 2016 tests passed
- Ruff and strict mypy passed
- formatting and diff checks passed

Phase 32 is not included.