### PR TITLE
feat(budget): add usage accounting and budget enforcement

### DIFF
--- a/SYNAPSEOS_DEVELOPMENT_CHECKLIST.md
+++ b/SYNAPSEOS_DEVELOPMENT_CHECKLIST.md
@@ -2312,14 +2312,14 @@ Ne modifie pas les scores uniquement pour produire des félicitations.
 
 ## Mesures
 
-- [ ] tokens
-- [ ] appels LLM
-- [ ] temps
-- [ ] tool calls
-- [ ] CPU/GPU
-- [ ] provider cost
-- [ ] budget projet
-- [ ] budget agent
+- [x] tokens
+- [x] appels LLM
+- [x] temps
+- [x] tool calls
+- [x] CPU/GPU
+- [x] provider cost
+- [x] budget projet
+- [x] budget agent
 
 ## Prompt Claude Code — Phase 37
 

--- a/alembic/versions/20260910_0007_usage_records.py
+++ b/alembic/versions/20260910_0007_usage_records.py
@@ -1,0 +1,107 @@
+"""Add append-only usage records for Phase 37.
+
+Revision ID: 20260910_0007
+Revises: 20260910_0006
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+from alembic import op
+
+revision: str = "20260910_0007"
+down_revision: str | Sequence[str] | None = "20260910_0006"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    enum_type = postgresql.ENUM("LLM_REQUEST", "TOOL_CALL", name="usage_kind")
+    enum_type.create(op.get_bind(), checkfirst=True)
+    usage_kind = postgresql.ENUM("LLM_REQUEST", "TOOL_CALL", name="usage_kind", create_type=False)
+    op.create_table(
+        "usage_records",
+        sa.Column("project_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("task_id", postgresql.UUID(as_uuid=True), nullable=True),
+        sa.Column("run_id", postgresql.UUID(as_uuid=True), nullable=True),
+        sa.Column("agent_id", postgresql.UUID(as_uuid=True), nullable=True),
+        sa.Column("kind", usage_kind, nullable=False),
+        sa.Column("provider", sa.String(length=255), nullable=True),
+        sa.Column("model", sa.String(length=255), nullable=True),
+        sa.Column("input_tokens", sa.Integer(), nullable=True),
+        sa.Column("output_tokens", sa.Integer(), nullable=True),
+        sa.Column(
+            "duration_ms", sa.Numeric(precision=16, scale=3), server_default="0", nullable=False
+        ),
+        sa.Column("tool_calls", sa.Integer(), server_default="0", nullable=False),
+        sa.Column("cpu_ms", sa.Numeric(precision=16, scale=3), server_default="0", nullable=False),
+        sa.Column("gpu_ms", sa.Numeric(precision=16, scale=3), server_default="0", nullable=False),
+        sa.Column("provider_cost", sa.Numeric(precision=16, scale=8), nullable=True),
+        sa.Column("metadata", postgresql.JSONB(), server_default="{}", nullable=False),
+        sa.Column("id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.CheckConstraint(
+            "input_tokens IS NULL OR input_tokens >= 0",
+            name=op.f("ck_usage_records_input_tokens_nonnegative"),
+        ),
+        sa.CheckConstraint(
+            "output_tokens IS NULL OR output_tokens >= 0",
+            name=op.f("ck_usage_records_output_tokens_nonnegative"),
+        ),
+        sa.CheckConstraint("duration_ms >= 0", name=op.f("ck_usage_records_duration_nonnegative")),
+        sa.CheckConstraint("tool_calls >= 0", name=op.f("ck_usage_records_tool_calls_nonnegative")),
+        sa.CheckConstraint("cpu_ms >= 0", name=op.f("ck_usage_records_cpu_nonnegative")),
+        sa.CheckConstraint("gpu_ms >= 0", name=op.f("ck_usage_records_gpu_nonnegative")),
+        sa.CheckConstraint(
+            "provider_cost IS NULL OR provider_cost >= 0",
+            name=op.f("ck_usage_records_provider_cost_nonnegative"),
+        ),
+        sa.ForeignKeyConstraint(
+            ["project_id"],
+            ["projects.id"],
+            ondelete="RESTRICT",
+            name=op.f("fk_usage_records_project_id_projects"),
+        ),
+        sa.ForeignKeyConstraint(
+            ["task_id"],
+            ["tasks.id"],
+            ondelete="RESTRICT",
+            name=op.f("fk_usage_records_task_id_tasks"),
+        ),
+        sa.ForeignKeyConstraint(
+            ["run_id"],
+            ["agent_runs.id"],
+            ondelete="RESTRICT",
+            name=op.f("fk_usage_records_run_id_agent_runs"),
+        ),
+        sa.ForeignKeyConstraint(
+            ["agent_id"],
+            ["agents.id"],
+            ondelete="RESTRICT",
+            name=op.f("fk_usage_records_agent_id_agents"),
+        ),
+        sa.PrimaryKeyConstraint("id", name=op.f("pk_usage_records")),
+    )
+    op.create_index(
+        "ix_usage_records_project_created", "usage_records", ["project_id", "created_at"]
+    )
+    op.create_index("ix_usage_records_task_created", "usage_records", ["task_id", "created_at"])
+    op.create_index("ix_usage_records_run_created", "usage_records", ["run_id", "created_at"])
+    op.create_index("ix_usage_records_agent_created", "usage_records", ["agent_id", "created_at"])
+    op.create_index("ix_usage_records_kind_created", "usage_records", ["kind", "created_at"])
+
+
+def downgrade() -> None:
+    op.drop_table("usage_records")
+    postgresql.ENUM("LLM_REQUEST", "TOOL_CALL", name="usage_kind").drop(
+        op.get_bind(), checkfirst=True
+    )

--- a/core/budget/__init__.py
+++ b/core/budget/__init__.py
@@ -1,0 +1,27 @@
+"""Provider-neutral usage accounting and budget enforcement."""
+
+from core.budget.calculator import CostCalculator, CostUnavailableError, ProviderRate
+from core.budget.engine import BudgetEngine
+from core.budget.types import (
+    Budget,
+    BudgetDecision,
+    BudgetDecisionOutcome,
+    BudgetPolicy,
+    BudgetScope,
+    UsageKind,
+    UsageRecord,
+)
+
+__all__ = [
+    "Budget",
+    "BudgetDecision",
+    "BudgetDecisionOutcome",
+    "BudgetEngine",
+    "BudgetPolicy",
+    "BudgetScope",
+    "CostCalculator",
+    "CostUnavailableError",
+    "ProviderRate",
+    "UsageKind",
+    "UsageRecord",
+]

--- a/core/budget/calculator.py
+++ b/core/budget/calculator.py
@@ -1,0 +1,46 @@
+"""Deterministic provider-cost calculation."""
+
+from __future__ import annotations
+
+from decimal import Decimal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from core.budget.types import UsageRecord
+
+
+class CostUnavailableError(ValueError):
+    """Raised when provider pricing is not available for a usage record."""
+
+
+class ProviderRate(BaseModel):
+    """Price per 1,000 input/output tokens for one provider model."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid", strict=True)
+
+    provider: str = Field(min_length=1, max_length=255)
+    model: str = Field(min_length=1, max_length=255)
+    input_cost_per_1k: Decimal = Field(ge=0, max_digits=16, decimal_places=8)
+    output_cost_per_1k: Decimal = Field(ge=0, max_digits=16, decimal_places=8)
+
+
+class CostCalculator:
+    """Calculate only from explicit provider rates or recorded provider cost."""
+
+    __slots__ = ("_rates",)
+
+    def __init__(self, rates: tuple[ProviderRate, ...] = ()) -> None:
+        self._rates = {(rate.provider, rate.model): rate for rate in rates}
+
+    def estimate(self, record: UsageRecord) -> Decimal:
+        if record.provider_cost is not None:
+            return record.provider_cost
+        if record.provider is None or record.model is None:
+            raise CostUnavailableError("provider pricing is unavailable")
+        rate = self._rates.get((record.provider, record.model))
+        if rate is None:
+            raise CostUnavailableError("provider pricing is unavailable")
+        return (
+            Decimal(record.input_tokens or 0) * rate.input_cost_per_1k / Decimal(1000)
+            + Decimal(record.output_tokens or 0) * rate.output_cost_per_1k / Decimal(1000)
+        ).quantize(Decimal("0.000001"))

