### PR TITLE
feat(feedback): add verified client feedback pipeline

### DIFF
--- a/SYNAPSEOS_DEVELOPMENT_CHECKLIST.md
+++ b/SYNAPSEOS_DEVELOPMENT_CHECKLIST.md
@@ -2142,6 +2142,15 @@ ne jamais pénaliser automatiquement un agent uniquement à partir du texte du c
 Une plainte doit être confirmée/analysée avant impact réputationnel.
 ```
 
+## Implementation plan
+
+- [x] Define bounded ClientFeedback and FeedbackCategory contracts
+- [x] Classify feedback deterministically without model or reputation side effects
+- [x] Keep root-cause analysis and responsibility assessment separate from client text
+- [x] Create corrective actions only after independent confirmation
+- [x] Prevent automatic reputation impact for unconfirmed complaints
+- [x] Verify full tests, Ruff, formatting, and strict mypy
+
 ---
 
 # PHASE 34 — Promotions, rétrogradations et autonomie

--- a/core/feedback/__init__.py
+++ b/core/feedback/__init__.py
@@ -1,0 +1,25 @@
+"""Phase 33 bounded client feedback contracts and pipeline."""
+
+from core.feedback.classifier import FeedbackClassifier
+from core.feedback.pipeline import ClientFeedbackPipeline
+from core.feedback.types import (
+    ClientFeedback,
+    CorrectiveAction,
+    FeedbackCase,
+    FeedbackCategory,
+    FeedbackClassification,
+    ResponsibilityAssessment,
+    RootCauseAnalysis,
+)
+
+__all__ = [
+    "ClientFeedback",
+    "ClientFeedbackPipeline",
+    "CorrectiveAction",
+    "FeedbackCase",
+    "FeedbackCategory",
+    "FeedbackClassification",
+    "FeedbackClassifier",
+    "ResponsibilityAssessment",
+    "RootCauseAnalysis",
+]

--- a/core/feedback/classifier.py
+++ b/core/feedback/classifier.py
@@ -1,0 +1,51 @@
+"""Deterministic client feedback classification."""
+
+from __future__ import annotations
+
+import re
+from decimal import Decimal
+
+from core.feedback.types import (
+    ClientFeedback,
+    FeedbackCategory,
+    FeedbackClassification,
+)
+
+_TERMS: dict[FeedbackCategory, frozenset[str]] = {
+    FeedbackCategory.BUG: frozenset({"bug", "error", "broken", "crash"}),
+    FeedbackCategory.UX: frozenset({"confusing", "interface", "usability", "ux"}),
+    FeedbackCategory.PERFORMANCE: frozenset({"slow", "timeout", "latency", "performance"}),
+    FeedbackCategory.SECURITY: frozenset({"security", "vulnerability", "leak", "secret"}),
+    FeedbackCategory.BUSINESS_LOGIC: frozenset({"incorrect", "rule", "calculation", "logic"}),
+    FeedbackCategory.MISSING_FEATURE: frozenset({"feature", "support", "request", "add"}),
+    FeedbackCategory.DOCUMENTATION: frozenset({"documentation", "docs", "guide", "manual"}),
+}
+_WORD_PATTERN = re.compile(r"[a-z0-9]+")
+
+
+class FeedbackClassifier:
+    """Classify feedback by bounded keyword scores without LLM inference."""
+
+    def classify(self, feedback: ClientFeedback) -> FeedbackClassification:
+        if type(feedback) is not ClientFeedback:
+            raise ValueError("feedback is invalid")
+        tokens = frozenset(_WORD_PATTERN.findall(feedback.text.lower()))
+        scored = sorted(
+            (
+                (len(tokens & terms), category, tuple(sorted(tokens & terms)))
+                for category, terms in _TERMS.items()
+            ),
+            key=lambda item: (-item[0], item[1].value),
+        )
+        count, category, matched = scored[0]
+        if count == 0:
+            return FeedbackClassification(
+                category=FeedbackCategory.OTHER,
+                score=Decimal("0.0000"),
+                matched_terms=(),
+            )
+        return FeedbackClassification(
+            category=category,
+            score=Decimal("1.0000"),
+            matched_terms=matched,
+        )

--- a/core/feedback/pipeline.py
+++ b/core/feedback/pipeline.py
@@ -1,0 +1,47 @@
+"""Verified client feedback pipeline with no automatic reputation mutation."""
+
+from __future__ import annotations
+
+from core.feedback.classifier import FeedbackClassifier
+from core.feedback.types import (
+    ClientFeedback,
+    CorrectiveAction,
+    FeedbackCase,
+    ResponsibilityAssessment,
+    RootCauseAnalysis,
+)
+
+
+class ClientFeedbackPipeline:
+    """Combine classification and independent verification into one case."""
+
+    def __init__(self, classifier: FeedbackClassifier | None = None) -> None:
+        self._classifier = classifier or FeedbackClassifier()
+
+    def build_case(
+        self,
+        feedback: ClientFeedback,
+        root_cause: RootCauseAnalysis,
+        responsibility: ResponsibilityAssessment,
+    ) -> FeedbackCase:
+        if type(feedback) is not ClientFeedback:
+            raise ValueError("feedback is invalid")
+        classification = self._classifier.classify(feedback)
+        if root_cause.category is not classification.category:
+            raise ValueError("root cause category does not match classification")
+        confirmed = root_cause.confirmed and responsibility.confirmed
+        action = None
+        if confirmed and responsibility.agent_ids:
+            action = CorrectiveAction(
+                category=classification.category,
+                owner_agent_id=responsibility.agent_ids[0],
+                title=f"Remediate confirmed {classification.category.value.lower()} feedback",
+            )
+        return FeedbackCase(
+            feedback=feedback,
+            classification=classification,
+            root_cause=root_cause,
+            responsibility=responsibility,
+            reputation_impact_allowed=confirmed,
+            corrective_action=action,
+        )

--- a/core/feedback/types.py
+++ b/core/feedback/types.py
@@ -1,0 +1,99 @@
+"""Immutable contracts for the Phase 33 client feedback pipeline."""
+
+from __future__ import annotations
+
+from decimal import Decimal
+from enum import StrEnum
+from typing import Annotated
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+Identifier = Annotated[str, Field(pattern=r"^[a-z0-9][a-z0-9._:-]{0,127}$")]
+Score = Annotated[Decimal, Field(ge=Decimal("0"), le=Decimal("1"), allow_inf_nan=False)]
+
+
+class FeedbackCategory(StrEnum):
+    BUG = "BUG"
+    UX = "UX"
+    PERFORMANCE = "PERFORMANCE"
+    SECURITY = "SECURITY"
+    BUSINESS_LOGIC = "BUSINESS_LOGIC"
+    MISSING_FEATURE = "MISSING_FEATURE"
+    DOCUMENTATION = "DOCUMENTATION"
+    OTHER = "OTHER"
+
+
+class ClientFeedback(BaseModel):
+    """Bounded raw client feedback; text alone has no reputation effect."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid", strict=True)
+
+    feedback_id: Identifier
+    project_id: Identifier
+    task_id: Identifier
+    text: str = Field(min_length=1, max_length=8_192)
+    submitted_by: Identifier
+
+    @field_validator("text")
+    @classmethod
+    def require_nonblank_text(cls, value: str) -> str:
+        value = value.strip()
+        if not value:
+            raise ValueError("feedback text must not be blank")
+        return value
+
+
+class FeedbackClassification(BaseModel):
+    """Deterministic category result with matched evidence terms."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid", strict=True)
+
+    category: FeedbackCategory
+    score: Score
+    matched_terms: tuple[str, ...] = Field(max_length=16)
+
+
+class RootCauseAnalysis(BaseModel):
+    """Independent analysis that can confirm or reject a client claim."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid", strict=True)
+
+    category: FeedbackCategory
+    summary: str = Field(min_length=1, max_length=2_048)
+    confirmed: bool
+    evidence_ids: tuple[Identifier, ...] = Field(min_length=1, max_length=16)
+    confidence: Score
+
+
+class ResponsibilityAssessment(BaseModel):
+    """Evidence-based attribution, separate from client text."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid", strict=True)
+
+    decision_ids: tuple[Identifier, ...] = Field(max_length=16)
+    agent_ids: tuple[Identifier, ...] = Field(max_length=16)
+    confirmed: bool
+    rationale: str = Field(min_length=1, max_length=2_048)
+
+
+class CorrectiveAction(BaseModel):
+    """One explicit action for a confirmed feedback case."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid", strict=True)
+
+    category: FeedbackCategory
+    owner_agent_id: Identifier
+    title: str = Field(min_length=1, max_length=255)
+
+
+class FeedbackCase(BaseModel):
+    """Feedback classification and verified accountability state."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid", strict=True)
+
+    feedback: ClientFeedback
+    classification: FeedbackClassification
+    root_cause: RootCauseAnalysis
+    responsibility: ResponsibilityAssessment
+    reputation_impact_allowed: bool
+    corrective_action: CorrectiveAction | None = None

--- a/tests/feedback/__init__.py
+++ b/tests/feedback/__init__.py
@@ -1,0 +1,1 @@
+"""Phase 33 client feedback tests."""

--- a/tests/feedback/test_pipeline.py
+++ b/tests/feedback/test_pipeline.py
@@ -1,0 +1,101 @@
+"""Tests for the bounded client feedback pipeline."""
+
+from __future__ import annotations
+
+from decimal import Decimal
+
+import pytest
+
+from core.feedback import (
+    ClientFeedback,
+    ClientFeedbackPipeline,
+    CorrectiveAction,
+    FeedbackCategory,
+    FeedbackClassifier,
+    ResponsibilityAssessment,
+    RootCauseAnalysis,
+)
+
+
+def _feedback(text: str) -> ClientFeedback:
+    return ClientFeedback(
+        feedback_id="feedback-001",
+        project_id="project-001",
+        task_id="task-001",
+        text=text,
+        submitted_by="client-001",
+    )
+
+
+def test_classifier_uses_deterministic_category_scores() -> None:
+    result = FeedbackClassifier().classify(_feedback("The checkout is slow and times out."))
+
+    assert result.category is FeedbackCategory.PERFORMANCE
+    assert result.score == Decimal("1.0000")
+    assert "slow" in result.matched_terms
+
+
+@pytest.mark.parametrize(
+    ("text", "category"),
+    [
+        ("There is a bug and error in checkout.", FeedbackCategory.BUG),
+        ("The interface is confusing to use.", FeedbackCategory.UX),
+        ("This is a new feature request.", FeedbackCategory.MISSING_FEATURE),
+        ("Please improve the documentation.", FeedbackCategory.DOCUMENTATION),
+        ("The payment rule is incorrect.", FeedbackCategory.BUSINESS_LOGIC),
+        ("A security vulnerability was found.", FeedbackCategory.SECURITY),
+        ("Something else happened.", FeedbackCategory.OTHER),
+    ],
+)
+def test_classifier_covers_all_feedback_categories(text: str, category: FeedbackCategory) -> None:
+    assert FeedbackClassifier().classify(_feedback(text)).category is category
+
+
+def test_pipeline_requires_confirmed_analysis_before_reputation_impact() -> None:
+    feedback = _feedback("The agent delivered a bug in checkout.")
+    analysis = RootCauseAnalysis(
+        category=FeedbackCategory.BUG,
+        summary="The reported defect is reproducible.",
+        confirmed=False,
+        evidence_ids=("test-run-001",),
+        confidence=Decimal("0.80"),
+    )
+    responsibility = ResponsibilityAssessment(
+        decision_ids=("decision-001",),
+        agent_ids=("agent-001",),
+        confirmed=False,
+        rationale="Attribution is not yet verified.",
+    )
+
+    case = ClientFeedbackPipeline().build_case(feedback, analysis, responsibility)
+
+    assert case.classification.category is FeedbackCategory.BUG
+    assert case.reputation_impact_allowed is False
+    assert case.corrective_action is None
+
+
+def test_confirmed_case_creates_explicit_corrective_action_without_score_mutation() -> None:
+    analysis = RootCauseAnalysis(
+        category=FeedbackCategory.SECURITY,
+        summary="The vulnerability is confirmed by the security scan.",
+        confirmed=True,
+        evidence_ids=("security-scan-001",),
+        confidence=Decimal("1.00"),
+    )
+    responsibility = ResponsibilityAssessment(
+        decision_ids=("decision-001",),
+        agent_ids=("agent-001",),
+        confirmed=True,
+        rationale="The responsible decision and agent are evidenced.",
+    )
+
+    case = ClientFeedbackPipeline().build_case(
+        _feedback("Security issue"), analysis, responsibility
+    )
+
+    assert case.reputation_impact_allowed is True
+    assert case.corrective_action == CorrectiveAction(
+        category=FeedbackCategory.SECURITY,
+        owner_agent_id="agent-001",
+        title="Remediate confirmed security feedback",
+    )


### PR DESCRIPTION
## Summary
- add bounded ClientFeedback and category contracts
- classify feedback deterministically across all Phase 33 categories
- separate root-cause analysis and responsibility assessment
- create corrective actions only after independent confirmation
- prevent automatic reputation penalties from unconfirmed client text

## Validation
- 2029 tests passed
- Ruff and strict mypy passed
- formatting and diff checks passed

Phase 34 is not included.