### PR TITLE
feat(career): add non-mutating autonomy policy

### DIFF
--- a/SYNAPSEOS_DEVELOPMENT_CHECKLIST.md
+++ b/SYNAPSEOS_DEVELOPMENT_CHECKLIST.md
@@ -2161,21 +2161,31 @@ Adapter les responsabilités selon les performances.
 
 ## Niveaux
 
-- [ ] Trainee
-- [ ] Junior
-- [ ] Engineer
-- [ ] Senior
-- [ ] Staff
-- [ ] Principal
+- [x] Trainee
+- [x] Junior
+- [x] Engineer
+- [x] Senior
+- [x] Staff
+- [x] Principal
 
 ## Actions possibles
 
-- [ ] promotion
-- [ ] rétrogradation
-- [ ] autonomie réduite
-- [ ] review obligatoire
-- [ ] perte d'une capability
-- [ ] mentoring
+- [x] promotion
+- [x] rétrogradation
+- [x] autonomie réduite
+- [x] review obligatoire
+- [x] perte d'une capability
+- [x] mentoring
+
+## Implementation plan
+
+- [x] Define bounded observed career metrics
+- [x] Produce deterministic promotion and demotion recommendations
+- [x] Produce autonomy increase and reduction recommendations
+- [x] Produce mandatory review, capability restriction, and mentoring recommendations
+- [x] Require human approval for every recommendation
+- [x] Keep the engine non-mutating and auditable through evidence fields
+- [x] Verify full tests, Ruff, formatting, and strict mypy
 
 ## Prompt Claude Code — Phase 34
 

--- a/core/career/__init__.py
+++ b/core/career/__init__.py
@@ -1,0 +1,17 @@
+"""Phase 34 career and autonomy policy engine."""
+
+from core.career.policy import CareerAutonomyPolicyEngine
+from core.career.types import (
+    CareerAction,
+    CareerMetrics,
+    CareerPolicyResult,
+    CareerRecommendation,
+)
+
+__all__ = [
+    "CareerAction",
+    "CareerAutonomyPolicyEngine",
+    "CareerMetrics",
+    "CareerPolicyResult",
+    "CareerRecommendation",
+]