--- a/core/budget/engine.py
+++ b/core/budget/engine.py
@@ -1,0 +1,85 @@
+"""Fail-closed budget gate with no implicit retries or side effects."""
+
+from __future__ import annotations
+
+from decimal import Decimal
+
+from core.budget.types import (
+    Budget,
+    BudgetDecision,
+    BudgetDecisionOutcome,
+    BudgetPolicy,
+    BudgetScope,
+    UsageKind,
+    UsageRecord,
+)
+
+
+class BudgetEngine:
+    """Evaluate one usage event against project, task, run, and agent ceilings."""
+
+    __slots__ = ("_policy",)
+
+    def __init__(self, policy: BudgetPolicy) -> None:
+        self._policy = policy
+
+    def evaluate(
+        self,
+        record: UsageRecord,
+        *,
+        history: tuple[UsageRecord, ...] = (),
+    ) -> BudgetDecision:
+        for budget in self._policy.budgets:
+            if not _matches(budget, record):
+                continue
+            decision = _evaluate_budget(budget, record, history)
+            if decision is not None:
+                return decision
+        return BudgetDecision(
+            outcome=BudgetDecisionOutcome.ALLOW,
+            reason="within budget",
+            escalation_required=False,
+        )
+
+
+def _matches(budget: Budget, record: UsageRecord) -> bool:
+    identifier = {
+        BudgetScope.PROJECT: record.project_id,
+        BudgetScope.TASK: record.task_id,
+        BudgetScope.RUN: record.run_id,
+        BudgetScope.AGENT: record.agent_id,
+    }[budget.scope]
+    return identifier == budget.scope_id
+
+
+def _evaluate_budget(
+    budget: Budget,
+    current: UsageRecord,
+    history: tuple[UsageRecord, ...],
+) -> BudgetDecision | None:
+    scoped = tuple(item for item in history if _matches(budget, item)) + (current,)
+    total_tokens = sum(item.total_tokens for item in scoped)
+    llm_calls = sum(item.kind is UsageKind.LLM_REQUEST for item in scoped)
+    duration_ms = sum(item.duration_ms for item in scoped)
+    tool_calls = sum(item.tool_calls for item in scoped)
+    cpu_ms = sum(item.cpu_ms for item in scoped)
+    gpu_ms = sum(item.gpu_ms for item in scoped)
+    provider_cost = sum((item.provider_cost or Decimal(0) for item in scoped), Decimal(0))
+    checks = (
+        (budget.max_tokens, total_tokens, "token budget exceeded"),
+        (budget.max_llm_calls, llm_calls, "LLM call budget exceeded"),
+        (budget.max_duration_ms, duration_ms, "duration budget exceeded"),
+        (budget.max_tool_calls, tool_calls, "tool-call budget exceeded"),
+        (budget.max_cpu_ms, cpu_ms, "CPU budget exceeded"),
+        (budget.max_gpu_ms, gpu_ms, "GPU budget exceeded"),
+        (budget.max_provider_cost, provider_cost, "provider cost budget exceeded"),
+    )
+    for limit, used, reason in checks:
+        if limit is not None and used > limit:
+            return BudgetDecision(
+                outcome=BudgetDecisionOutcome.STOP,
+                scope=budget.scope,
+                reason=reason,
+                escalation_required=True,
+            )
+    return None

