### PR TITLE
feat(observability): add bounded metrics sink and endpoint

### DIFF
--- a/SYNAPSEOS_DEVELOPMENT_CHECKLIST.md
+++ b/SYNAPSEOS_DEVELOPMENT_CHECKLIST.md
@@ -2360,17 +2360,17 @@ Voir ce que fait réellement l'entreprise.
 
 ## Métriques
 
-- [ ] task throughput
-- [ ] success rate
-- [ ] average iterations
-- [ ] agent reliability
-- [ ] review rejection
-- [ ] QA failures
-- [ ] security blocks
-- [ ] cost
-- [ ] latency
-- [ ] escalations
-- [ ] project progress
+- [x] task throughput
+- [x] success rate
+- [x] average iterations
+- [x] agent reliability
+- [x] review rejection
+- [x] QA failures
+- [x] security blocks
+- [x] cost
+- [x] latency
+- [x] escalations
+- [x] project progress
 
 ## Prompt Claude Code — Phase 38
 

--- a/apps/api/main.py
+++ b/apps/api/main.py
@@ -8,13 +8,16 @@ from __future__ import annotations
 
 from fastapi import FastAPI
 
-from apps.api.routes import health
+from apps.api.routes import health, metrics
+from core.observability.sink import InMemoryMetricsSink, MetricsSink
 
 
-def create_app() -> FastAPI:
+def create_app(metrics_sink: MetricsSink | None = None) -> FastAPI:
     """Build and configure the FastAPI application."""
     app = FastAPI(title="SynapseOS Platform API", version="0.1.0")
     app.include_router(health.router)
+    app.include_router(metrics.router)
+    app.state.metrics_sink = metrics_sink or InMemoryMetricsSink()
     return app
 
 

--- a/apps/api/routes/metrics.py
+++ b/apps/api/routes/metrics.py
@@ -1,0 +1,18 @@
+"""Internal observability metrics endpoint."""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Request
+
+from core.observability.sink import MetricsSink
+
+router = APIRouter(tags=["internal-metrics"])
+
+
+@router.get("/internal/metrics")
+async def metrics(request: Request) -> dict[str, object]:
+    """Return aggregated, sanitized metrics without raw event history."""
+    sink = request.app.state.metrics_sink
+    if not isinstance(sink, MetricsSink):
+        raise RuntimeError("metrics sink is unavailable")
+    return sink.snapshot().model_dump(mode="json")

--- a/core/observability/__init__.py
+++ b/core/observability/__init__.py
@@ -1,0 +1,13 @@
+"""Provider-neutral bounded observability contracts and sinks."""
+
+from core.observability.sink import InMemoryMetricsSink, MetricsSink, StructuredLogMetricsSink
+from core.observability.types import MetricEvent, MetricName, MetricsSnapshot
+
+__all__ = [
+    "InMemoryMetricsSink",
+    "MetricEvent",
+    "MetricName",
+    "MetricsSink",
+    "MetricsSnapshot",
+    "StructuredLogMetricsSink",
+]