--- a/core/career/policy.py
+++ b/core/career/policy.py
@@ -1,0 +1,124 @@
+"""Deterministic non-mutating career and autonomy recommendations."""
+
+from __future__ import annotations
+
+from core.career.types import (
+    CareerAction,
+    CareerMetrics,
+    CareerPolicyResult,
+    CareerRecommendation,
+)
+from core.enums import AgentSeniority
+
+_ORDER = (
+    AgentSeniority.TRAINEE,
+    AgentSeniority.JUNIOR,
+    AgentSeniority.ENGINEER,
+    AgentSeniority.SENIOR,
+    AgentSeniority.STAFF,
+    AgentSeniority.PRINCIPAL,
+)
+
+
+class CareerAutonomyPolicyEngine:
+    """Recommend career changes from observed metrics without applying them."""
+
+    def recommend(self, metrics: CareerMetrics) -> CareerPolicyResult:
+        if type(metrics) is not CareerMetrics:
+            raise ValueError("career metrics are invalid")
+        recommendations: list[CareerRecommendation] = []
+        strong = (
+            metrics.success_rate >= 0.90
+            and metrics.reliability >= 0.90
+            and metrics.calibration_score >= 0.85
+            and metrics.review_failures == 0
+            and metrics.high_risk_incidents == 0
+        )
+        weak = metrics.success_rate < 0.60 or metrics.reliability < 0.60
+        incident = metrics.high_risk_incidents > 0
+        current_index = _ORDER.index(metrics.seniority)
+        if strong and current_index < len(_ORDER) - 1:
+            recommendations.append(
+                _recommendation(
+                    metrics,
+                    CareerAction.PROMOTION,
+                    "Observed delivery and reliability support a seniority review.",
+                    ("success_rate", "reliability", "calibration_score"),
+                    proposed_seniority=_ORDER[current_index + 1],
+                )
+            )
+        if strong and metrics.autonomy_level < 5:
+            recommendations.append(
+                _recommendation(
+                    metrics,
+                    CareerAction.AUTONOMY_INCREASE,
+                    "Stable verified performance supports an autonomy review.",
+                    ("success_rate", "reliability", "zero_incidents"),
+                    proposed_autonomy_level=metrics.autonomy_level + 1,
+                )
+            )
+        if weak:
+            recommendations.append(
+                _recommendation(
+                    metrics,
+                    CareerAction.DEMOTION,
+                    "Observed reliability is below the demotion review threshold.",
+                    ("success_rate", "reliability"),
+                    proposed_seniority=_ORDER[max(0, current_index - 1)],
+                )
+            )
+            recommendations.append(
+                _recommendation(
+                    metrics,
+                    CareerAction.AUTONOMY_REDUCTION,
+                    "Observed reliability requires a narrower autonomy review.",
+                    ("success_rate", "reliability"),
+                    proposed_autonomy_level=max(0, metrics.autonomy_level - 1),
+                )
+            )
+        if incident or metrics.review_failures > 0:
+            recommendations.append(
+                _recommendation(
+                    metrics,
+                    CareerAction.MANDATORY_REVIEW,
+                    "A review is required before expanding responsibility.",
+                    ("high_risk_incidents", "review_failures"),
+                )
+            )
+            recommendations.append(
+                _recommendation(
+                    metrics,
+                    CareerAction.CAPABILITY_RESTRICTION,
+                    "Capabilities linked to unresolved risk require temporary restriction.",
+                    ("high_risk_incidents",),
+                )
+            )
+        if weak or incident:
+            recommendations.append(
+                _recommendation(
+                    metrics,
+                    CareerAction.MENTORING,
+                    "Observed risk or performance weakness requires mentoring support.",
+                    ("success_rate", "reliability", "high_risk_incidents"),
+                )
+            )
+        return CareerPolicyResult(agent_id=metrics.agent_id, recommendations=tuple(recommendations))
+
+
+def _recommendation(
+    metrics: CareerMetrics,
+    action: CareerAction,
+    reason: str,
+    evidence: tuple[str, ...],
+    *,
+    proposed_seniority: AgentSeniority | None = None,
+    proposed_autonomy_level: int | None = None,
+) -> CareerRecommendation:
+    return CareerRecommendation(
+        agent_id=metrics.agent_id,
+        action=action,
+        reason=reason,
+        evidence=evidence,
+        proposed_seniority=proposed_seniority,
+        proposed_autonomy_level=proposed_autonomy_level,
+    )