--- a/core/budget/types.py
+++ b/core/budget/types.py
@@ -1,0 +1,120 @@
+"""Immutable contracts for Phase 37 usage and budget control."""
+
+from __future__ import annotations
+
+from decimal import Decimal
+from enum import StrEnum
+from typing import Self
+from uuid import UUID, uuid4
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+
+class _BudgetModel(BaseModel):
+    model_config = ConfigDict(
+        frozen=True,
+        extra="forbid",
+        strict=True,
+        hide_input_in_errors=True,
+        revalidate_instances="always",
+    )
+
+
+class BudgetScope(StrEnum):
+    """Resource scope to which a budget applies."""
+
+    PROJECT = "PROJECT"
+    TASK = "TASK"
+    RUN = "RUN"
+    AGENT = "AGENT"
+
+
+class UsageKind(StrEnum):
+    """Accountable classes of resource consumption."""
+
+    LLM_REQUEST = "LLM_REQUEST"
+    TOOL_CALL = "TOOL_CALL"
+
+
+class UsageRecord(_BudgetModel):
+    """One bounded, attributable usage measurement."""
+
+    id: UUID = Field(default_factory=uuid4)
+    project_id: UUID
+    task_id: UUID | None = None
+    run_id: UUID | None = None
+    agent_id: UUID | None = None
+    kind: UsageKind
+    provider: str | None = Field(default=None, min_length=1, max_length=255)
+    model: str | None = Field(default=None, min_length=1, max_length=255)
+    input_tokens: int | None = Field(default=None, ge=0, le=10_000_000)
+    output_tokens: int | None = Field(default=None, ge=0, le=10_000_000)
+    duration_ms: float = Field(default=0.0, ge=0.0, le=86_400_000.0)
+    tool_calls: int = Field(default=0, ge=0, le=100_000)
+    cpu_ms: float = Field(default=0.0, ge=0.0, le=86_400_000.0)
+    gpu_ms: float = Field(default=0.0, ge=0.0, le=86_400_000.0)
+    provider_cost: Decimal | None = Field(default=None, ge=0, max_digits=16, decimal_places=8)
+
+    @property
+    def total_tokens(self) -> int:
+        return (self.input_tokens or 0) + (self.output_tokens or 0)
+
+
+class Budget(_BudgetModel):
+    """A finite ceiling for one project, task, or run."""
+
+    scope: BudgetScope
+    scope_id: UUID
+    max_tokens: int | None = Field(default=None, ge=0, le=10_000_000_000)
+    max_llm_calls: int | None = Field(default=None, ge=0, le=10_000_000)
+    max_duration_ms: float | None = Field(default=None, ge=0.0, le=86_400_000_000.0)
+    max_tool_calls: int | None = Field(default=None, ge=0, le=10_000_000)
+    max_cpu_ms: float | None = Field(default=None, ge=0.0, le=86_400_000_000.0)
+    max_gpu_ms: float | None = Field(default=None, ge=0.0, le=86_400_000_000.0)
+    max_provider_cost: Decimal | None = Field(default=None, ge=0, max_digits=16, decimal_places=8)
+
+    @model_validator(mode="after")
+    def require_one_limit(self) -> Self:
+        if not any(
+            value is not None
+            for value in (
+                self.max_tokens,
+                self.max_llm_calls,
+                self.max_duration_ms,
+                self.max_tool_calls,
+                self.max_cpu_ms,
+                self.max_gpu_ms,
+                self.max_provider_cost,
+            )
+        ):
+            raise ValueError("budget must define at least one limit")
+        return self
+
+
+class BudgetPolicy(_BudgetModel):
+    """All active ceilings applied to one execution context."""
+
+    budgets: tuple[Budget, ...] = Field(max_length=4)
+
+    @model_validator(mode="after")
+    def require_unique_scopes(self) -> Self:
+        keys = [(budget.scope, budget.scope_id) for budget in self.budgets]
+        if len(keys) != len(set(keys)):
+            raise ValueError("budget scopes must be unique")
+        return self
+
+
+class BudgetDecisionOutcome(StrEnum):
+    """Safe budget gate outcomes."""
+
+    ALLOW = "ALLOW"
+    STOP = "STOP"
+
+
+class BudgetDecision(_BudgetModel):
+    """Explainable result of one pre-execution budget check."""
+
+    outcome: BudgetDecisionOutcome
+    scope: BudgetScope | None = None
+    reason: str = Field(min_length=1, max_length=255)
+    escalation_required: bool