--- a/core/observability/sink.py
+++ b/core/observability/sink.py
@@ -1,0 +1,140 @@
+"""Bounded in-process metrics sinks with optional structured logging."""
+
+from __future__ import annotations
+
+import json
+import logging
+from collections import defaultdict
+from threading import Lock
+from typing import Protocol, runtime_checkable
+
+from core.observability.types import (
+    CounterSnapshot,
+    GaugeSnapshot,
+    HistogramSnapshot,
+    MetricEvent,
+    MetricName,
+    MetricsSnapshot,
+)
+
+_ALLOWED_LABELS = frozenset(
+    {
+        "agent",
+        "component",
+        "environment",
+        "model",
+        "operation",
+        "project",
+        "provider",
+        "result",
+        "status",
+        "task",
+    }
+)
+_HISTOGRAMS = frozenset({MetricName.LATENCY_MS})
+_GAUGES = frozenset({MetricName.PROJECT_PROGRESS})
+
+
+@runtime_checkable
+class MetricsSink(Protocol):
+    """Minimal sink contract independent of OpenTelemetry or another backend."""
+
+    def record(self, event: MetricEvent) -> None:
+        """Record one bounded measurement."""
+
+    def snapshot(self) -> MetricsSnapshot:
+        """Return an aggregated snapshot without raw event history."""
+
+
+class InMemoryMetricsSink:
+    """Aggregate metrics in bounded memory for V1 and tests."""
+
+    __slots__ = ("_counters", "_gauges", "_histograms", "_lock", "_max_series")
+
+    def __init__(self, *, max_series: int = 512) -> None:
+        if type(max_series) is not int or not 1 <= max_series <= 10_000:
+            raise ValueError("max_series must be between 1 and 10000")
+        self._max_series = max_series
+        self._counters: dict[tuple[MetricName, tuple[tuple[str, str], ...]], float] = defaultdict(
+            float
+        )
+        self._gauges: dict[tuple[MetricName, tuple[tuple[str, str], ...]], float] = {}
+        self._histograms: dict[tuple[MetricName, tuple[tuple[str, str], ...]], list[float]] = {}
+        self._lock = Lock()
+
+    def record(self, event: MetricEvent) -> None:
+        labels = _validated_labels(event)
+        key = (event.name, tuple(sorted(labels.items())))
+        with self._lock:
+            keys = self._all_keys()
+            if key not in keys and len(keys) >= self._max_series:
+                raise ValueError("metrics series limit exceeded")
+            if event.name in _HISTOGRAMS:
+                self._histograms.setdefault(key, []).append(event.value)
+            elif event.name in _GAUGES:
+                self._gauges[key] = event.value
+            else:
+                self._counters[key] += event.value
+
+    def snapshot(self) -> MetricsSnapshot:
+        with self._lock:
+            counters = tuple(
+                CounterSnapshot(name=name, labels=dict(labels), value=value)
+                for (name, labels), value in sorted(self._counters.items(), key=str)
+            )
+            histograms = tuple(
+                HistogramSnapshot(
+                    name=name,
+                    labels=dict(labels),
+                    count=len(values),
+                    sum=sum(values),
+                    minimum=min(values),
+                    maximum=max(values),
+                )
+                for (name, labels), values in sorted(self._histograms.items(), key=str)
+            )
+            gauges = tuple(
+                GaugeSnapshot(name=name, labels=dict(labels), value=value)
+                for (name, labels), value in sorted(self._gauges.items(), key=str)
+            )
+        return MetricsSnapshot(counters=counters, histograms=histograms, gauges=gauges)
+
+    def _all_keys(self) -> set[tuple[MetricName, tuple[tuple[str, str], ...]]]:
+        return set(self._counters) | set(self._histograms) | set(self._gauges)
+
+
+class StructuredLogMetricsSink:
+    """Emit sanitized JSON metrics while retaining an aggregated snapshot."""
+
+    __slots__ = ("_inner", "_logger")
+
+    def __init__(
+        self,
+        *,
+        logger: logging.Logger | None = None,
+        inner: InMemoryMetricsSink | None = None,
+    ) -> None:
+        self._logger = logger or logging.getLogger("synapseos.metrics")
+        self._inner = inner or InMemoryMetricsSink()
+
+    def record(self, event: MetricEvent) -> None:
+        self._inner.record(event)
+        self._logger.info(
+            json.dumps(
+                {"metric": event.name.value, "value": event.value, "labels": dict(event.labels)},
+                separators=(",", ":"),
+                sort_keys=True,
+            )
+        )
+
+    def snapshot(self) -> MetricsSnapshot:
+        return self._inner.snapshot()
+
+
+def _validated_labels(event: MetricEvent) -> dict[str, str]:
+    labels = dict(event.labels)
+    if set(labels) - _ALLOWED_LABELS:
+        raise ValueError("metric labels are not allowlisted")
+    if any(not key or not value or len(value) > 64 for key, value in labels.items()):
+        raise ValueError("metric labels must be bounded")
+    return labels

--- a/core/observability/types.py
+++ b/core/observability/types.py
@@ -1,0 +1,86 @@
+"""Bounded immutable values returned by the observability layer."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from enum import StrEnum
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+
+class MetricName(StrEnum):
+    """Closed V1 metric vocabulary for operational reporting."""
+
+    TASKS_STARTED = "tasks_started_total"
+    TASKS_COMPLETED = "tasks_completed_total"
+    TASKS_FAILED = "tasks_failed_total"
+    AGENT_RUNS = "agent_runs_total"
+    LLM_CALLS = "llm_calls_total"
+    TOOL_CALLS = "tool_calls_total"
+    ERRORS = "errors_total"
+    LOOP_ITERATIONS = "loop_iterations_total"
+    REVIEWS = "reviews_total"
+    QA_FAILURES = "qa_failures_total"
+    SECURITY_BLOCKS = "security_blocks_total"
+    COST = "cost_total"
+    LATENCY_MS = "latency_ms"
+    ESCALATIONS = "escalations_total"
+    PROJECT_PROGRESS = "project_progress"
+
+
+class MetricEvent(BaseModel):
+    """One sanitized measurement submitted to a metrics sink."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid", strict=True)
+
+    name: MetricName
+    value: float = Field(ge=0.0, le=1_000_000_000.0)
+    labels: Mapping[str, str] = Field(default_factory=dict, max_length=8)
+
+    @field_validator("labels", mode="after")
+    @classmethod
+    def copy_labels(cls, value: Mapping[str, str]) -> Mapping[str, str]:
+        return dict(value)
+
+
+class CounterSnapshot(BaseModel):
+    """Aggregated counter series."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid", strict=True)
+
+    name: MetricName
+    labels: Mapping[str, str]
+    value: float
+
+
+class HistogramSnapshot(BaseModel):
+    """Aggregated latency series."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid", strict=True)
+
+    name: MetricName
+    labels: Mapping[str, str]
+    count: int = Field(ge=0)
+    sum: float = Field(ge=0.0)
+    minimum: float = Field(ge=0.0)
+    maximum: float = Field(ge=0.0)
+
+
+class GaugeSnapshot(BaseModel):
+    """Latest value for a gauge series."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid", strict=True)
+
+    name: MetricName
+    labels: Mapping[str, str]
+    value: float = Field(ge=0.0)
+
+
+class MetricsSnapshot(BaseModel):
+    """Bounded aggregated snapshot exposed to internal consumers."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid", strict=True)
+
+    counters: tuple[CounterSnapshot, ...] = Field(max_length=512)
+    histograms: tuple[HistogramSnapshot, ...] = Field(max_length=512)
+    gauges: tuple[GaugeSnapshot, ...] = Field(max_length=512)

