### PR TITLE
feat(router): add deterministic capability planning

### DIFF
--- a/SYNAPSEOS_DEVELOPMENT_CHECKLIST.md
+++ b/SYNAPSEOS_DEVELOPMENT_CHECKLIST.md
@@ -2082,6 +2082,16 @@ scoring déterministe.
 Ne laisse pas un agent contourner les permissions en choisissant une capacité.
 ```
 
+## Implementation plan
+
+- [x] Define bounded task, agent, and project routing context
+- [x] Select skills through the existing deterministic skill selector
+- [x] Select only explicitly registered and permission-compatible tools
+- [x] Select only healthy, allowlisted, permission-compatible MCP capabilities
+- [x] Return a bounded CapabilityPlan with required permissions and rationale
+- [x] Reject unknown requested tools and prevent permission bypasses
+- [x] Verify full tests, Ruff, formatting, and strict mypy
+
 ---
 
 # PHASE 33 — Feedback client

--- a/core/capability_router/__init__.py
+++ b/core/capability_router/__init__.py
@@ -1,0 +1,5 @@
+"""Phase 32 deterministic capability router."""
+
+from core.capability_router.router import CapabilityPlan, CapabilityRouter, CapabilityRoutingRequest
+
+__all__ = ["CapabilityPlan", "CapabilityRouter", "CapabilityRoutingRequest"]

--- a/core/capability_router/router.py
+++ b/core/capability_router/router.py
@@ -1,0 +1,156 @@
+"""Deterministic, permission-preserving capability planning."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from typing import Annotated
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+from core.enums import Permission
+from core.mcp import MCPRegistry
+from core.skills import SkillRegistry, SkillSelectionRequest, SkillSelector
+from core.tools import ToolRegistry
+
+Identifier = Annotated[str, Field(pattern=r"^[a-z0-9][a-z0-9._:-]{0,127}$")]
+
+
+class CapabilityRoutingRequest(BaseModel):
+    """Bounded task, agent, and project context for one capability plan."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid", strict=True)
+
+    task_id: Identifier
+    agent_id: Identifier
+    task_description: str = Field(min_length=1, max_length=4_096)
+    agent_role: str = Field(min_length=1, max_length=255)
+    domains: frozenset[Identifier] = Field(max_length=32)
+    technologies: frozenset[Identifier] = Field(max_length=32)
+    tags: frozenset[Identifier] = Field(max_length=32)
+    available_permissions: frozenset[Permission] = Field(max_length=11)
+    requested_tools: frozenset[Identifier] = Field(max_length=32)
+    requested_mcp_capabilities: frozenset[Identifier] = Field(max_length=32)
+
+    @field_validator(
+        "domains",
+        "technologies",
+        "tags",
+        "available_permissions",
+        "requested_tools",
+        "requested_mcp_capabilities",
+        mode="before",
+    )
+    @classmethod
+    def copy_sets(cls, value: object) -> object:
+        return frozenset(value) if isinstance(value, (set, frozenset, tuple, list)) else value
+
+
+class CapabilityPlan(BaseModel):
+    """Immutable selected capabilities and an explainable routing rationale."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid", strict=True)
+
+    task_id: Identifier
+    agent_id: Identifier
+    selected_skill_ids: tuple[Identifier, ...] = Field(max_length=64)
+    selected_tool_ids: tuple[Identifier, ...] = Field(max_length=64)
+    selected_mcp_capabilities: tuple[Identifier, ...] = Field(max_length=64)
+    required_permissions: frozenset[Permission] = Field(max_length=11)
+    rationale: tuple[str, ...] = Field(min_length=1, max_length=16)
+
+
+class CapabilityRouter:
+    """Select only registered capabilities authorized by the agent context."""
+
+    def __init__(
+        self,
+        skills: SkillRegistry,
+        tools: ToolRegistry,
+        mcp: MCPRegistry,
+    ) -> None:
+        self._skills = skills
+        self._tools = tools
+        self._mcp = mcp
+        self._skill_selector = SkillSelector(skills)
+
+    def plan(self, request: CapabilityRoutingRequest) -> CapabilityPlan:
+        """Build one deterministic plan without executing or mutating capabilities."""
+        if type(request) is not CapabilityRoutingRequest:
+            raise ValueError("capability routing request is invalid")
+        validated = CapabilityRoutingRequest.model_validate(request.model_dump(), strict=True)
+        skill_matches = self._skill_selector.select(
+            SkillSelectionRequest(
+                task_description=validated.task_description,
+                agent_role=validated.agent_role,
+                domains=validated.domains,
+                technologies=validated.technologies,
+                tags=validated.tags,
+                available_permissions=validated.available_permissions,
+                max_results=64,
+            )
+        )
+        selected_skills = tuple(match.skill_id for match in skill_matches)
+        selected_tools = self._select_tools(
+            validated.requested_tools, validated.available_permissions
+        )
+        available_mcp = self._mcp.discover(validated.available_permissions)
+        selected_mcp = tuple(
+            capability
+            for capability in sorted(validated.requested_mcp_capabilities)
+            if capability in available_mcp
+        )
+        permissions = self._required_permissions(
+            selected_skills, selected_tools, selected_mcp, validated.available_permissions
+        )
+        permissions = frozenset(
+            permissions
+            | self._mcp.required_permissions(selected_mcp, validated.available_permissions)
+        )
+        return CapabilityPlan(
+            task_id=validated.task_id,
+            agent_id=validated.agent_id,
+            selected_skill_ids=selected_skills,
+            selected_tool_ids=selected_tools,
+            selected_mcp_capabilities=selected_mcp,
+            required_permissions=permissions,
+            rationale=(
+                "Skills ranked by deterministic metadata relevance and permission prerequisites.",
+                "Tools selected only from the explicit registry and active permissions.",
+                "MCP capabilities selected only from healthy allowlisted registry entries.",
+            ),
+        )
+
+    def _select_tools(
+        self, requested: Iterable[str], permissions: frozenset[Permission]
+    ) -> tuple[str, ...]:
+        available = {definition.name: definition for definition in self._tools.definitions}
+        unknown = sorted(set(requested) - available.keys())
+        if unknown:
+            raise ValueError("requested tool is not registered")
+        return tuple(
+            name
+            for name in sorted(requested)
+            if available[name].required_permissions.issubset(permissions)
+        )
+
+    def _required_permissions(
+        self,
+        skill_ids: tuple[str, ...],
+        tool_ids: tuple[str, ...],
+        mcp_ids: tuple[str, ...],
+        available: frozenset[Permission],
+    ) -> frozenset[Permission]:
+        required = {
+            permission
+            for skill in self._skills.definitions
+            if skill.id in skill_ids
+            for permission in skill.required_permissions
+        }
+        required.update(
+            permission
+            for tool in self._tools.definitions
+            if tool.name in tool_ids
+            for permission in tool.required_permissions
+        )
+        del mcp_ids
+        return frozenset(permission for permission in required if permission in available)

--- a/core/mcp/types.py
+++ b/core/mcp/types.py
@@ -173,6 +173,17 @@ class MCPRegistry:
             raise MCPRouterError("MCP capability is unavailable.")
         return candidates[0]
 
+    def required_permissions(
+        self, capabilities: Sequence[str], permissions: frozenset[Permission]
+    ) -> frozenset[Permission]:
+        """Return the permissions required by resolved capabilities."""
+        required: set[Permission] = set()
+        for capability in capabilities:
+            server, definition = self.resolve(capability, permissions)
+            required.update(server.required_permissions)
+            required.update(definition.required_permissions)
+        return frozenset(required)
+
 
 class MCPRouter:
     """Route capability requests through allowlisted, healthy MCP definitions."""

--- a/tests/capability_router/__init__.py
+++ b/tests/capability_router/__init__.py
@@ -1,0 +1,1 @@
+"""Phase 32 capability router tests."""

--- a/tests/capability_router/test_router.py
+++ b/tests/capability_router/test_router.py
@@ -1,0 +1,113 @@
+"""Tests for deterministic capability planning."""
+
+from __future__ import annotations
+
+import pytest
+
+from core.capability_router import CapabilityRouter, CapabilityRoutingRequest
+from core.enums import Permission
+from core.mcp import MCPCapability, MCPHealthStatus, MCPRegistry, MCPServerDefinition
+from core.skills import Skill, SkillMetadata, SkillRegistry
+from core.tools import ToolRegistry
+from tests.tools.fakes import FakeTool
+
+
+def _skill() -> Skill:
+    return Skill(
+        metadata=SkillMetadata(
+            id="python-testing",
+            name="Python testing",
+            description="Write reliable Python tests.",
+            domains=frozenset({"backend"}),
+            technologies=frozenset({"python"}),
+            tags=frozenset({"testing"}),
+            version="1.0.0",
+            recommended_tool_ids=frozenset({"fake_read"}),
+            required_permissions=frozenset({Permission.FILESYSTEM_READ}),
+        ),
+        instructions="Use deterministic tests.",
+    )
+
+
+def _mcp_registry() -> MCPRegistry:
+    return MCPRegistry(
+        (
+            MCPServerDefinition(
+                server_id="git-server",
+                display_name="Git MCP",
+                allowlisted=True,
+                status=MCPHealthStatus.HEALTHY,
+                required_permissions=frozenset({Permission.GIT_READ}),
+                capabilities=(
+                    MCPCapability(
+                        name="repository.read",
+                        description="Read repository metadata.",
+                        required_permissions=frozenset({Permission.GIT_READ}),
+                    ),
+                ),
+                timeout_seconds=5.0,
+            ),
+        )
+    )
+
+
+def _request(**overrides: object) -> CapabilityRoutingRequest:
+    values: dict[str, object] = {
+        "task_id": "task-001",
+        "agent_id": "agent-001",
+        "task_description": "Test the Python backend repository.",
+        "agent_role": "Backend Engineer",
+        "domains": frozenset({"backend"}),
+        "technologies": frozenset({"python"}),
+        "tags": frozenset({"testing"}),
+        "available_permissions": frozenset({Permission.FILESYSTEM_READ, Permission.GIT_READ}),
+        "requested_tools": frozenset({"fake_read"}),
+        "requested_mcp_capabilities": frozenset({"repository.read"}),
+    }
+    values.update(overrides)
+    return CapabilityRoutingRequest.model_validate(values)
+
+
+def test_router_returns_deterministic_plan_across_registries() -> None:
+    router = CapabilityRouter(
+        SkillRegistry((_skill(),)), ToolRegistry((FakeTool(),)), _mcp_registry()
+    )
+
+    first = router.plan(_request())
+    second = router.plan(_request())
+
+    assert first == second
+    assert first.selected_skill_ids == ("python-testing",)
+    assert first.selected_tool_ids == ("fake_read",)
+    assert first.selected_mcp_capabilities == ("repository.read",)
+    assert first.required_permissions == frozenset(
+        {Permission.FILESYSTEM_READ, Permission.GIT_READ}
+    )
+    assert first.rationale
+
+
+def test_router_never_selects_capability_without_permission() -> None:
+    router = CapabilityRouter(
+        SkillRegistry((_skill(),)), ToolRegistry((FakeTool(),)), _mcp_registry()
+    )
+
+    plan = router.plan(
+        _request(
+            available_permissions=frozenset(),
+            requested_mcp_capabilities=frozenset(),
+        )
+    )
+
+    assert plan.selected_skill_ids == ()
+    assert plan.selected_tool_ids == ()
+    assert plan.selected_mcp_capabilities == ()
+    assert plan.required_permissions == frozenset()
+
+
+def test_router_rejects_unknown_requested_capability() -> None:
+    router = CapabilityRouter(
+        SkillRegistry((_skill(),)), ToolRegistry((FakeTool(),)), _mcp_registry()
+    )
+
+    with pytest.raises(ValueError):
+        router.plan(_request(requested_tools=frozenset({"unknown-tool"})))


### PR DESCRIPTION
## Summary
- add bounded task, agent, and project capability routing contracts
- select skills through deterministic relevance and permission filtering
- select registered tools and healthy allowlisted MCP capabilities only
- return required permissions and explainable rationale

## Validation
- 2019 tests passed
- Ruff and strict mypy passed
- formatting and diff checks passed

Phase 33 is not included.