--- a/infrastructure/database/models/__init__.py
+++ b/infrastructure/database/models/__init__.py
@@ -1,5 +1,6 @@
 """Phase 2 SQLAlchemy persistence models."""
 
+from infrastructure.database.models.budget import UsageRecord
 from infrastructure.database.models.execution import AgentRun, Decision, ToolCall
 from infrastructure.database.models.history import AgentScore, AuditEvent
 from infrastructure.database.models.memory import MemoryEntry
@@ -28,4 +29,5 @@ __all__ = [
     "Task",
     "TaskDependency",
     "ToolCall",
+    "UsageRecord",
 ]

--- a/infrastructure/database/models/budget.py
+++ b/infrastructure/database/models/budget.py
@@ -1,0 +1,78 @@
+"""Append-only PostgreSQL usage records for Phase 37."""
+
+from __future__ import annotations
+
+import uuid
+from decimal import Decimal
+from typing import TYPE_CHECKING
+
+from sqlalchemy import CheckConstraint, Enum, ForeignKey, Index, Numeric, String
+from sqlalchemy.dialects.postgresql import JSONB, UUID
+from sqlalchemy.ext.mutable import MutableDict
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from core.budget.types import UsageKind
+from infrastructure.database.append_only import AppendOnlyMixin
+from infrastructure.database.base import Base, CreatedAtMixin, UUIDPrimaryKeyMixin
+
+if TYPE_CHECKING:
+    from infrastructure.database.models.execution import AgentRun
+    from infrastructure.database.models.organization import Agent, Project
+    from infrastructure.database.models.work import Task
+
+
+class UsageRecord(AppendOnlyMixin, UUIDPrimaryKeyMixin, CreatedAtMixin, Base):
+    """One immutable resource-usage measurement attributable to a project."""
+
+    __tablename__ = "usage_records"
+    __table_args__ = (
+        CheckConstraint(
+            "input_tokens IS NULL OR input_tokens >= 0", name="input_tokens_nonnegative"
+        ),
+        CheckConstraint(
+            "output_tokens IS NULL OR output_tokens >= 0", name="output_tokens_nonnegative"
+        ),
+        CheckConstraint("duration_ms >= 0", name="duration_nonnegative"),
+        CheckConstraint("tool_calls >= 0", name="tool_calls_nonnegative"),
+        CheckConstraint("cpu_ms >= 0", name="cpu_nonnegative"),
+        CheckConstraint("gpu_ms >= 0", name="gpu_nonnegative"),
+        CheckConstraint(
+            "provider_cost IS NULL OR provider_cost >= 0", name="provider_cost_nonnegative"
+        ),
+        Index("ix_usage_records_project_created", "project_id", "created_at"),
+        Index("ix_usage_records_task_created", "task_id", "created_at"),
+        Index("ix_usage_records_run_created", "run_id", "created_at"),
+        Index("ix_usage_records_agent_created", "agent_id", "created_at"),
+        Index("ix_usage_records_kind_created", "kind", "created_at"),
+    )
+
+    project_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("projects.id", ondelete="RESTRICT"), nullable=False
+    )
+    task_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("tasks.id", ondelete="RESTRICT"), nullable=True
+    )
+    run_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("agent_runs.id", ondelete="RESTRICT"), nullable=True
+    )
+    agent_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("agents.id", ondelete="RESTRICT"), nullable=True
+    )
+    kind: Mapped[UsageKind] = mapped_column(Enum(UsageKind, name="usage_kind"), nullable=False)
+    provider: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    model: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    input_tokens: Mapped[int | None] = mapped_column(nullable=True)
+    output_tokens: Mapped[int | None] = mapped_column(nullable=True)
+    duration_ms: Mapped[Decimal] = mapped_column(Numeric(16, 3), nullable=False, default=0)
+    tool_calls: Mapped[int] = mapped_column(nullable=False, default=0)
+    cpu_ms: Mapped[Decimal] = mapped_column(Numeric(16, 3), nullable=False, default=0)
+    gpu_ms: Mapped[Decimal] = mapped_column(Numeric(16, 3), nullable=False, default=0)
+    provider_cost: Mapped[Decimal | None] = mapped_column(Numeric(16, 8), nullable=True)
+    metadata_: Mapped[dict[str, object]] = mapped_column(
+        "metadata", MutableDict.as_mutable(JSONB), default=dict, nullable=False
+    )
+
+    project: Mapped[Project] = relationship()
+    task: Mapped[Task | None] = relationship()
+    run: Mapped[AgentRun | None] = relationship()
+    agent: Mapped[Agent | None] = relationship()