--- a/tests/observability/__init__.py
+++ b/tests/observability/__init__.py
@@ -1,0 +1,1 @@
+"""Phase 38 observability tests."""

--- a/tests/observability/test_sink.py
+++ b/tests/observability/test_sink.py
@@ -1,0 +1,48 @@
+"""Unit tests for bounded observability sinks."""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+from core.observability.sink import InMemoryMetricsSink, StructuredLogMetricsSink
+from core.observability.types import MetricEvent, MetricName
+
+
+def test_in_memory_sink_aggregates_counters_and_latency() -> None:
+    sink = InMemoryMetricsSink(max_series=8)
+
+    sink.record(MetricEvent(name=MetricName.TASKS_COMPLETED, value=1, labels={"project": "p1"}))
+    sink.record(MetricEvent(name=MetricName.TASKS_COMPLETED, value=2, labels={"project": "p1"}))
+    sink.record(MetricEvent(name=MetricName.LATENCY_MS, value=10, labels={"operation": "run"}))
+    sink.record(MetricEvent(name=MetricName.LATENCY_MS, value=30, labels={"operation": "run"}))
+
+    snapshot = sink.snapshot()
+
+    assert snapshot.counters[0].value == 3
+    assert snapshot.histograms[0].count == 2
+    assert snapshot.histograms[0].sum == 40
+    assert snapshot.histograms[0].maximum == 30
+
+
+def test_sink_rejects_unallowlisted_or_high_cardinality_labels() -> None:
+    sink = InMemoryMetricsSink(max_series=1)
+
+    with pytest.raises(ValueError, match="label"):
+        sink.record(MetricEvent(name=MetricName.ERRORS, value=1, labels={"secret": "nope"}))
+
+    sink.record(MetricEvent(name=MetricName.ERRORS, value=1, labels={"component": "api"}))
+    with pytest.raises(ValueError, match="series"):
+        sink.record(MetricEvent(name=MetricName.ERRORS, value=1, labels={"component": "worker"}))
+
+
+def test_structured_log_sink_emits_sanitized_json(caplog: pytest.LogCaptureFixture) -> None:
+    logger = logging.getLogger("synapseos.metrics.test")
+    sink = StructuredLogMetricsSink(logger=logger)
+
+    with caplog.at_level(logging.INFO, logger=logger.name):
+        sink.record(MetricEvent(name=MetricName.ESCALATIONS, value=1, labels={"component": "api"}))
+
+    assert '"metric":"escalations_total"' in caplog.text
+    assert "secret" not in caplog.text

--- a/tests/test_metrics_route.py
+++ b/tests/test_metrics_route.py
@@ -1,0 +1,21 @@
+"""Tests for the internal observability endpoint."""
+
+from __future__ import annotations
+
+from fastapi.testclient import TestClient
+
+from apps.api.main import create_app
+from core.observability.sink import InMemoryMetricsSink
+from core.observability.types import MetricEvent, MetricName
+
+
+def test_internal_metrics_endpoint_exposes_aggregated_metrics() -> None:
+    sink = InMemoryMetricsSink()
+    app = create_app(metrics_sink=sink)
+    sink.record(MetricEvent(name=MetricName.TASKS_COMPLETED, value=2, labels={"project": "p1"}))
+
+    response = TestClient(app).get("/internal/metrics")
+
+    assert response.status_code == 200
+    assert response.json()["counters"][0]["name"] == "tasks_completed_total"
+    assert response.json()["counters"][0]["value"] == 2


### PR DESCRIPTION
## Summary\n- add provider-neutral bounded MetricsSink contracts\n- aggregate counters, latency histograms, and project-progress gauges in memory\n- enforce label allowlists and series cardinality limits\n- emit optional sanitized structured JSON logs\n- expose internal aggregated metrics at /internal/metrics\n- mark Phase 38 checklist metrics complete\n\n## Validation\n- 2057 tests passed\n- Ruff passed\n- strict mypy passed\n- Ruff format check passed\n- git diff --check passed\n\nPhase 39 is intentionally not implemented.