### PR TITLE
feat(incidents): add incident management lifecycle

### DIFF
--- a/SYNAPSEOS_DEVELOPMENT_CHECKLIST.md
+++ b/SYNAPSEOS_DEVELOPMENT_CHECKLIST.md
@@ -2415,6 +2415,17 @@ POSTMORTEM
 CLOSED
 ```
 
+## Phase 39 implementation checklist
+
+- [x] Add bounded incident contracts and severity classification.
+- [x] Enforce the DETECTED → ACKNOWLEDGED → INVESTIGATING → MITIGATING → RESOLVED → POSTMORTEM → CLOSED lifecycle.
+- [x] Record immutable incident timeline events with append-only application protection.
+- [x] Require owner, affected service, mitigation, resolution, root cause, and follow-up actions.
+- [x] Persist incidents, timeline events, and postmortems through PostgreSQL and Alembic.
+- [x] Add read/append repositories without update or delete operations for incident events.
+- [x] Verify unit tests, real-PostgreSQL integration tests, Ruff, formatting, mypy, and diff hygiene.
+- [x] Keep production deployment automation and frontend work out of Phase 39.
+
 ## Prompt Claude Code — Phase 39
 
 ```text

--- a/alembic/versions/20260910_0008_incident_management.py
+++ b/alembic/versions/20260910_0008_incident_management.py
@@ -1,0 +1,156 @@
+"""Add Phase 39 incident management persistence.
+
+Revision ID: 20260910_0008
+Revises: 20260910_0007
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+from alembic import op
+
+revision: str = "20260910_0008"
+down_revision: str | Sequence[str] | None = "20260910_0007"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    incident_severity = postgresql.ENUM(
+        "CRITICAL", "HIGH", "MEDIUM", "LOW", name="incident_severity"
+    )
+    incident_severity.create(op.get_bind(), checkfirst=True)
+    incident_state = postgresql.ENUM(
+        "DETECTED",
+        "ACKNOWLEDGED",
+        "INVESTIGATING",
+        "MITIGATING",
+        "RESOLVED",
+        "POSTMORTEM",
+        "CLOSED",
+        name="incident_state",
+    )
+    incident_state.create(op.get_bind(), checkfirst=True)
+    incident_severity_column = postgresql.ENUM(
+        "CRITICAL", "HIGH", "MEDIUM", "LOW", name="incident_severity", create_type=False
+    )
+    incident_state_column = postgresql.ENUM(
+        "DETECTED",
+        "ACKNOWLEDGED",
+        "INVESTIGATING",
+        "MITIGATING",
+        "RESOLVED",
+        "POSTMORTEM",
+        "CLOSED",
+        name="incident_state",
+        create_type=False,
+    )
+
+    op.create_table(
+        "incidents",
+        sa.Column("project_id", postgresql.UUID(as_uuid=True), nullable=True),
+        sa.Column("owner", sa.String(length=255), nullable=False),
+        sa.Column("affected_service", sa.String(length=255), nullable=False),
+        sa.Column("severity", incident_severity_column, nullable=False),
+        sa.Column("state", incident_state_column, nullable=False),
+        sa.Column("mitigation", sa.Text(), nullable=True),
+        sa.Column("resolution", sa.Text(), nullable=True),
+        sa.Column("id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column(
+            "created_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False
+        ),
+        sa.Column(
+            "updated_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False
+        ),
+        sa.CheckConstraint("length(trim(owner)) > 0", name=op.f("ck_incidents_owner_nonblank")),
+        sa.CheckConstraint(
+            "length(trim(affected_service)) > 0",
+            name=op.f("ck_incidents_service_nonblank"),
+        ),
+        sa.ForeignKeyConstraint(
+            ["project_id"],
+            ["projects.id"],
+            ondelete="RESTRICT",
+            name=op.f("fk_incidents_project_id_projects"),
+        ),
+        sa.PrimaryKeyConstraint("id", name=op.f("pk_incidents")),
+    )
+    op.create_index(
+        "ix_incidents_state_severity_created",
+        "incidents",
+        ["state", "severity", "created_at"],
+    )
+    op.create_index("ix_incidents_service_created", "incidents", ["affected_service", "created_at"])
+    op.create_index("ix_incidents_project_created", "incidents", ["project_id", "created_at"])
+
+    audit_actor_type = postgresql.ENUM(
+        "AGENT",
+        "HUMAN",
+        "SYSTEM",
+        "WORKER",
+        "TOOL",
+        "WEBHOOK",
+        name="audit_actor_type",
+        create_type=False,
+    )
+    op.create_table(
+        "incident_events",
+        sa.Column("incident_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("from_state", incident_state_column, nullable=True),
+        sa.Column("to_state", incident_state_column, nullable=False),
+        sa.Column("actor_type", audit_actor_type, nullable=False),
+        sa.Column("actor_id", sa.String(length=255), nullable=True),
+        sa.Column("action", sa.String(length=255), nullable=False),
+        sa.Column("detail", sa.Text(), nullable=False),
+        sa.Column("id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column(
+            "created_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False
+        ),
+        sa.ForeignKeyConstraint(
+            ["incident_id"],
+            ["incidents.id"],
+            ondelete="RESTRICT",
+            name=op.f("fk_incident_events_incident_id_incidents"),
+        ),
+        sa.PrimaryKeyConstraint("id", name=op.f("pk_incident_events")),
+    )
+    op.create_index(
+        "ix_incident_events_incident_created", "incident_events", ["incident_id", "created_at"]
+    )
+    op.create_index(
+        "ix_incident_events_transition_created", "incident_events", ["to_state", "created_at"]
+    )
+
+    op.create_table(
+        "incident_postmortems",
+        sa.Column("incident_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("summary", sa.Text(), nullable=False),
+        sa.Column("root_cause", sa.Text(), nullable=False),
+        sa.Column("mitigation", sa.Text(), nullable=False),
+        sa.Column("resolution", sa.Text(), nullable=False),
+        sa.Column("follow_up_actions", postgresql.JSONB(), server_default="[]", nullable=False),
+        sa.Column("id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column(
+            "created_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False
+        ),
+        sa.ForeignKeyConstraint(
+            ["incident_id"],
+            ["incidents.id"],
+            ondelete="RESTRICT",
+            name=op.f("fk_incident_postmortems_incident_id_incidents"),
+        ),
+        sa.PrimaryKeyConstraint("id", name=op.f("pk_incident_postmortems")),
+        sa.UniqueConstraint("incident_id", name=op.f("uq_incident_postmortems_incident_id")),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("incident_postmortems")
+    op.drop_table("incident_events")
+    op.drop_table("incidents")
+    postgresql.ENUM(name="incident_state").drop(op.get_bind(), checkfirst=True)
+    postgresql.ENUM(name="incident_severity").drop(op.get_bind(), checkfirst=True)

--- a/core/incidents/__init__.py
+++ b/core/incidents/__init__.py
@@ -1,0 +1,19 @@
+"""Phase 39 incident management contracts."""
+
+from core.incidents.types import (
+    Incident,
+    IncidentEvent,
+    IncidentSeverity,
+    IncidentState,
+    IncidentStateMachine,
+    Postmortem,
+)
+
+__all__ = [
+    "Incident",
+    "IncidentEvent",
+    "IncidentSeverity",
+    "IncidentState",
+    "IncidentStateMachine",
+    "Postmortem",
+]

--- a/core/incidents/types.py
+++ b/core/incidents/types.py
@@ -1,0 +1,159 @@
+"""Provider-neutral contracts for bounded incident management."""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime
+from enum import StrEnum
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+from core.enums import AuditActorType
+
+
+class IncidentSeverity(StrEnum):
+    """Operational impact classification for an incident."""
+
+    CRITICAL = "CRITICAL"
+    HIGH = "HIGH"
+    MEDIUM = "MEDIUM"
+    LOW = "LOW"
+
+
+class IncidentState(StrEnum):
+    """Ordered lifecycle states for one incident."""
+
+    DETECTED = "DETECTED"
+    ACKNOWLEDGED = "ACKNOWLEDGED"
+    INVESTIGATING = "INVESTIGATING"
+    MITIGATING = "MITIGATING"
+    RESOLVED = "RESOLVED"
+    POSTMORTEM = "POSTMORTEM"
+    CLOSED = "CLOSED"
+
+
+class _IncidentModel(BaseModel):
+    model_config = ConfigDict(
+        frozen=True,
+        extra="forbid",
+        strict=True,
+        hide_input_in_errors=True,
+        revalidate_instances="always",
+    )
+
+
+def _clean_text(value: str) -> str:
+    value = value.strip()
+    if not value:
+        raise ValueError("incident text must not be blank")
+    return value
+
+
+class IncidentEvent(_IncidentModel):
+    """One immutable timeline entry for an incident state change."""
+
+    event_id: uuid.UUID = Field(default_factory=uuid.uuid4)
+    incident_id: uuid.UUID
+    from_state: IncidentState | None
+    to_state: IncidentState
+    actor_type: AuditActorType
+    actor_id: str | None = Field(default=None, max_length=255)
+    action: str = Field(min_length=1, max_length=255)
+    detail: str = Field(min_length=1, max_length=2_048)
+    created_at: datetime = Field(default_factory=lambda: datetime.now(UTC))
+
+    _clean_action = field_validator("action", "detail", mode="before")(_clean_text)
+
+    @field_validator("actor_id", mode="before")
+    @classmethod
+    def clean_actor_id(cls, value: str | None) -> str | None:
+        if value is None:
+            return None
+        return _clean_text(value)
+
+
+class Postmortem(_IncidentModel):
+    """Bounded evidence required before an incident can be closed."""
+
+    summary: str = Field(min_length=1, max_length=4_096)
+    root_cause: str = Field(min_length=1, max_length=4_096)
+    mitigation: str = Field(min_length=1, max_length=4_096)
+    resolution: str = Field(min_length=1, max_length=4_096)
+    follow_up_actions: tuple[str, ...] = Field(min_length=1, max_length=32)
+
+    _clean_fields = field_validator(
+        "summary", "root_cause", "mitigation", "resolution", mode="before"
+    )(_clean_text)
+
+    @field_validator("follow_up_actions", mode="before")
+    @classmethod
+    def clean_follow_up_actions(cls, value: tuple[str, ...] | list[str]) -> tuple[str, ...]:
+        return tuple(_clean_text(item) for item in value)
+
+
+class Incident(_IncidentModel):
+    """A bounded incident aggregate with an immutable in-memory timeline."""
+
+    incident_id: uuid.UUID = Field(default_factory=uuid.uuid4)
+    owner: str = Field(min_length=1, max_length=255)
+    affected_service: str = Field(min_length=1, max_length=255)
+    severity: IncidentSeverity
+    state: IncidentState = IncidentState.DETECTED
+    mitigation: str | None = Field(default=None, max_length=4_096)
+    resolution: str | None = Field(default=None, max_length=4_096)
+    timeline: tuple[IncidentEvent, ...] = Field(default=(), max_length=512)
+    postmortem: Postmortem | None = None
+
+    _clean_fields = field_validator("owner", "affected_service", mode="before")(_clean_text)
+
+
+class IncidentStateMachine:
+    """Apply only the approved forward incident lifecycle transitions."""
+
+    _allowed: dict[IncidentState, frozenset[IncidentState]] = {
+        IncidentState.DETECTED: frozenset({IncidentState.ACKNOWLEDGED}),
+        IncidentState.ACKNOWLEDGED: frozenset({IncidentState.INVESTIGATING}),
+        IncidentState.INVESTIGATING: frozenset({IncidentState.MITIGATING}),
+        IncidentState.MITIGATING: frozenset({IncidentState.RESOLVED}),
+        IncidentState.RESOLVED: frozenset({IncidentState.POSTMORTEM}),
+        IncidentState.POSTMORTEM: frozenset({IncidentState.CLOSED}),
+        IncidentState.CLOSED: frozenset(),
+    }
+
+    @classmethod
+    def can_transition(cls, current: IncidentState, target: IncidentState) -> bool:
+        """Return whether a lifecycle transition is explicitly allowed."""
+        return target in cls._allowed[current]
+
+    @classmethod
+    def transition(
+        cls,
+        incident: Incident,
+        target: IncidentState,
+        *,
+        actor_type: AuditActorType,
+        actor_id: str | None,
+        detail: str,
+    ) -> Incident:
+        """Return a new incident with one audited state transition appended."""
+        if not cls.can_transition(incident.state, target):
+            raise ValueError(
+                f"invalid incident transition: {incident.state.value} -> {target.value}"
+            )
+        if target is IncidentState.CLOSED and incident.postmortem is None:
+            raise ValueError("postmortem is required before closing an incident")
+        if actor_type is not AuditActorType.SYSTEM and actor_id is None:
+            raise ValueError("actor_id is required for non-system incident transitions")
+
+        event = IncidentEvent(
+            incident_id=incident.incident_id,
+            from_state=incident.state,
+            to_state=target,
+            actor_type=actor_type,
+            actor_id=actor_id,
+            action="transition_incident",
+            detail=detail,
+        )
+        return incident.model_copy(
+            update={"state": target, "timeline": (*incident.timeline, event)}
+        )

--- a/infrastructure/database/models/__init__.py
+++ b/infrastructure/database/models/__init__.py
@@ -3,6 +3,7 @@
 from infrastructure.database.models.budget import UsageRecord
 from infrastructure.database.models.execution import AgentRun, Decision, ToolCall
 from infrastructure.database.models.history import AgentScore, AuditEvent
+from infrastructure.database.models.incidents import Incident, IncidentEvent, Postmortem
 from infrastructure.database.models.memory import MemoryEntry
 from infrastructure.database.models.organization import (
     Agent,
@@ -21,9 +22,12 @@ __all__ = [
     "AgentScore",
     "Approval",
     "AuditEvent",
+    "Incident",
+    "IncidentEvent",
     "MemoryEntry",
     "Decision",
     "Project",
+    "Postmortem",
     "PullRequest",
     "PullRequestReview",
     "Task",

--- a/infrastructure/database/models/incidents.py
+++ b/infrastructure/database/models/incidents.py
@@ -1,0 +1,95 @@
+"""PostgreSQL persistence models for Phase 39 incident management."""
+
+from __future__ import annotations
+
+import uuid
+from typing import TYPE_CHECKING
+
+from sqlalchemy import CheckConstraint, Enum, ForeignKey, Index, String, Text, UniqueConstraint
+from sqlalchemy.dialects.postgresql import JSONB, UUID
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from core.enums import AuditActorType
+from core.incidents import IncidentSeverity, IncidentState
+from infrastructure.database.append_only import AppendOnlyMixin
+from infrastructure.database.base import Base, CreatedAtMixin, TimestampMixin, UUIDPrimaryKeyMixin
+
+if TYPE_CHECKING:
+    from infrastructure.database.models.organization import Project
+
+
+class Incident(UUIDPrimaryKeyMixin, TimestampMixin, Base):
+    """Current incident state and bounded operational context."""
+
+    __tablename__ = "incidents"
+    __table_args__ = (
+        CheckConstraint("length(trim(owner)) > 0", name="owner_nonblank"),
+        CheckConstraint("length(trim(affected_service)) > 0", name="service_nonblank"),
+        Index("ix_incidents_state_severity_created", "state", "severity", "created_at"),
+        Index("ix_incidents_service_created", "affected_service", "created_at"),
+        Index("ix_incidents_project_created", "project_id", "created_at"),
+    )
+
+    project_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("projects.id", ondelete="RESTRICT"), nullable=True
+    )
+    owner: Mapped[str] = mapped_column(String(255), nullable=False)
+    affected_service: Mapped[str] = mapped_column(String(255), nullable=False)
+    severity: Mapped[IncidentSeverity] = mapped_column(
+        Enum(IncidentSeverity, name="incident_severity"), nullable=False
+    )
+    state: Mapped[IncidentState] = mapped_column(
+        Enum(IncidentState, name="incident_state"), default=IncidentState.DETECTED, nullable=False
+    )
+    mitigation: Mapped[str | None] = mapped_column(Text, nullable=True)
+    resolution: Mapped[str | None] = mapped_column(Text, nullable=True)
+
+    project: Mapped[Project | None] = relationship(back_populates="incidents")
+    events: Mapped[list[IncidentEvent]] = relationship(back_populates="incident")
+    postmortem: Mapped[Postmortem | None] = relationship(back_populates="incident", uselist=False)
+
+
+class IncidentEvent(AppendOnlyMixin, UUIDPrimaryKeyMixin, CreatedAtMixin, Base):
+    """Immutable incident timeline entry."""
+
+    __tablename__ = "incident_events"
+    __table_args__ = (
+        Index("ix_incident_events_incident_created", "incident_id", "created_at"),
+        Index("ix_incident_events_transition_created", "to_state", "created_at"),
+    )
+
+    incident_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("incidents.id", ondelete="RESTRICT"), nullable=False
+    )
+    from_state: Mapped[IncidentState | None] = mapped_column(
+        Enum(IncidentState, name="incident_state", create_type=False), nullable=True
+    )
+    to_state: Mapped[IncidentState] = mapped_column(
+        Enum(IncidentState, name="incident_state", create_type=False), nullable=False
+    )
+    actor_type: Mapped[AuditActorType] = mapped_column(
+        Enum(AuditActorType, name="audit_actor_type", create_type=False), nullable=False
+    )
+    actor_id: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    action: Mapped[str] = mapped_column(String(255), nullable=False)
+    detail: Mapped[str] = mapped_column(Text, nullable=False)
+
+    incident: Mapped[Incident] = relationship(back_populates="events")
+
+
+class Postmortem(UUIDPrimaryKeyMixin, CreatedAtMixin, Base):
+    """Required incident analysis recorded before closure."""
+
+    __tablename__ = "incident_postmortems"
+    __table_args__ = (UniqueConstraint("incident_id", name="incident_id_unique"),)
+
+    incident_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("incidents.id", ondelete="RESTRICT"), nullable=False
+    )
+    summary: Mapped[str] = mapped_column(Text, nullable=False)
+    root_cause: Mapped[str] = mapped_column(Text, nullable=False)
+    mitigation: Mapped[str] = mapped_column(Text, nullable=False)
+    resolution: Mapped[str] = mapped_column(Text, nullable=False)
+    follow_up_actions: Mapped[list[object]] = mapped_column(JSONB, default=list, nullable=False)
+
+    incident: Mapped[Incident] = relationship(back_populates="postmortem")

--- a/infrastructure/database/models/organization.py
+++ b/infrastructure/database/models/organization.py
@@ -32,6 +32,7 @@ from infrastructure.database.base import (
 if TYPE_CHECKING:
     from infrastructure.database.models.execution import AgentRun, Decision
     from infrastructure.database.models.history import AgentScore, AuditEvent
+    from infrastructure.database.models.incidents import Incident
     from infrastructure.database.models.pull_requests import (
         Approval,
         PullRequest,
@@ -129,6 +130,7 @@ class Project(UUIDPrimaryKeyMixin, TimestampMixin, Base):
     audit_events: Mapped[list[AuditEvent]] = relationship(back_populates="project")
     agent_permissions: Mapped[list[AgentPermission]] = relationship(back_populates="project")
     pull_requests: Mapped[list[PullRequest]] = relationship(back_populates="project")
+    incidents: Mapped[list[Incident]] = relationship(back_populates="project")
 
 
 class AgentPermission(UUIDPrimaryKeyMixin, CreatedAtMixin, Base):

--- a/infrastructure/database/repositories/__init__.py
+++ b/infrastructure/database/repositories/__init__.py
@@ -2,6 +2,8 @@
 
 from infrastructure.database.repositories.agent_scores import AgentScoreRepository
 from infrastructure.database.repositories.audit_events import AuditEventRepository
+from infrastructure.database.repositories.incident_events import IncidentEventRepository
+from infrastructure.database.repositories.incidents import IncidentRepository, PostmortemRepository
 from infrastructure.database.repositories.memory import MemoryRepository
 from infrastructure.database.repositories.pull_requests import (
     ApprovalRepository,
@@ -14,8 +16,11 @@ __all__ = [
     "AgentScoreRepository",
     "ApprovalRepository",
     "AuditEventRepository",
+    "IncidentEventRepository",
+    "IncidentRepository",
     "MemoryRepository",
     "PullRequestRepository",
     "PullRequestReviewRepository",
+    "PostmortemRepository",
     "UsageRecordRepository",
 ]

--- a/infrastructure/database/repositories/incident_events.py
+++ b/infrastructure/database/repositories/incident_events.py
@@ -1,0 +1,35 @@
+"""Read and append repository for immutable incident timeline events."""
+
+from __future__ import annotations
+
+import uuid
+
+from sqlalchemy import Select, select
+from sqlalchemy.orm import Session
+
+from infrastructure.database.models.incidents import IncidentEvent
+
+
+class IncidentEventRepository:
+    """Repository intentionally exposing no update or delete operations."""
+
+    def __init__(self, session: Session) -> None:
+        self._session = session
+
+    def append(self, event: IncidentEvent) -> IncidentEvent:
+        self._session.add(event)
+        return event
+
+    def get_by_id(self, event_id: uuid.UUID) -> IncidentEvent | None:
+        return self._session.get(IncidentEvent, event_id)
+
+    def list_for_incident(self, incident_id: uuid.UUID, *, limit: int = 512) -> list[IncidentEvent]:
+        if limit < 1 or limit > 512:
+            raise ValueError("incident event limit must be between 1 and 512")
+        statement: Select[tuple[IncidentEvent]] = (
+            select(IncidentEvent)
+            .where(IncidentEvent.incident_id == incident_id)
+            .order_by(IncidentEvent.created_at, IncidentEvent.id)
+            .limit(limit)
+        )
+        return list(self._session.scalars(statement))

--- a/infrastructure/database/repositories/incidents.py
+++ b/infrastructure/database/repositories/incidents.py
@@ -1,0 +1,52 @@
+"""Persistence repositories for incident aggregates and postmortems."""
+
+from __future__ import annotations
+
+import uuid
+
+from sqlalchemy import Select, select
+from sqlalchemy.orm import Session
+
+from infrastructure.database.models.incidents import Incident, Postmortem
+
+
+class IncidentRepository:
+    """Read and persist current incident aggregates."""
+
+    def __init__(self, session: Session) -> None:
+        self._session = session
+
+    def add(self, incident: Incident) -> Incident:
+        self._session.add(incident)
+        return incident
+
+    def get_by_id(self, incident_id: uuid.UUID) -> Incident | None:
+        return self._session.get(Incident, incident_id)
+
+    def list_open(self, *, limit: int = 100) -> list[Incident]:
+        if limit < 1 or limit > 100:
+            raise ValueError("incident limit must be between 1 and 100")
+        statement: Select[tuple[Incident]] = (
+            select(Incident)
+            .where(Incident.state != "CLOSED")
+            .order_by(Incident.created_at.desc(), Incident.id.desc())
+            .limit(limit)
+        )
+        return list(self._session.scalars(statement))
+
+
+class PostmortemRepository:
+    """Repository for creating and reading incident postmortems."""
+
+    def __init__(self, session: Session) -> None:
+        self._session = session
+
+    def add(self, postmortem: Postmortem) -> Postmortem:
+        self._session.add(postmortem)
+        return postmortem
+
+    def get_for_incident(self, incident_id: uuid.UUID) -> Postmortem | None:
+        statement: Select[tuple[Postmortem]] = select(Postmortem).where(
+            Postmortem.incident_id == incident_id
+        )
+        return self._session.scalar(statement)

--- a/tests/database/test_incident_models.py
+++ b/tests/database/test_incident_models.py
@@ -1,0 +1,177 @@
+"""Database tests for Phase 39 incident persistence."""
+
+from __future__ import annotations
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.exc import IntegrityError
+
+from core.enums import AuditActorType
+from core.incidents import IncidentSeverity, IncidentState
+from infrastructure.database.models import Incident, IncidentEvent, Postmortem
+from infrastructure.database.repositories.incident_events import IncidentEventRepository
+
+
+def test_incident_models_expose_phase_39_fields() -> None:
+    assert set(Incident.__table__.columns.keys()) == {
+        "id",
+        "project_id",
+        "owner",
+        "affected_service",
+        "severity",
+        "state",
+        "mitigation",
+        "resolution",
+        "created_at",
+        "updated_at",
+    }
+    assert set(IncidentEvent.__table__.columns.keys()) == {
+        "id",
+        "incident_id",
+        "from_state",
+        "to_state",
+        "actor_type",
+        "actor_id",
+        "action",
+        "detail",
+        "created_at",
+    }
+    assert set(Postmortem.__table__.columns.keys()) == {
+        "id",
+        "incident_id",
+        "summary",
+        "root_cause",
+        "mitigation",
+        "resolution",
+        "follow_up_actions",
+        "created_at",
+    }
+
+
+@pytest.mark.usefixtures("database_url")
+def test_incident_persists_with_event_and_postmortem(db_session) -> None:  # type: ignore[no-untyped-def]
+    incident = Incident(
+        owner="on-call-platform",
+        affected_service="platform-api",
+        severity=IncidentSeverity.HIGH,
+        state=IncidentState.DETECTED,
+    )
+    db_session.add(incident)
+    db_session.flush()
+
+    event = IncidentEvent(
+        incident_id=incident.id,
+        from_state=None,
+        to_state=IncidentState.DETECTED,
+        actor_type=AuditActorType.SYSTEM,
+        actor_id=None,
+        action="detect_incident",
+        detail="Incident detected by the platform.",
+    )
+    postmortem = Postmortem(
+        incident_id=incident.id,
+        summary="Service recovered.",
+        root_cause="Test root cause.",
+        mitigation="Test mitigation.",
+        resolution="Test resolution.",
+        follow_up_actions=["Add a regression test"],
+    )
+    db_session.add_all([event, postmortem])
+    db_session.commit()
+
+    assert db_session.scalar(select(Incident).where(Incident.id == incident.id)) is not None
+    assert db_session.scalar(select(IncidentEvent).where(IncidentEvent.incident_id == incident.id))
+    assert db_session.scalar(select(Postmortem).where(Postmortem.incident_id == incident.id))
+
+
+def test_incident_event_is_append_only() -> None:
+    from infrastructure.database.append_only import AppendOnlyMixin
+
+    assert issubclass(IncidentEvent, AppendOnlyMixin)
+    assert not hasattr(IncidentEventRepository, "update")
+    assert not hasattr(IncidentEventRepository, "delete")
+
+
+@pytest.mark.usefixtures("database_url")
+def test_loaded_incident_event_cannot_be_updated(db_session) -> None:  # type: ignore[no-untyped-def]
+    from infrastructure.database.append_only import AppendOnlyViolationError
+
+    incident = Incident(
+        owner="on-call-platform",
+        affected_service="platform-api",
+        severity=IncidentSeverity.HIGH,
+    )
+    db_session.add(incident)
+    db_session.flush()
+    event = IncidentEvent(
+        incident_id=incident.id,
+        to_state=IncidentState.DETECTED,
+        actor_type=AuditActorType.SYSTEM,
+        action="detect_incident",
+        detail="Detected.",
+    )
+    db_session.add(event)
+    db_session.flush()
+    loaded = db_session.get(IncidentEvent, event.id)
+    assert loaded is not None
+    loaded.detail = "Changed."
+
+    with pytest.raises(AppendOnlyViolationError):
+        db_session.flush()
+
+
+@pytest.mark.usefixtures("database_url")
+def test_loaded_incident_event_cannot_be_deleted(db_session) -> None:  # type: ignore[no-untyped-def]
+    from infrastructure.database.append_only import AppendOnlyViolationError
+
+    incident = Incident(
+        owner="on-call-platform",
+        affected_service="platform-api",
+        severity=IncidentSeverity.HIGH,
+    )
+    db_session.add(incident)
+    db_session.flush()
+    event = IncidentEvent(
+        incident_id=incident.id,
+        to_state=IncidentState.DETECTED,
+        actor_type=AuditActorType.SYSTEM,
+        action="detect_incident",
+        detail="Detected.",
+    )
+    db_session.add(event)
+    db_session.flush()
+    db_session.delete(event)
+
+    with pytest.raises(AppendOnlyViolationError):
+        db_session.flush()
+
+
+@pytest.mark.usefixtures("database_url")
+def test_postmortem_is_unique_per_incident(db_session) -> None:  # type: ignore[no-untyped-def]
+    incident = Incident(
+        owner="on-call-platform",
+        affected_service="platform-api",
+        severity=IncidentSeverity.HIGH,
+    )
+    db_session.add(incident)
+    db_session.flush()
+    first = Postmortem(
+        incident_id=incident.id,
+        summary="Summary.",
+        root_cause="Cause.",
+        mitigation="Mitigation.",
+        resolution="Resolution.",
+        follow_up_actions=["Follow up"],
+    )
+    second = Postmortem(
+        incident_id=incident.id,
+        summary="Summary 2.",
+        root_cause="Cause 2.",
+        mitigation="Mitigation 2.",
+        resolution="Resolution 2.",
+        follow_up_actions=["Follow up 2"],
+    )
+    db_session.add_all([first, second])
+
+    with pytest.raises(IntegrityError):
+        db_session.flush()

--- a/tests/incidents/__init__.py
+++ b/tests/incidents/__init__.py
@@ -1,0 +1,1 @@
+"""Phase 39 incident management tests."""

--- a/tests/incidents/test_state_machine.py
+++ b/tests/incidents/test_state_machine.py
@@ -1,0 +1,133 @@
+"""TDD tests for the Phase 39 incident lifecycle."""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from pydantic import ValidationError
+
+from core.enums import AuditActorType
+from core.incidents import (
+    Incident,
+    IncidentEvent,
+    IncidentSeverity,
+    IncidentState,
+    IncidentStateMachine,
+    Postmortem,
+)
+
+
+def _incident(**overrides: object) -> Incident:
+    values: dict[str, object] = {
+        "incident_id": uuid.UUID("00000000-0000-0000-0000-000000000101"),
+        "owner": "on-call-platform",
+        "affected_service": "platform-api",
+        "severity": IncidentSeverity.HIGH,
+    }
+    values.update(overrides)
+    return Incident.model_validate(values)
+
+
+def test_incident_creation_normalizes_bounded_fields() -> None:
+    incident = _incident(owner=" on-call-platform ", affected_service=" platform-api ")
+
+    assert incident.owner == "on-call-platform"
+    assert incident.affected_service == "platform-api"
+    assert incident.state is IncidentState.DETECTED
+    assert incident.timeline == ()
+
+
+def test_incident_rejects_blank_or_oversized_fields() -> None:
+    with pytest.raises(ValidationError):
+        _incident(owner=" ")
+    with pytest.raises(ValidationError):
+        _incident(affected_service="x" * 256)
+
+
+def test_state_machine_appends_event_for_valid_transition() -> None:
+    incident = _incident()
+
+    updated = IncidentStateMachine.transition(
+        incident,
+        IncidentState.ACKNOWLEDGED,
+        actor_type=AuditActorType.HUMAN,
+        actor_id="operator-1",
+        detail="On-call accepted the incident.",
+    )
+
+    assert updated.state is IncidentState.ACKNOWLEDGED
+    assert len(updated.timeline) == 1
+    assert updated.timeline[0].from_state is IncidentState.DETECTED
+    assert updated.timeline[0].to_state is IncidentState.ACKNOWLEDGED
+
+
+def test_state_machine_rejects_invalid_transition() -> None:
+    with pytest.raises(ValueError, match="invalid incident transition"):
+        IncidentStateMachine.transition(
+            _incident(),
+            IncidentState.CLOSED,
+            actor_type=AuditActorType.HUMAN,
+            actor_id="operator-1",
+            detail="Skip lifecycle.",
+        )
+
+
+def test_closed_incident_requires_postmortem() -> None:
+    incident = _incident()
+    for state in (
+        IncidentState.ACKNOWLEDGED,
+        IncidentState.INVESTIGATING,
+        IncidentState.MITIGATING,
+        IncidentState.RESOLVED,
+        IncidentState.POSTMORTEM,
+    ):
+        incident = IncidentStateMachine.transition(
+            incident,
+            state,
+            actor_type=AuditActorType.HUMAN,
+            actor_id="operator-1",
+            detail=f"Transitioned to {state.value}.",
+        )
+
+    with pytest.raises(ValueError, match="postmortem is required"):
+        IncidentStateMachine.transition(
+            incident,
+            IncidentState.CLOSED,
+            actor_type=AuditActorType.HUMAN,
+            actor_id="operator-1",
+            detail="Close incident.",
+        )
+
+    postmortem = Postmortem(
+        summary="Database connection exhaustion was mitigated.",
+        root_cause="A leaked connection path exhausted the pool.",
+        mitigation="Restarted the affected worker pool.",
+        resolution="Patched connection cleanup and verified recovery.",
+        follow_up_actions=("Add connection leak monitoring",),
+    )
+    incident = incident.model_copy(update={"postmortem": postmortem})
+    closed = IncidentStateMachine.transition(
+        incident,
+        IncidentState.CLOSED,
+        actor_type=AuditActorType.HUMAN,
+        actor_id="operator-1",
+        detail="Close incident after postmortem.",
+    )
+
+    assert closed.state is IncidentState.CLOSED
+
+
+def test_incident_event_is_immutable_and_bounded() -> None:
+    event = IncidentEvent(
+        incident_id=uuid.uuid4(),
+        from_state=IncidentState.DETECTED,
+        to_state=IncidentState.ACKNOWLEDGED,
+        actor_type=AuditActorType.HUMAN,
+        actor_id="operator-1",
+        action="transition_incident",
+        detail="Accepted.",
+    )
+
+    with pytest.raises(ValidationError):
+        event.detail = "changed"  # type: ignore[misc]


### PR DESCRIPTION
## Summary\n- add bounded incident contracts and strict lifecycle transitions\n- persist incidents, immutable timeline events, and postmortems in PostgreSQL\n- add append-only repositories and real-PostgreSQL tests\n- update Phase 39 checklist only\n\n## Validation\n- 2069 tests passed\n- Ruff passed\n- mypy strict passed\n- Ruff format check passed\n- git diff --check passed\n\nPhase 40 frontend work is intentionally excluded.