--- a/infrastructure/database/repositories/__init__.py
+++ b/infrastructure/database/repositories/__init__.py
@@ -8,6 +8,7 @@ from infrastructure.database.repositories.pull_requests import (
     PullRequestRepository,
     PullRequestReviewRepository,
 )
+from infrastructure.database.repositories.usage_records import UsageRecordRepository
 
 __all__ = [
     "AgentScoreRepository",
@@ -16,4 +17,5 @@ __all__ = [
     "MemoryRepository",
     "PullRequestRepository",
     "PullRequestReviewRepository",
+    "UsageRecordRepository",
 ]

--- a/infrastructure/database/repositories/usage_records.py
+++ b/infrastructure/database/repositories/usage_records.py
@@ -1,0 +1,49 @@
+"""Append-only usage record repository."""
+
+from __future__ import annotations
+
+import uuid
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from core.budget.types import UsageKind
+from infrastructure.database.models import UsageRecord
+
+
+class UsageRecordRepository:
+    """Expose only append and read operations for usage history."""
+
+    def __init__(self, session: Session) -> None:
+        self._session = session
+
+    def add(self, record: UsageRecord) -> UsageRecord:
+        self._session.add(record)
+        return record
+
+    def get_by_id(self, record_id: uuid.UUID) -> UsageRecord | None:
+        return self._session.get(UsageRecord, record_id)
+
+    def list(
+        self,
+        *,
+        project_id: uuid.UUID | None = None,
+        task_id: uuid.UUID | None = None,
+        run_id: uuid.UUID | None = None,
+        agent_id: uuid.UUID | None = None,
+        kind: UsageKind | None = None,
+        limit: int = 100,
+        offset: int = 0,
+    ) -> list[UsageRecord]:
+        statement = select(UsageRecord).order_by(UsageRecord.created_at, UsageRecord.id)
+        if project_id is not None:
+            statement = statement.where(UsageRecord.project_id == project_id)
+        if task_id is not None:
+            statement = statement.where(UsageRecord.task_id == task_id)
+        if run_id is not None:
+            statement = statement.where(UsageRecord.run_id == run_id)
+        if agent_id is not None:
+            statement = statement.where(UsageRecord.agent_id == agent_id)
+        if kind is not None:
+            statement = statement.where(UsageRecord.kind == kind)
+        return list(self._session.scalars(statement.limit(limit).offset(offset)).all())

--- a/tests/budget/__init__.py
+++ b/tests/budget/__init__.py
@@ -1,0 +1,1 @@
+"""Phase 37 budget and cost-control tests."""

--- a/tests/budget/test_engine.py
+++ b/tests/budget/test_engine.py
@@ -1,0 +1,131 @@
+"""Unit tests for safe budget decisions."""
+
+from __future__ import annotations
+
+from decimal import Decimal
+from uuid import uuid4
+
+from core.budget.calculator import CostCalculator, ProviderRate
+from core.budget.engine import BudgetEngine
+from core.budget.types import (
+    Budget,
+    BudgetDecisionOutcome,
+    BudgetPolicy,
+    BudgetScope,
+    UsageKind,
+    UsageRecord,
+)
+
+
+def test_cost_calculator_estimates_input_and_output_provider_cost() -> None:
+    calculator = CostCalculator(
+        rates=(
+            ProviderRate(
+                provider="openai",
+                model="gpt-test",
+                input_cost_per_1k=Decimal("0.01"),
+                output_cost_per_1k=Decimal("0.03"),
+            ),
+        )
+    )
+    record = UsageRecord(
+        project_id=uuid4(),
+        kind=UsageKind.LLM_REQUEST,
+        provider="openai",
+        model="gpt-test",
+        input_tokens=1000,
+        output_tokens=500,
+    )
+
+    assert calculator.estimate(record) == Decimal("0.025000")
+
+
+def test_engine_stops_and_escalates_before_crossing_project_budget() -> None:
+    project_id = uuid4()
+    policy = BudgetPolicy(
+        budgets=(
+            Budget(
+                scope=BudgetScope.PROJECT,
+                scope_id=project_id,
+                max_tokens=100,
+                max_llm_calls=5,
+                max_duration_ms=10_000.0,
+                max_tool_calls=5,
+                max_provider_cost=Decimal("1.00"),
+            ),
+        )
+    )
+    existing = UsageRecord(
+        project_id=project_id,
+        kind=UsageKind.LLM_REQUEST,
+        input_tokens=80,
+        output_tokens=10,
+        provider_cost=Decimal("0.20"),
+    )
+    next_record = UsageRecord(
+        project_id=project_id,
+        kind=UsageKind.LLM_REQUEST,
+        input_tokens=10,
+        output_tokens=5,
+        provider_cost=Decimal("0.10"),
+    )
+
+    decision = BudgetEngine(policy).evaluate(next_record, history=(existing,))
+
+    assert decision.outcome is BudgetDecisionOutcome.STOP
+    assert decision.scope is BudgetScope.PROJECT
+    assert decision.escalation_required is True
+    assert decision.reason == "token budget exceeded"
+
+
+def test_engine_counts_tool_calls_and_allows_within_budget() -> None:
+    project_id = uuid4()
+    policy = BudgetPolicy(
+        budgets=(
+            Budget(
+                scope=BudgetScope.PROJECT,
+                scope_id=project_id,
+                max_tokens=100,
+                max_llm_calls=5,
+                max_duration_ms=10_000.0,
+                max_tool_calls=2,
+                max_provider_cost=Decimal("1.00"),
+            ),
+        )
+    )
+    record = UsageRecord(
+        project_id=project_id,
+        kind=UsageKind.TOOL_CALL,
+        duration_ms=100.0,
+        tool_calls=1,
+    )
+
+    decision = BudgetEngine(policy).evaluate(record)
+
+    assert decision.outcome is BudgetDecisionOutcome.ALLOW
+    assert decision.escalation_required is False
+
+
+def test_engine_applies_agent_budget() -> None:
+    agent_id = uuid4()
+    project_id = uuid4()
+    policy = BudgetPolicy(
+        budgets=(
+            Budget(
+                scope=BudgetScope.AGENT,
+                scope_id=agent_id,
+                max_tokens=10,
+            ),
+        )
+    )
+    record = UsageRecord(
+        project_id=project_id,
+        agent_id=agent_id,
+        kind=UsageKind.LLM_REQUEST,
+        input_tokens=11,
+    )
+
+    decision = BudgetEngine(policy).evaluate(record)
+
+    assert decision.outcome is BudgetDecisionOutcome.STOP
+    assert decision.scope is BudgetScope.AGENT

--- a/tests/budget/test_types.py
+++ b/tests/budget/test_types.py
@@ -1,0 +1,58 @@
+"""Unit tests for bounded budget contracts."""
+
+from __future__ import annotations
+
+from decimal import Decimal
+from uuid import uuid4
+
+import pytest
+from pydantic import ValidationError
+
+from core.budget.types import Budget, BudgetPolicy, BudgetScope, UsageKind, UsageRecord
+
+
+def test_usage_record_accepts_bounded_usage_dimensions() -> None:
+    record = UsageRecord(
+        project_id=uuid4(),
+        task_id=uuid4(),
+        run_id=uuid4(),
+        agent_id=uuid4(),
+        kind=UsageKind.LLM_REQUEST,
+        provider="ollama",
+        model="qwen",
+        input_tokens=100,
+        output_tokens=50,
+        duration_ms=250.0,
+        tool_calls=0,
+        cpu_ms=20.0,
+        gpu_ms=100.0,
+        provider_cost=Decimal("0.0042"),
+    )
+
+    assert record.total_tokens == 150
+    assert record.provider_cost == Decimal("0.0042")
+
+
+def test_usage_record_rejects_negative_or_invalid_measurements() -> None:
+    with pytest.raises(ValidationError):
+        UsageRecord(
+            project_id=uuid4(),
+            kind=UsageKind.TOOL_CALL,
+            duration_ms=-1.0,
+        )
+
+
+def test_budget_policy_requires_unique_scopes() -> None:
+    project_id = uuid4()
+    budget = Budget(
+        scope=BudgetScope.PROJECT,
+        scope_id=project_id,
+        max_tokens=100,
+        max_llm_calls=2,
+        max_duration_ms=1000.0,
+        max_tool_calls=3,
+        max_provider_cost=Decimal("1.00"),
+    )
+
+    with pytest.raises(ValueError, match="budget scopes must be unique"):
+        BudgetPolicy(budgets=(budget, budget))

--- a/tests/database/test_usage_records.py
+++ b/tests/database/test_usage_records.py
@@ -1,0 +1,57 @@
+"""Real-PostgreSQL tests for append-only usage records."""
+
+from __future__ import annotations
+
+from uuid import uuid4
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from core.budget.types import UsageKind
+from infrastructure.database.append_only import AppendOnlyViolationError
+from infrastructure.database.models import Project, UsageRecord
+from infrastructure.database.repositories.usage_records import UsageRecordRepository
+
+
+def test_usage_record_repository_appends_and_reads_usage(db_session: Session) -> None:
+    project_id = uuid4()
+    project = Project(id=project_id, name="Usage project")
+    repository = UsageRecordRepository(db_session)
+    db_session.add(project)
+    db_session.flush()
+    record = repository.add(
+        UsageRecord(
+            project_id=project_id,
+            kind=UsageKind.LLM_REQUEST,
+            provider="ollama",
+            model="qwen",
+            input_tokens=20,
+            output_tokens=10,
+            duration_ms=42.0,
+            tool_calls=0,
+        )
+    )
+    db_session.commit()
+
+    assert repository.get_by_id(record.id) is record
+    assert repository.list(project_id=project_id) == [record]
+    assert db_session.scalar(select(UsageRecord).where(UsageRecord.id == record.id)) is record
+
+
+def test_usage_record_update_and_mutable_metadata_are_rejected(db_session: Session) -> None:
+    project = Project(name="Immutable usage project")
+    record = UsageRecord(project=project, kind=UsageKind.TOOL_CALL, metadata_={"step": "run"})
+    db_session.add(record)
+    db_session.commit()
+
+    record.provider = "forbidden-update"
+    with pytest.raises(AppendOnlyViolationError):
+        db_session.flush()
+    db_session.rollback()
+
+    loaded_record = db_session.get(UsageRecord, record.id)
+    assert loaded_record is not None
+    loaded_record.metadata_["step"] = "forbidden-json-update"
+    with pytest.raises(AppendOnlyViolationError):
+        db_session.flush()


### PR DESCRIPTION
## Summary\n- add bounded UsageRecord, Budget, BudgetPolicy, and BudgetDecision contracts\n- calculate provider costs from explicit rates or recorded provider costs\n- enforce project, task, run, and agent budgets with safe stop and escalation decisions\n- persist append-only usage records with PostgreSQL migration and repository\n- mark Phase 37 checklist measures complete\n\n## Validation\n- 2053 tests passed\n- Ruff passed\n- strict mypy passed\n- Ruff format check passed\n- PostgreSQL migration and append-only integration tests passed\n- git diff --check passed\n\nPhase 38 is intentionally not implemented.