--- a/core/career/types.py
+++ b/core/career/types.py
@@ -1,0 +1,64 @@
+"""Immutable career and autonomy policy contracts."""
+
+from __future__ import annotations
+
+from decimal import Decimal
+from enum import StrEnum
+from typing import Annotated
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from core.enums import AgentSeniority
+
+Score = Annotated[Decimal, Field(ge=Decimal("0"), le=Decimal("1"), allow_inf_nan=False)]
+Identifier = Annotated[str, Field(pattern=r"^[a-z0-9][a-z0-9._:-]{0,127}$")]
+
+
+class CareerAction(StrEnum):
+    PROMOTION = "PROMOTION"
+    DEMOTION = "DEMOTION"
+    AUTONOMY_INCREASE = "AUTONOMY_INCREASE"
+    AUTONOMY_REDUCTION = "AUTONOMY_REDUCTION"
+    MANDATORY_REVIEW = "MANDATORY_REVIEW"
+    CAPABILITY_RESTRICTION = "CAPABILITY_RESTRICTION"
+    MENTORING = "MENTORING"
+
+
+class CareerMetrics(BaseModel):
+    """Observed bounded metrics used for one recommendation snapshot."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid", strict=True)
+
+    agent_id: Identifier
+    seniority: AgentSeniority
+    autonomy_level: int = Field(ge=0, le=5)
+    success_rate: Score
+    reliability: Score
+    review_failures: int = Field(ge=0, le=1_000)
+    high_risk_incidents: int = Field(ge=0, le=1_000)
+    calibration_score: Score
+    active_capabilities: tuple[Identifier, ...] = Field(max_length=64)
+
+
+class CareerRecommendation(BaseModel):
+    """Auditable recommendation that never mutates the agent."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid", strict=True)
+
+    agent_id: Identifier
+    action: CareerAction
+    reason: str = Field(min_length=1, max_length=1_024)
+    evidence: tuple[str, ...] = Field(min_length=1, max_length=8)
+    proposed_seniority: AgentSeniority | None = None
+    proposed_autonomy_level: int | None = Field(default=None, ge=0, le=5)
+    requires_human_approval: bool = True
+
+
+class CareerPolicyResult(BaseModel):
+    """Ordered recommendations for one immutable metrics snapshot."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid", strict=True)
+
+    agent_id: Identifier
+    recommendations: tuple[CareerRecommendation, ...] = Field(max_length=8)
+    applied: bool = False

--- a/tests/career/__init__.py
+++ b/tests/career/__init__.py
@@ -1,0 +1,1 @@
+"""Phase 34 career and autonomy tests."""

--- a/tests/career/test_policy.py
+++ b/tests/career/test_policy.py
@@ -1,0 +1,70 @@
+"""Tests for the non-mutating career and autonomy policy engine."""
+
+from __future__ import annotations
+
+from decimal import Decimal
+
+from core.career import (
+    CareerAction,
+    CareerAutonomyPolicyEngine,
+    CareerMetrics,
+)
+from core.enums import AgentSeniority
+
+
+def _metrics(**overrides: object) -> CareerMetrics:
+    values: dict[str, object] = {
+        "agent_id": "agent-001",
+        "seniority": AgentSeniority.ENGINEER,
+        "autonomy_level": 2,
+        "success_rate": Decimal("0.95"),
+        "reliability": Decimal("0.95"),
+        "review_failures": 0,
+        "high_risk_incidents": 0,
+        "calibration_score": Decimal("0.90"),
+        "active_capabilities": ("backend", "testing"),
+    }
+    values.update(overrides)
+    return CareerMetrics.model_validate(values)
+
+
+def test_strong_observed_metrics_recommend_but_do_not_apply_promotion() -> None:
+    result = CareerAutonomyPolicyEngine().recommend(_metrics())
+
+    assert result.applied is False
+    assert [item.action for item in result.recommendations] == [
+        CareerAction.PROMOTION,
+        CareerAction.AUTONOMY_INCREASE,
+    ]
+    assert result.recommendations[0].proposed_seniority is AgentSeniority.SENIOR
+    assert result.recommendations[1].proposed_autonomy_level == 3
+    assert all(item.requires_human_approval for item in result.recommendations)
+
+
+def test_incidents_recommend_restriction_review_and_mentoring() -> None:
+    result = CareerAutonomyPolicyEngine().recommend(
+        _metrics(
+            success_rate=Decimal("0.40"),
+            reliability=Decimal("0.50"),
+            high_risk_incidents=2,
+            active_capabilities=("backend", "payments"),
+        )
+    )
+
+    actions = {item.action for item in result.recommendations}
+    assert CareerAction.DEMOTION in actions
+    assert CareerAction.AUTONOMY_REDUCTION in actions
+    assert CareerAction.MANDATORY_REVIEW in actions
+    assert CareerAction.CAPABILITY_RESTRICTION in actions
+    assert CareerAction.MENTORING in actions
+
+
+def test_policy_is_deterministic_and_never_mutates_input() -> None:
+    metrics = _metrics()
+
+    first = CareerAutonomyPolicyEngine().recommend(metrics)
+    second = CareerAutonomyPolicyEngine().recommend(metrics)
+
+    assert first == second
+    assert metrics.autonomy_level == 2
+    assert metrics.seniority is AgentSeniority.ENGINEER


### PR DESCRIPTION
## Summary
- add bounded observed career metrics and seniority ladder
- produce deterministic promotion, demotion, autonomy, review, restriction, and mentoring recommendations
- require human approval and keep the engine non-mutating

## Validation
- 2032 tests passed
- Ruff and strict mypy passed
- formatting and diff checks passed

Phase 35 is not included.